### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorywhale",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale"
-version = "0.1.0"
+version = "0.2.1"
 description = "A Rust/Tauri visual second brain for local knowledge graphs"
 authors = ["MemoryWhale"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MemoryWhale",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "identifier": "com.memorywhale.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
The in-code version was still `0.1.0` while release tags reached **v0.2.1**. This syncs it across `src-tauri/Cargo.toml`, `package.json`, `src-tauri/tauri.conf.json`, and the `Cargo.lock` memorywhale entry. No functional change.