### PR TITLE
Semantic recall via local Ollama embeddings (with lexical fallback)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -532,6 +532,21 @@ fn load_memories(conn: &Connection) -> Result<Vec<mw_memory::Memory>, AppError> 
     Ok(mems)
 }
 
+/// Build the recall engine. Uses local **Ollama** embeddings for semantic recall
+/// when the Ollama server is running (`ollama pull nomic-embed-text`), and
+/// transparently falls back to the lexical scorer when it isn't — so the app
+/// stays zero-setup and works offline.
+fn build_recall_engine(mems: Vec<mw_memory::Memory>) -> mw_memory::engine::BuiltinEngine {
+    use mw_memory::engine::BuiltinEngine;
+    let lexical = BuiltinEngine::new(mems.clone());
+    match BuiltinEngine::new(mems)
+        .with_embedder(std::sync::Arc::new(mw_memory::embed::OllamaEmbedder::default()))
+    {
+        Ok(engine) => engine,
+        Err(_) => lexical,
+    }
+}
+
 #[tauri::command]
 fn recall_memories(
     state: tauri::State<AppState>,
@@ -545,7 +560,7 @@ fn recall_memories(
             .map_err(|_| AppError::Message("database lock poisoned".to_string()))?;
         load_memories(&conn)?
     };
-    let engine = mw_memory::engine::BuiltinEngine::new(mems);
+    let engine = build_recall_engine(mems);
     let q = mw_memory::Query::new(query, Utc::now());
     Ok(engine
         .retrieve(&q, limit.unwrap_or(8))
@@ -567,7 +582,7 @@ fn explain_memory(
             .map_err(|_| AppError::Message("database lock poisoned".to_string()))?;
         load_memories(&conn)?
     };
-    let engine = mw_memory::engine::BuiltinEngine::new(mems);
+    let engine = build_recall_engine(mems);
     let q = mw_memory::Query::new(query, Utc::now());
     Ok(engine.explain(id, &q).as_ref().map(to_hit))
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,6 +144,7 @@ function App() {
   const [recallQuery, setRecallQuery] = useState("");
   const [recallHits, setRecallHits] = useState<RecallHit[]>([]);
   const [openHit, setOpenHit] = useState<number | null>(null);
+  const recallTimer = useRef<number | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [searchResult, setSearchResult] = useState<SearchResult | null>(null);
@@ -264,15 +265,18 @@ function App() {
     setTerminalResult(terminal);
   }
 
-  async function runRecall(nextQuery = recallQuery) {
+  // Debounced so semantic mode doesn't re-embed on every keystroke.
+  function runRecall(nextQuery = recallQuery) {
     setRecallQuery(nextQuery);
     setOpenHit(null);
+    if (recallTimer.current) window.clearTimeout(recallTimer.current);
     if (!nextQuery.trim()) {
       setRecallHits([]);
       return;
     }
-    const hits = await callBackend<RecallHit[]>("recall_memories", { query: nextQuery, limit: 8 });
-    setRecallHits(hits);
+    recallTimer.current = window.setTimeout(() => {
+      void callBackend<RecallHit[]>("recall_memories", { query: nextQuery, limit: 8 }).then(setRecallHits);
+    }, 350);
   }
 
   async function rememberCommand() {


### PR DESCRIPTION
## What
Flips the Recall engine to **semantic** similarity using local **Ollama** embeddings (`nomic-embed-text`, 768-d), with a transparent **lexical fallback** when Ollama isn't running — so the app stays zero-setup and offline-capable.

- `recall_memories`/`explain_memory` build the engine with `OllamaEmbedder`; on any embedding error they fall back to the lexical `BuiltinEngine`.
- Recall input is **debounced (350ms)** so semantic mode doesn't re-embed on every keystroke.

## Why it matters (verified on real data)
Query **"where do we keep our data?"**:
- **Lexical:** all hits 0% term overlap → can't tell what's relevant.
- **Semantic:** surfaces *"use mw-core for storage"* (53%) and the MemoryWhale-MVP note (55%) — matching *data ↔ storage* with **no shared words**.

## Notes
- Requires `ollama pull nomic-embed-text` + the Ollama server for semantic mode; otherwise it's lexical (no breakage).
- Embeddings are computed per query for now (fine at current scale); caching memory embeddings is a sensible follow-up.
- Verified: `cargo check` ✓, `tsc && vite build` ✓ (2133 modules).