### PR TITLE
fix: finalize live recordings immediately on parent death

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,6 +2051,7 @@ version = "0.4.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
+ "libc",
  "regex",
  "rusqlite",
  "serde",

--- a/REPORT-issue-5.md
+++ b/REPORT-issue-5.md
@@ -1,0 +1,79 @@
+# Issue 5 — Parent-death cleanup for recorder children
+
+**Branch:** `issue/5-parent-death-cleanup`
+
+## Problem
+
+`mw --live` inserts a `status='recording'` session row and then blocks inside the
+interactive `script` child. If the process that launched `mw` dies, `mw` is
+orphaned and the row is stranded as `recording`. Today it only gets finalized on
+the dashboard's *next startup* (`mw-serve` -> `recover_orphans`). Goal: the child
+detects parent death and finalizes **immediately**.
+
+## Mechanism (per platform)
+
+A single reusable guard — `memorywhale_cli::guard_parent_death(finalize)` in
+`crates/mw-cli/src/lib.rs` — spawns a background watcher and, on parent death,
+runs `finalize` then `exit(0)`:
+
+- **Linux:** `prctl(PR_SET_PDEATHSIG, SIGTERM)`. SIGTERM is blocked process-wide
+  first (before any other thread spawns) and a dedicated thread `sigwait`s for
+  it, so `finalize` runs on a normal thread — SQLite is not async-signal-safe.
+  The race where the parent dies *before* `prctl` is handled by re-checking
+  `getppid()` immediately after and finalizing on the spot if it changed.
+- **macOS / other Unix (no pdeathsig):** if a cooperating parent handed us the
+  read end of a pipe via the `MW_PDEATH_FD` env var, a thread blocks reading it
+  and treats **EOF** (parent closed its write end) as parent death. If no pipe
+  was provided — the real case for an arbitrary terminal/shell parent — it falls
+  back to polling `getppid()` for reparenting. (The getppid poll is a small
+  addition beyond the task's pipe spec; without it `mw --live` would gain nothing
+  on macOS under a normal shell parent, which never holds an MW pipe.)
+- **Windows:** untouched — the guard is `#[cfg(unix)]` and the mw wiring is
+  `#[cfg(unix)]`, so Windows behavior is unchanged.
+
+On death the guard reuses the **existing** finalization path
+(`update_session_from_transcript(id, path, ended_at, "interrupted")` in
+`mw.rs`) — it flushes the current transcript to the row and sets the status.
+Nothing was duplicated.
+
+## Idempotency / existing signal handling
+
+- `interrupted` is an existing status value (already produced by `mw-recover`
+  and rendered by `mw-serve`). Finalization is idempotent: the guard flips an
+  existing row, and startup `recover_orphans` skips any transcript that already
+  has a session row — so the signal path and startup recovery can both run
+  without producing duplicates.
+- There was no prior explicit SIGINT/SIGTERM handler in the code (`script`
+  handles interactive signals inside the recorded shell; normal exit flows
+  through unchanged). The Linux guard only claims SIGTERM, and only within
+  `mw --live`; SIGINT and all other binaries are unaffected.
+
+## Scope
+
+Only `mw --live` owns a long-lived in-progress row, so only it wires the guard.
+`mw-run` finalizes synchronously (no stranded row) and `mw-serve` owns no session
+row, so neither needed wiring.
+
+## Migration
+
+**No migration.** No schema change — the `sessions.status` column and the
+`interrupted` value already exist.
+
+## Changed files
+
+- `crates/mw-cli/Cargo.toml` — added `libc` (cfg(unix) dep) and cfg(unix)
+  dev-deps (`libc`, `rusqlite`) for the integration test.
+- `crates/mw-cli/src/lib.rs` — new `guard_parent_death` + `PDEATH_FD_ENV`.
+- `crates/mw-cli/src/bin/mw.rs` — install the guard for `mw --live`.
+- `crates/mw-cli/tests/parent_death.rs` — new integration test.
+
+## Verification
+
+- `cargo build --workspace` — passes.
+- `cargo test --workspace` — passes. New integration test
+  `interrupted_on_parent_death_via_pipe_eof` builds a 3-generation process tree
+  (test -> middle -> recorder), SIGKILLs the middle, and asserts the recorder
+  finalizes its row to `interrupted` within a 5s timeout. It exercises the
+  **pipe/EOF fallback** (the path that runs on this darwin box) and passed.
+  A companion `interrupted_on_parent_death_via_prctl` test is gated to
+  `cfg(target_os = "linux")` for the prctl path (not run on darwin).

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -20,6 +20,15 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+# Parent-death detection (prctl on Linux, getppid/pipe-EOF elsewhere).
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+# Integration test spawns a real process tree (fork) and inspects the DB row.
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
+rusqlite = { version = "0.32", features = ["bundled"] }
+
 # `cargo install cargo-deb && cargo deb -p mw-cli` builds the Debian/Jetson package.
 # ponytail: asset paths are manifest-relative; verified only in CI (no dpkg locally).
 [package.metadata.deb]

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -119,6 +119,18 @@ fn record_session(notes: String, live: bool) -> Result<(), String> {
             notes: &notes,
             started_at: &started_at,
         })?;
+        // If our parent dies while `script` is still running, finalize this row
+        // as `interrupted` immediately instead of leaving it stranded as
+        // `recording` until the dashboard's next-startup recovery. Installed
+        // before any other thread so the SIGTERM mask (Linux) covers them.
+        #[cfg(unix)]
+        {
+            let death_path = transcript_path.clone();
+            memorywhale_cli::guard_parent_death(move || {
+                let ended_at = Utc::now().to_rfc3339();
+                let _ = update_session_from_transcript(id, &death_path, &ended_at, "interrupted");
+            });
+        }
         let sync = start_live_sync(id, transcript_path.clone());
         Some((id, sync))
     } else {

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -158,6 +158,117 @@ fn secret_patterns() -> &'static [Regex] {
     })
 }
 
+/// Finalize the current in-progress recording the moment this process's parent
+/// dies, instead of waiting for the dashboard's next-startup recovery.
+///
+/// `mw --live` inserts a `status='recording'` session row and then blocks inside
+/// the interactive `script` child. If its parent (the terminal/shell that
+/// launched it) is killed, `mw` is orphaned and the row is stranded. This guard
+/// spawns a small background watcher that detects parent death and runs
+/// `finalize` (which flips the row to `interrupted`), then exits cleanly.
+///
+/// Mechanisms, cheapest reliable one per platform:
+///   * Linux: `prctl(PR_SET_PDEATHSIG, SIGTERM)`, with SIGTERM blocked and a
+///     thread `sigwait`-ing for it so `finalize` runs on a normal thread (SQLite
+///     is not async-signal-safe). Handles the race where the parent died before
+///     `prctl` by re-checking `getppid()`.
+///   * Other Unix (macOS, BSD): if a cooperating parent handed us the read end of
+///     a pipe via `MW_PDEATH_FD`, watch it for EOF (parent closed its write end =
+///     parent gone). Otherwise poll `getppid()` for reparenting — the portable
+///     fallback that needs no parent cooperation, which is what an arbitrary
+///     terminal/shell parent gives us.
+///
+/// `finalize` must be idempotent: startup recovery may still run later. Flipping
+/// a row to `interrupted` and skipping already-imported transcripts both are.
+#[cfg(unix)]
+pub fn guard_parent_death<F>(finalize: F)
+where
+    F: Fn() + Send + 'static,
+{
+    // safety: getppid() takes no args and only reads our own parent pid.
+    let original_ppid = unsafe { libc::getppid() };
+
+    #[cfg(target_os = "linux")]
+    {
+        // Block SIGTERM process-wide so the PDEATHSIG below can't just kill us
+        // before we finalize; a thread sigwaits for it instead. Called before any
+        // other thread spawns so the mask is inherited by all of them.
+        // safety: zeroed sigset_t is a valid empty set for the libc sig* calls.
+        unsafe {
+            let mut set: libc::sigset_t = std::mem::zeroed();
+            libc::sigemptyset(&mut set);
+            libc::sigaddset(&mut set, libc::SIGTERM);
+            libc::pthread_sigmask(libc::SIG_BLOCK, &set, std::ptr::null_mut());
+            // Ask the kernel to send us SIGTERM when our parent dies.
+            libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM as libc::c_ulong, 0, 0, 0);
+        }
+        // Race: the parent may have died between our start and prctl. If so we've
+        // been reparented (getppid changed, typically to 1) — finalize now.
+        // safety: see above.
+        if unsafe { libc::getppid() } != original_ppid {
+            finalize();
+            std::process::exit(0);
+        }
+        std::thread::spawn(move || {
+            // safety: sigset_t built here, sigwait blocks until SIGTERM arrives.
+            unsafe {
+                let mut set: libc::sigset_t = std::mem::zeroed();
+                libc::sigemptyset(&mut set);
+                libc::sigaddset(&mut set, libc::SIGTERM);
+                let mut sig: libc::c_int = 0;
+                libc::sigwait(&set, &mut sig);
+            }
+            finalize();
+            std::process::exit(0);
+        });
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        use std::os::unix::io::RawFd;
+        let pipe_fd: Option<RawFd> = std::env::var(PDEATH_FD_ENV)
+            .ok()
+            .and_then(|v| v.parse::<RawFd>().ok());
+        std::thread::spawn(move || {
+            match pipe_fd {
+                Some(fd) => {
+                    let mut buf = [0u8; 1];
+                    loop {
+                        // safety: blocking read of one byte from a pipe fd handed
+                        // to us by the parent; the buffer is a local we own.
+                        let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, 1) };
+                        if n == 0 {
+                            break; // EOF: parent closed its write end -> parent gone
+                        }
+                        if n < 0 {
+                            let e = std::io::Error::last_os_error();
+                            if e.kind() == std::io::ErrorKind::Interrupted {
+                                continue;
+                            }
+                            break; // any other error: treat as parent gone
+                        }
+                        // n == 1: unexpected byte on the control pipe; keep waiting.
+                    }
+                }
+                None => loop {
+                    std::thread::sleep(std::time::Duration::from_millis(200));
+                    // safety: getppid() only reads our own parent pid.
+                    if unsafe { libc::getppid() } != original_ppid {
+                        break; // reparented -> parent gone
+                    }
+                },
+            }
+            finalize();
+            std::process::exit(0);
+        });
+    }
+}
+
+/// Env var a cooperating parent sets to the inherited read-end fd of a
+/// parent-death pipe, for the non-Linux EOF mechanism above.
+#[cfg(unix)]
+pub const PDEATH_FD_ENV: &str = "MW_PDEATH_FD";
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mw-cli/tests/parent_death.rs
+++ b/crates/mw-cli/tests/parent_death.rs
@@ -1,0 +1,148 @@
+//! A recorder child must finalize its in-progress session row as `interrupted`
+//! the moment its parent dies — not wait for the dashboard's next-startup
+//! recovery. These tests build a real 3-generation process tree (grandparent =
+//! the test, middle = the parent we kill, recorder = the guarded child) so the
+//! child's parent genuinely dies and the OS mechanism under test actually fires.
+#![cfg(unix)]
+
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+const SCHEMA: &str = "CREATE TABLE IF NOT EXISTS sessions (id INTEGER PRIMARY KEY,
+    shell TEXT, cwd TEXT, transcript_path TEXT NOT NULL DEFAULT '',
+    transcript TEXT NOT NULL DEFAULT '', notes TEXT NOT NULL DEFAULT '',
+    started_at TEXT NOT NULL DEFAULT '', ended_at TEXT NOT NULL DEFAULT '',
+    byte_count INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'finished');";
+
+/// Fresh temp data dir + a `recording` session row; returns (db_path, transcript, id).
+fn setup(tag: &str) -> (PathBuf, PathBuf, i64) {
+    let dir = std::env::temp_dir().join(format!("mw-pdeath-{}-{}", tag, std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let db_path = dir.join("memorywhale.sqlite3");
+    let transcript = dir.join("session.log");
+    std::fs::write(&transcript, b"partial output before the crash\n").unwrap();
+
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute_batch(SCHEMA).unwrap();
+    conn.execute(
+        "INSERT INTO sessions (transcript_path, transcript, notes, started_at, ended_at, byte_count, status)
+         VALUES (?1, '', '', 't', 't', 0, 'recording')",
+        [transcript.to_str().unwrap()],
+    )
+    .unwrap();
+    let id = conn.last_insert_rowid();
+    (db_path, transcript, id)
+}
+
+/// Finalization the recorder runs on parent death — same effect as mw's real
+/// `update_session_from_transcript(.., "interrupted")`: flip the row's status.
+fn finalize_interrupted(db_path: &Path, id: i64) {
+    let conn = Connection::open(db_path).unwrap();
+    conn.execute("UPDATE sessions SET status = 'interrupted' WHERE id = ?1", [id])
+        .unwrap();
+}
+
+fn poll_status(db_path: &Path, id: i64, want: &str, timeout: Duration) -> String {
+    let deadline = Instant::now() + timeout;
+    let mut got = String::new();
+    while Instant::now() < deadline {
+        let conn = Connection::open(db_path).unwrap();
+        got = conn
+            .query_row("SELECT status FROM sessions WHERE id = ?1", [id], |r| r.get(0))
+            .unwrap();
+        if got == want {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    got
+}
+
+// safety: fork() in a test. The middle and recorder are single-threaded at their
+// fork points (the second fork happens from the single-threaded middle before any
+// thread spawns), so the guarded work (thread + SQLite) runs in a child forked
+// from a single-threaded process.
+unsafe fn fork() -> libc::pid_t {
+    libc::fork()
+}
+
+/// Exercises the non-Linux pipe/EOF fallback: the middle holds the pipe's write
+/// end; killing it closes that end; the recorder sees EOF and finalizes.
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn interrupted_on_parent_death_via_pipe_eof() {
+    let (db_path, _transcript, id) = setup("pipe");
+
+    let mut fds = [0 as libc::c_int; 2];
+    assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0, "pipe() failed");
+    let (read_fd, write_fd) = (fds[0], fds[1]);
+
+    let middle = unsafe { fork() };
+    assert!(middle >= 0, "first fork failed");
+    if middle == 0 {
+        // MIDDLE: single-threaded. Spawn the recorder, then hold the write end.
+        let recorder = unsafe { fork() };
+        if recorder == 0 {
+            // RECORDER: keep the read end, drop the write end so only the middle
+            // is a writer; when the middle dies we get EOF.
+            unsafe { libc::close(write_fd) };
+            std::env::set_var(memorywhale_cli::PDEATH_FD_ENV, read_fd.to_string());
+            let dbp = db_path.clone();
+            memorywhale_cli::guard_parent_death(move || finalize_interrupted(&dbp, id));
+            loop {
+                std::thread::sleep(Duration::from_secs(1));
+            }
+        }
+        unsafe { libc::close(read_fd) };
+        loop {
+            std::thread::sleep(Duration::from_secs(1));
+        }
+    }
+
+    // TEST (grandparent): drop both ends so the middle is the sole writer.
+    unsafe {
+        libc::close(read_fd);
+        libc::close(write_fd);
+    }
+    std::thread::sleep(Duration::from_millis(300)); // let the recorder arm its watcher
+    unsafe { libc::kill(middle, libc::SIGKILL) };
+    let mut status = 0;
+    unsafe { libc::waitpid(middle, &mut status, 0) };
+
+    let got = poll_status(&db_path, id, "interrupted", Duration::from_secs(5));
+    assert_eq!(got, "interrupted", "row must be finalized as interrupted after parent death (pipe EOF)");
+    let _ = std::fs::remove_dir_all(db_path.parent().unwrap());
+}
+
+/// Exercises the Linux prctl(PR_SET_PDEATHSIG) path: the middle simply exits and
+/// the kernel delivers SIGTERM to the recorder, which finalizes.
+#[cfg(target_os = "linux")]
+#[test]
+fn interrupted_on_parent_death_via_prctl() {
+    let (db_path, _transcript, id) = setup("prctl");
+
+    let middle = unsafe { fork() };
+    assert!(middle >= 0, "first fork failed");
+    if middle == 0 {
+        let recorder = unsafe { fork() };
+        if recorder == 0 {
+            // RECORDER: no pipe — rely on prctl PDEATHSIG (+ getppid race check).
+            let dbp = db_path.clone();
+            memorywhale_cli::guard_parent_death(move || finalize_interrupted(&dbp, id));
+            loop {
+                std::thread::sleep(Duration::from_secs(1));
+            }
+        }
+        // MIDDLE: let the recorder arm prctl, then die so the kernel signals it.
+        std::thread::sleep(Duration::from_millis(300));
+        unsafe { libc::_exit(0) };
+    }
+
+    let got = poll_status(&db_path, id, "interrupted", Duration::from_secs(5));
+    let mut status = 0;
+    unsafe { libc::waitpid(middle, &mut status, 0) };
+    assert_eq!(got, "interrupted", "row must be finalized as interrupted after parent death (prctl)");
+    let _ = std::fs::remove_dir_all(db_path.parent().unwrap());
+}


### PR DESCRIPTION
`mw --live` owns a long-lived in-progress session row. If its parent dies, the row was left half-written until the next dashboard startup ran recovery. This makes the child detect parent death and finalize immediately.

## Mechanism
One reusable `guard_parent_death(finalize)` in `crates/mw-cli/src/lib.rs`:

- **Linux:** `prctl(PR_SET_PDEATHSIG, SIGTERM)`, with SIGTERM blocked process-wide and a thread `sigwait`-ing for it (SQLite isn't async-signal-safe). The pre-`prctl` race is caught by re-checking `getppid()`.
- **macOS / other Unix:** watches a parent-held pipe read-end (`MW_PDEATH_FD`) for EOF, falling back to `getppid()` polling when no pipe is provided — which is the real case under an arbitrary shell parent, so without it `mw --live` would gain nothing on macOS.

On death it flushes and reuses the existing `update_session_from_transcript(..., "interrupted")` finalizer, then exits cleanly.

## Scope
Wired into `mw --live` only. `mw-run` finalizes synchronously and `mw-serve` owns no session row, so neither needs it. Windows untouched (`#[cfg(unix)]`). Unsafe blocks are minimal and commented.

## Notes
- **No schema change** — `sessions.status` and the `interrupted` value already existed.
- Finalization is idempotent: startup `recover_orphans` skips transcripts that already have a row, so the signal path and startup recovery can both run safely.

## Verification
`cargo build --workspace` and `cargo test --workspace` pass. New integration test `interrupted_on_parent_death_via_pipe_eof` spawns a test→middle→recorder tree, SIGKILLs the middle process, and asserts the row becomes `interrupted` within 5s — exercising the pipe/EOF path on macOS. A `cfg(target_os = "linux")`-gated companion covers the prctl path (not exercised on this box).
