### PR TITLE
feat: record provenance and review state for agent-written memories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,6 +2032,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "dirs 5.0.1",
+ "memorywhale-cli",
  "mw-memory",
  "regex",
  "rusqlite",

--- a/REPORT-issue-7.md
+++ b/REPORT-issue-7.md
@@ -1,0 +1,68 @@
+# Issue 7 — Memory provenance + optional review
+
+Branch: `issue/7-memory-provenance`
+
+## Migration
+
+No migration framework existed before; schema was scattered `CREATE TABLE IF
+NOT EXISTS`. Introduced a `PRAGMA user_version`-based runner in
+`crates/mw-cli/src/lib.rs::migrate()`.
+
+Migration number chosen: 1 (`PRAGMA user_version = 1`). Applied when
+`user_version < 1` against the `bookmarks` table (the remembered-lessons store
+used by `mw mark`, `mw remember`, and the MCP `remember` tool). Exact SQL:
+
+```sql
+-- ensure base bookmarks table exists first, then:
+ALTER TABLE bookmarks ADD COLUMN author_kind TEXT NOT NULL DEFAULT 'human';
+ALTER TABLE bookmarks ADD COLUMN author_name TEXT;
+ALTER TABLE bookmarks ADD COLUMN source_session_id INTEGER;
+ALTER TABLE bookmarks ADD COLUMN approved INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE bookmarks ADD COLUMN created_at TEXT;  -- only if missing; base already has it
+PRAGMA user_version = 1;
+```
+
+Each ADD COLUMN is guarded by a `pragma_table_info` existence check, so it is
+safe to re-run and safe whether the table was just created or pre-existing.
+Existing rows backfill automatically via the constant DEFAULTs
+(author_kind='human', approved=1) — ADD COLUMN with a constant default does not
+rewrite rows, safe on a populated DB. RENUMBER NOTE: if merging collides on
+user_version=1, bump both the `< 1` check and the `PRAGMA user_version = N`
+write in migrate() together.
+
+## Changed files
+
+- crates/mw-cli/src/lib.rs — migrate(), add_column_if_missing(),
+  review_agent_memories() (config flag: env MEMORYWHALE_REVIEW_AGENT_MEMORIES=1
+  or `review_agent_memories = true` in <data dir>/config.toml; default OFF; no
+  new dep), provenance_label(), and remember_as(); remember() now delegates to
+  remember_as with human defaults.
+- crates/mw-cli/src/bin/mw-mcp.rs — capture clientInfo.name from initialize,
+  thread through tools/call; remember tool → remember_as agent + client name;
+  search_memory/get_context render provenance and filter approved=1; open()
+  runs migrate. Tool schemas unchanged (additive requirement met).
+- crates/mw-cli/src/bin/mw.rs — mw search Notes shows provenance, filters approved=1.
+- src-tauri/Cargo.toml — added memorywhale-cli path dep (reuse migrate/provenance).
+- src-tauri/src/lib.rs — Lesson struct + tauri commands list_lessons(agent_only),
+  delete_lesson(id), approve_lesson(id), registered in generate_handler!.
+- src/App.tsx — "Remembered lessons" panel: agent-only filter, provenance line,
+  Delete button, Approve for pending-review lessons.
+
+## Decisions
+
+- Single choke point: CLI and MCP writes both go through remember_as; provenance
+  set in one place.
+- Review-mode exclusion enforced at read time via WHERE approved=1 on retrieval
+  surfaces (mw search, MCP search_memory/get_context). Diagnostic surfaces
+  (mw doctor, mw export) left unfiltered (not retrieval).
+- Human memories store author_name=NULL, displayed as "you".
+
+## Verification
+
+- cargo build --workspace: OK.
+- cargo test --workspace: OK. mw-cli suite 12 passed / 0 failed. New tests:
+  cli_remember_is_human, mcp_remember_is_agent_attributed,
+  review_mode_hides_unapproved_agent_memories,
+  migrate_backfills_existing_rows_as_human, provenance_label_formats.
+- Frontend TS not typechecked (no node_modules / tsc); not part of cargo verify.
+- No pre-existing unrelated failures observed.

--- a/crates/mw-cli/src/bin/mw-mcp.rs
+++ b/crates/mw-cli/src/bin/mw-mcp.rs
@@ -14,6 +14,10 @@ use std::io::{BufRead, Write};
 fn main() {
     let stdin = std::io::stdin();
     let mut stdout = std::io::stdout();
+    // Client name from the `initialize` handshake (e.g. "Claude Code"), used to
+    // attribute agent-written memories. One process serves one client, so a
+    // single mutable slot is enough.
+    let mut client_name: Option<String> = None;
     for line in stdin.lock().lines() {
         let Ok(line) = line else { break };
         if line.trim().is_empty() {
@@ -23,13 +27,21 @@ fn main() {
             Ok(v) => v,
             Err(_) => continue,
         };
+        let method = msg.get("method").and_then(Value::as_str).unwrap_or("");
+        let params = msg.get("params").cloned().unwrap_or(json!({}));
+        if method == "initialize" {
+            client_name = params
+                .get("clientInfo")
+                .and_then(|c| c.get("name"))
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+        }
         // Notifications (no `id`) get no reply.
         let Some(id) = msg.get("id").cloned() else {
             continue;
         };
-        let method = msg.get("method").and_then(Value::as_str).unwrap_or("");
-        let params = msg.get("params").cloned().unwrap_or(json!({}));
-        let reply = match handle(method, &params) {
+        let reply = match handle(method, &params, client_name.as_deref()) {
             Ok(result) => json!({"jsonrpc": "2.0", "id": id, "result": result}),
             Err(msg) => json!({"jsonrpc": "2.0", "id": id,
                 "error": {"code": -32603, "message": msg}}),
@@ -39,7 +51,7 @@ fn main() {
     }
 }
 
-fn handle(method: &str, params: &Value) -> Result<Value, String> {
+fn handle(method: &str, params: &Value, client_name: Option<&str>) -> Result<Value, String> {
     match method {
         "initialize" => Ok(json!({
             "protocolVersion": "2024-11-05",
@@ -50,7 +62,7 @@ fn handle(method: &str, params: &Value) -> Result<Value, String> {
         "tools/call" => {
             let name = params.get("name").and_then(Value::as_str).unwrap_or("");
             let args = params.get("arguments").cloned().unwrap_or(json!({}));
-            let text = call_tool(name, &args)?;
+            let text = call_tool(name, &args, client_name)?;
             Ok(json!({"content": [{"type": "text", "text": text}]}))
         }
         // Unknown method: return empty result rather than erroring the session.
@@ -93,10 +105,14 @@ fn tool_defs() -> Value {
 
 fn open() -> Result<Connection, String> {
     let path = memorywhale_cli::database_path()?;
-    Connection::open(&path).map_err(|e| format!("failed to open {}: {e}", path.display()))
+    let conn =
+        Connection::open(&path).map_err(|e| format!("failed to open {}: {e}", path.display()))?;
+    // Ensure bookmarks provenance columns exist so reads below can rely on them.
+    let _ = memorywhale_cli::migrate(&conn);
+    Ok(conn)
 }
 
-fn call_tool(name: &str, args: &Value) -> Result<String, String> {
+fn call_tool(name: &str, args: &Value, client_name: Option<&str>) -> Result<String, String> {
     match name {
         "recent_errors" => {
             let limit = args.get("limit").and_then(Value::as_i64).unwrap_or(8);
@@ -118,7 +134,7 @@ fn call_tool(name: &str, args: &Value) -> Result<String, String> {
                 .get("text")
                 .and_then(Value::as_str)
                 .ok_or_else(|| "remember needs a 'text'".to_string())?;
-            remember_tool(text)
+            remember_tool(text, client_name)
         }
         other => Err(format!("unknown tool: {other}")),
     }
@@ -208,14 +224,23 @@ fn search_memory(query: &str) -> Result<String, String> {
     // Remembered lessons (`mw mark` / `mw remember` / this server's `remember`
     // tool). The table may not exist yet on a DB that's only ever seen
     // command_runs, so treat a missing table as zero results, not an error.
-    if let Ok(mut stmt) =
-        conn.prepare("SELECT label, created_at FROM bookmarks WHERE label LIKE ?1 ORDER BY id DESC LIMIT 20")
-    {
-        if let Ok(rows) =
-            stmt.query_map(params![like], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))
-        {
-            for (label, created_at) in rows.flatten() {
-                out.push_str(&format!("- remembered ({created_at}): {label}\n"));
+    if let Ok(mut stmt) = conn.prepare(
+        "SELECT label, created_at, author_kind, author_name, source_session_id FROM bookmarks
+         WHERE label LIKE ?1 AND approved = 1 ORDER BY id DESC LIMIT 20",
+    ) {
+        if let Ok(rows) = stmt.query_map(params![like], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, Option<String>>(3)?,
+                r.get::<_, Option<i64>>(4)?,
+            ))
+        }) {
+            for (label, created_at, kind, name, sid) in rows.flatten() {
+                let prov =
+                    memorywhale_cli::provenance_label(&kind, name.as_deref(), &created_at, sid);
+                out.push_str(&format!("- {label} ({prov})\n"));
             }
         }
     }
@@ -269,27 +294,35 @@ fn get_context(project: Option<&str>) -> Result<String, String> {
 
     // Remembered lessons — same missing-table tolerance as search_memory.
     if let Ok(mut stmt) = conn.prepare(
-        "SELECT label, created_at FROM bookmarks
-         WHERE ?1 IS NULL OR label LIKE ?1 ORDER BY id DESC LIMIT 8",
+        "SELECT label, created_at, author_kind, author_name, source_session_id FROM bookmarks
+         WHERE (?1 IS NULL OR label LIKE ?1) AND approved = 1 ORDER BY id DESC LIMIT 8",
     ) {
         if let Ok(rows) = stmt.query_map(params![like.as_deref()], |r| {
-            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, Option<String>>(3)?,
+                r.get::<_, Option<i64>>(4)?,
+            ))
         }) {
             let mut any_notes = false;
-            for (label, created_at) in rows.flatten() {
+            for (label, created_at, kind, name, sid) in rows.flatten() {
                 if !any_notes {
                     out.push_str("\nRemembered lessons:\n");
                     any_notes = true;
                 }
-                out.push_str(&format!("- ({created_at}): {label}\n"));
+                let prov =
+                    memorywhale_cli::provenance_label(&kind, name.as_deref(), &created_at, sid);
+                out.push_str(&format!("- {label} ({prov})\n"));
             }
         }
     }
     Ok(out)
 }
 
-fn remember_tool(text: &str) -> Result<String, String> {
-    let id = memorywhale_cli::remember(text, None)?;
+fn remember_tool(text: &str, client_name: Option<&str>) -> Result<String, String> {
+    let id = memorywhale_cli::remember_as(text, None, "agent", client_name, None)?;
     Ok(format!(
         "Saved as memory #{id}. Future search_memory/get_context calls (yours or a teammate's) will find it."
     ))

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -1418,11 +1418,15 @@ fn search_memory(args: &[String]) -> Result<(), String> {
         println!("(none)");
     }
 
-    // Remembered notes/lessons (`mw mark` / `mw remember`).
+    // Remembered notes/lessons (`mw mark` / `mw remember` / MCP `remember`).
+    // Provenance columns are guaranteed by the migration; unapproved agent
+    // memories (review mode) are excluded from retrieval.
+    let _ = memorywhale_cli::migrate(&conn);
     let mut stmt = conn
         .prepare(
-            "SELECT id, label, created_at FROM bookmarks
-             WHERE label LIKE ?1 ORDER BY id DESC LIMIT 30",
+            "SELECT id, label, created_at, author_kind, author_name, source_session_id
+             FROM bookmarks
+             WHERE label LIKE ?1 AND approved = 1 ORDER BY id DESC LIMIT 30",
         )
         .map_err(|err| format!("failed to prepare notes search: {err}"))?;
     let rows = stmt
@@ -1431,15 +1435,20 @@ fn search_memory(args: &[String]) -> Result<(), String> {
                 r.get::<_, i64>(0)?,
                 r.get::<_, String>(1)?,
                 r.get::<_, String>(2)?,
+                r.get::<_, String>(3)?,
+                r.get::<_, Option<String>>(4)?,
+                r.get::<_, Option<i64>>(5)?,
             ))
         })
         .map_err(|err| format!("failed to search notes: {err}"))?;
     println!("\n## Notes");
     let mut any = false;
     for row in rows {
-        let (id, label, created_at) = row.map_err(|err| format!("row error: {err}"))?;
+        let (id, label, created_at, kind, name, sid) =
+            row.map_err(|err| format!("row error: {err}"))?;
         any = true;
-        println!("- #{id} {created_at}: {label}");
+        let prov = memorywhale_cli::provenance_label(&kind, name.as_deref(), &created_at, sid);
+        println!("- #{id} {label} ({prov})");
     }
     if !any {
         println!("(none)");

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -79,32 +79,142 @@ pub fn fts_match_query(query: &str) -> String {
         .join(" ")
 }
 
+/// Base `bookmarks` schema (pre-provenance). Kept as-is so `migrate` can layer
+/// the provenance columns on top with `PRAGMA user_version` migrations.
+const BOOKMARKS_BASE: &str = "CREATE TABLE IF NOT EXISTS bookmarks (
+         id INTEGER PRIMARY KEY,
+         label TEXT NOT NULL,
+         cwd TEXT,
+         created_at TEXT NOT NULL,
+         command_run_id INTEGER,
+         session_id INTEGER
+     );
+     CREATE INDEX IF NOT EXISTS idx_bookmarks_created_at ON bookmarks(created_at);";
+
+/// Apply numbered schema migrations to a MemoryWhale database. Idempotent and
+/// cheap (a `user_version` check), so callers run it before touching bookmarks.
+///
+/// Migration 1 — memory provenance: adds `author_kind`/`author_name`/
+/// `source_session_id`/`approved` to `bookmarks` and backfills existing rows as
+/// human (via the column defaults). Safe on a populated DB: `ADD COLUMN` with a
+/// constant default never rewrites rows.
+pub fn migrate(conn: &Connection) -> Result<(), String> {
+    let version: i64 = conn
+        .query_row("PRAGMA user_version", [], |r| r.get(0))
+        .map_err(|e| format!("failed to read schema version: {e}"))?;
+    if version < 1 {
+        conn.execute_batch(BOOKMARKS_BASE)
+            .map_err(|e| format!("failed to prepare bookmarks table: {e}"))?;
+        add_column_if_missing(conn, "author_kind", "TEXT NOT NULL DEFAULT 'human'")?;
+        add_column_if_missing(conn, "author_name", "TEXT")?;
+        add_column_if_missing(conn, "source_session_id", "INTEGER")?;
+        add_column_if_missing(conn, "approved", "INTEGER NOT NULL DEFAULT 1")?;
+        add_column_if_missing(conn, "created_at", "TEXT")?; // belt-and-suspenders; base has it
+        conn.execute_batch("PRAGMA user_version = 1;")
+            .map_err(|e| format!("failed to bump schema version: {e}"))?;
+    }
+    Ok(())
+}
+
+fn add_column_if_missing(conn: &Connection, column: &str, decl: &str) -> Result<(), String> {
+    let present = conn
+        .prepare("SELECT 1 FROM pragma_table_info('bookmarks') WHERE name = ?1")
+        .and_then(|mut s| s.exists(params![column]))
+        .map_err(|e| format!("failed to inspect bookmarks columns: {e}"))?;
+    if !present {
+        conn.execute(&format!("ALTER TABLE bookmarks ADD COLUMN {column} {decl}"), [])
+            .map_err(|e| format!("failed to add bookmarks.{column}: {e}"))?;
+    }
+    Ok(())
+}
+
+/// True when agent-written memories should start unapproved and be excluded from
+/// retrieval until approved in the dashboard. Off by default. Enabled by env var
+/// `MEMORYWHALE_REVIEW_AGENT_MEMORIES=1` or a `review_agent_memories = true` line
+/// in `<data dir>/config.toml`.
+pub fn review_agent_memories() -> bool {
+    if let Some(v) = std::env::var_os("MEMORYWHALE_REVIEW_AGENT_MEMORIES") {
+        return v == "1" || v == "true";
+    }
+    data_dir()
+        .ok()
+        .map(|d| d.join("config.toml"))
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .map(|s| {
+            s.lines().any(|l| {
+                let l = l.trim();
+                l.starts_with("review_agent_memories") && l.contains("true")
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// Human-readable provenance, e.g. "remembered by Claude Code on 2026-07-12
+/// during session #41". `created_at` may be an RFC3339 timestamp; only the date
+/// part is shown.
+pub fn provenance_label(
+    author_kind: &str,
+    author_name: Option<&str>,
+    created_at: &str,
+    session_id: Option<i64>,
+) -> String {
+    let who = match (author_kind, author_name) {
+        ("agent", Some(n)) if !n.is_empty() => n.to_string(),
+        ("agent", _) => "agent".to_string(),
+        _ => "you".to_string(),
+    };
+    let date = created_at.get(..10).unwrap_or(created_at);
+    let mut s = format!("remembered by {who} on {date}");
+    if let Some(sid) = session_id {
+        s.push_str(&format!(" during session #{sid}"));
+    }
+    s
+}
+
 /// Save a freeform lesson or conclusion ("the fix was X") into the bookmarks
-/// table — the same store `mw mark` writes to. Shared by `mw remember` and the
-/// MCP `remember` tool, so a human and an agent write to the same place and
-/// either one can search it back out later.
+/// table — the same store `mw mark` writes to. Records the author as a human;
+/// see [`remember_as`] for agent-attributed writes. Shared by `mw remember` and
+/// `mw mark`.
 pub fn remember(text: &str, cwd: Option<&str>) -> Result<i64, String> {
+    remember_as(text, cwd, "human", None, None)
+}
+
+/// Like [`remember`] but records who wrote the lesson. `author_kind` is
+/// "human" or "agent"; `author_name` is the MCP client name for agents (else
+/// `None`). When [`review_agent_memories`] is on, agent lessons are stored
+/// unapproved so retrieval skips them until approved in the dashboard.
+pub fn remember_as(
+    text: &str,
+    cwd: Option<&str>,
+    author_kind: &str,
+    author_name: Option<&str>,
+    source_session_id: Option<i64>,
+) -> Result<i64, String> {
     let text = redact(text);
     let path = database_path()?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("failed to create data dir: {e}"))?;
     }
     let conn = Connection::open(&path).map_err(|e| format!("failed to open db: {e}"))?;
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS bookmarks (
-             id INTEGER PRIMARY KEY,
-             label TEXT NOT NULL,
-             cwd TEXT,
-             created_at TEXT NOT NULL,
-             command_run_id INTEGER,
-             session_id INTEGER
-         );
-         CREATE INDEX IF NOT EXISTS idx_bookmarks_created_at ON bookmarks(created_at);",
-    )
-    .map_err(|e| format!("failed to prepare bookmarks table: {e}"))?;
+    migrate(&conn)?;
+    let approved = if author_kind == "agent" && review_agent_memories() {
+        0
+    } else {
+        1
+    };
     conn.execute(
-        "INSERT INTO bookmarks (label, cwd, created_at) VALUES (?1, ?2, ?3)",
-        params![text, cwd, Utc::now().to_rfc3339()],
+        "INSERT INTO bookmarks
+            (label, cwd, created_at, author_kind, author_name, source_session_id, approved)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            text,
+            cwd,
+            Utc::now().to_rfc3339(),
+            author_kind,
+            author_name,
+            source_session_id,
+            approved
+        ],
     )
     .map_err(|e| format!("failed to save note: {e}"))?;
     Ok(conn.last_insert_rowid())
@@ -235,14 +345,27 @@ mod tests {
         assert_eq!(n, 1, "trigger should index the new row");
     }
 
-    #[test]
-    fn remember_writes_and_redacts() {
+    // Tests that mutate process-global env (MEMORYWHALE_DATA_DIR / review flag)
+    // are serialized so they don't clobber each other under parallel runs.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn fresh_data_dir(tag: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
-            "mw-remember-test-{}",
-            std::process::id()
+            "mw-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
         ));
+        let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         std::env::set_var("MEMORYWHALE_DATA_DIR", &dir);
+        dir
+    }
+
+    #[test]
+    fn remember_writes_and_redacts() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("MEMORYWHALE_REVIEW_AGENT_MEMORIES");
+        let dir = fresh_data_dir("remember-test");
 
         let id = remember("the fix: API_KEY=abcdef123456 in .env", Some("/tmp/repo")).unwrap();
         assert!(id > 0);
@@ -260,5 +383,137 @@ mod tests {
 
         std::env::remove_var("MEMORYWHALE_DATA_DIR");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // `mw remember` / `mw mark` (CLI) attribute the lesson to a human.
+    #[test]
+    fn cli_remember_is_human() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("MEMORYWHALE_REVIEW_AGENT_MEMORIES");
+        let dir = fresh_data_dir("prov-human");
+
+        let id = remember("the fix was --features vendored-ssl", None).unwrap();
+        let conn = Connection::open(dir.join("memorywhale.sqlite3")).unwrap();
+        let (kind, name, approved): (String, Option<String>, i64) = conn
+            .query_row(
+                "SELECT author_kind, author_name, approved FROM bookmarks WHERE id = ?1",
+                [id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(kind, "human");
+        assert_eq!(name, None);
+        assert_eq!(approved, 1);
+
+        std::env::remove_var("MEMORYWHALE_DATA_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The MCP `remember` tool attributes the lesson to the agent + client name.
+    #[test]
+    fn mcp_remember_is_agent_attributed() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("MEMORYWHALE_REVIEW_AGENT_MEMORIES");
+        let dir = fresh_data_dir("prov-agent");
+
+        let id = remember_as("E0308 was a string fps field", None, "agent", Some("Claude Code"), Some(41))
+            .unwrap();
+        let conn = Connection::open(dir.join("memorywhale.sqlite3")).unwrap();
+        let (kind, name, sid, approved): (String, Option<String>, Option<i64>, i64) = conn
+            .query_row(
+                "SELECT author_kind, author_name, source_session_id, approved FROM bookmarks WHERE id = ?1",
+                [id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(kind, "agent");
+        assert_eq!(name.as_deref(), Some("Claude Code"));
+        assert_eq!(sid, Some(41));
+        assert_eq!(approved, 1, "agent memory is approved when review mode is off");
+
+        std::env::remove_var("MEMORYWHALE_DATA_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // With review mode ON, agent memories start unapproved and are excluded from
+    // the approved-only retrieval query.
+    #[test]
+    fn review_mode_hides_unapproved_agent_memories() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = fresh_data_dir("prov-review");
+        std::env::set_var("MEMORYWHALE_REVIEW_AGENT_MEMORIES", "1");
+
+        let agent_id = remember_as("unreviewed agent claim", None, "agent", Some("Codex"), None).unwrap();
+        let human_id = remember("trusted human note", None).unwrap();
+
+        let conn = Connection::open(dir.join("memorywhale.sqlite3")).unwrap();
+        let agent_approved: i64 = conn
+            .query_row("SELECT approved FROM bookmarks WHERE id = ?1", [agent_id], |r| r.get(0))
+            .unwrap();
+        assert_eq!(agent_approved, 0, "agent memory pending review");
+
+        // Retrieval filters on approved = 1 (as mw search / MCP do).
+        let visible: Vec<i64> = conn
+            .prepare("SELECT id FROM bookmarks WHERE approved = 1")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert!(visible.contains(&human_id), "human memory visible");
+        assert!(!visible.contains(&agent_id), "unapproved agent memory hidden");
+
+        std::env::remove_var("MEMORYWHALE_REVIEW_AGENT_MEMORIES");
+        std::env::remove_var("MEMORYWHALE_DATA_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The migration is safe on a populated DB: an existing pre-provenance row is
+    // backfilled as human/approved, and new provenance columns are usable.
+    #[test]
+    fn migrate_backfills_existing_rows_as_human() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Fixture: legacy bookmarks table with a row, no provenance columns.
+        conn.execute_batch(
+            "CREATE TABLE bookmarks (
+                 id INTEGER PRIMARY KEY, label TEXT NOT NULL, cwd TEXT,
+                 created_at TEXT NOT NULL, command_run_id INTEGER, session_id INTEGER
+             );
+             INSERT INTO bookmarks (label, created_at) VALUES ('old lesson', '2026-01-01T00:00:00Z');",
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        let (kind, approved): (String, i64) = conn
+            .query_row(
+                "SELECT author_kind, approved FROM bookmarks WHERE label = 'old lesson'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(kind, "human", "existing rows backfilled as human");
+        assert_eq!(approved, 1);
+
+        // migrate is idempotent
+        migrate(&conn).unwrap();
+        let version: i64 = conn.query_row("PRAGMA user_version", [], |r| r.get(0)).unwrap();
+        assert_eq!(version, 1);
+    }
+
+    #[test]
+    fn provenance_label_formats() {
+        assert_eq!(
+            provenance_label("agent", Some("Claude Code"), "2026-07-12T09:00:00Z", Some(41)),
+            "remembered by Claude Code on 2026-07-12 during session #41"
+        );
+        assert_eq!(
+            provenance_label("human", None, "2026-07-12T09:00:00Z", None),
+            "remembered by you on 2026-07-12"
+        );
+        assert_eq!(
+            provenance_label("agent", None, "2026-07-12", None),
+            "remembered by agent on 2026-07-12"
+        );
     }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-build = { version = "2.1", features = [] }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5"
+memorywhale-cli = { path = "../crates/mw-cli" }
 mw-memory = { path = "../crates/mw-memory" }
 regex = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,6 +100,19 @@ struct TerminalMemory {
     arguments: Vec<CommandArgument>,
 }
 
+/// A remembered lesson (bookmarks table) with provenance, for the dashboard.
+#[derive(Debug, Serialize)]
+struct Lesson {
+    id: i64,
+    label: String,
+    created_at: String,
+    author_kind: String,
+    author_name: Option<String>,
+    source_session_id: Option<i64>,
+    approved: bool,
+    provenance: String,
+}
+
 #[derive(Debug, Serialize)]
 struct GraphNode {
     id: String,
@@ -148,7 +161,10 @@ pub fn run() {
             list_terminal_memory,
             recall_memories,
             explain_memory,
-            reset_demo_data
+            reset_demo_data,
+            list_lessons,
+            delete_lesson,
+            approve_lesson
         ])
         .run(tauri::generate_context!())
         .expect("error while running MemoryWhale");
@@ -371,6 +387,76 @@ fn list_terminal_memory(
         .lock()
         .map_err(|_| AppError::Message("database lock poisoned".to_string()))?;
     load_terminal_memory(&conn, query.as_deref())
+}
+
+// ── Remembered lessons with provenance (bookmarks table) ───────────────────
+
+/// List remembered lessons with provenance. `agent_only` filters to
+/// agent-written ones. Includes unapproved (pending-review) lessons so the
+/// dashboard can surface and approve them.
+#[tauri::command]
+fn list_lessons(
+    state: tauri::State<AppState>,
+    agent_only: Option<bool>,
+) -> Result<Vec<Lesson>, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Message("database lock poisoned".to_string()))?;
+    memorywhale_cli::migrate(&conn).map_err(AppError::Message)?;
+    let sql = "SELECT id, label, created_at, author_kind, author_name, source_session_id, approved
+               FROM bookmarks
+               WHERE (?1 = 0 OR author_kind = 'agent')
+               ORDER BY id DESC LIMIT 500";
+    let filter = i64::from(agent_only.unwrap_or(false));
+    let lessons = conn
+        .prepare(sql)?
+        .query_map(params![filter], |r| {
+            let created_at: String = r.get(2)?;
+            let author_kind: String = r.get(3)?;
+            let author_name: Option<String> = r.get(4)?;
+            let source_session_id: Option<i64> = r.get(5)?;
+            Ok(Lesson {
+                id: r.get(0)?,
+                label: r.get(1)?,
+                provenance: memorywhale_cli::provenance_label(
+                    &author_kind,
+                    author_name.as_deref(),
+                    &created_at,
+                    source_session_id,
+                ),
+                created_at,
+                author_kind,
+                author_name,
+                source_session_id,
+                approved: r.get::<_, i64>(6)? != 0,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(lessons)
+}
+
+/// Delete a remembered lesson by id.
+#[tauri::command]
+fn delete_lesson(state: tauri::State<AppState>, id: i64) -> Result<(), AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Message("database lock poisoned".to_string()))?;
+    conn.execute("DELETE FROM bookmarks WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+/// Approve a pending (agent-written, review-mode) lesson so retrieval includes it.
+#[tauri::command]
+fn approve_lesson(state: tauri::State<AppState>, id: i64) -> Result<(), AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Message("database lock poisoned".to_string()))?;
+    memorywhale_cli::migrate(&conn).map_err(AppError::Message)?;
+    conn.execute("UPDATE bookmarks SET approved = 1 WHERE id = ?1", params![id])?;
+    Ok(())
 }
 
 // ── Explainable retrieval (mw-memory) ──────────────────────────────────────

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,6 +85,17 @@ type SearchResult = {
   concepts: Concept[];
 };
 
+type Lesson = {
+  id: number;
+  label: string;
+  created_at: string;
+  author_kind: string;
+  author_name: string | null;
+  source_session_id: number | null;
+  approved: boolean;
+  provenance: string;
+};
+
 type SignalView = {
   name: string;
   weight: number;
@@ -159,10 +170,35 @@ function App() {
   const [stderr, setStderr] = useState("zsh:1: command not found: cargo");
   const [commandNotes, setCommandNotes] = useState("Terminal could not verify Rust because cargo is missing.");
   const [status, setStatus] = useState("Ready");
+  const [lessons, setLessons] = useState<Lesson[]>([]);
+  const [agentOnly, setAgentOnly] = useState(false);
 
   useEffect(() => {
     void refreshGraph();
   }, []);
+
+  useEffect(() => {
+    void refreshLessons();
+  }, [agentOnly]);
+
+  async function refreshLessons() {
+    try {
+      const next = await callBackend<Lesson[]>("list_lessons", { agentOnly });
+      setLessons(next);
+    } catch {
+      setLessons([]);
+    }
+  }
+
+  async function deleteLesson(id: number) {
+    await callBackend("delete_lesson", { id });
+    await refreshLessons();
+  }
+
+  async function approveLesson(id: number) {
+    await callBackend("approve_lesson", { id });
+    await refreshLessons();
+  }
 
   const selected = useMemo(() => {
     if (!selectedId) return null;
@@ -467,6 +503,35 @@ function App() {
                 <span className={`dot ${run.exit_code === 0 ? "command-dot" : "error-dot"}`} />
                 <span>{run.command}</span>
               </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="panel-title">
+            <span>Remembered lessons</span>
+            <label style={{ marginLeft: "auto", fontSize: "0.8rem", display: "flex", gap: "0.35rem", alignItems: "center" }}>
+              <input
+                type="checkbox"
+                checked={agentOnly}
+                onChange={(event) => setAgentOnly(event.target.checked)}
+              />
+              Agent-written only
+            </label>
+          </div>
+          <div className="result-list">
+            {lessons.length === 0 && <span className="source-item">No lessons yet.</span>}
+            {lessons.map((lesson) => (
+              <div className="source-item" key={`lesson-${lesson.id}`} style={{ flexDirection: "column", alignItems: "stretch", gap: "0.25rem" }}>
+                <span>{lesson.label}{lesson.approved ? "" : " (pending review)"}</span>
+                <span style={{ fontSize: "0.75rem", opacity: 0.7 }}>{lesson.provenance}</span>
+                <span style={{ display: "flex", gap: "0.5rem" }}>
+                  {!lesson.approved && (
+                    <button type="button" onClick={() => void approveLesson(lesson.id)}>Approve</button>
+                  )}
+                  <button type="button" onClick={() => void deleteLesson(lesson.id)}>Delete</button>
+                </span>
+              </div>
             ))}
           </div>
         </section>


### PR DESCRIPTION
The MCP `remember` tool let any connected agent write durable memories with no attribution. A wrong agent-written lesson is worse than none, because retrieval later presents it as settled knowledge.

## Migration 1
This PR also introduces the migration runner itself (`migrate()` in `crates/mw-cli/src/lib.rs`, keyed on `PRAGMA user_version`) — none existed before. Targets the `bookmarks` table, each `ADD COLUMN` guarded by a `pragma_table_info` check:

```sql
ALTER TABLE bookmarks ADD COLUMN author_kind TEXT NOT NULL DEFAULT 'human';
ALTER TABLE bookmarks ADD COLUMN author_name TEXT;
ALTER TABLE bookmarks ADD COLUMN source_session_id INTEGER;
ALTER TABLE bookmarks ADD COLUMN approved INTEGER NOT NULL DEFAULT 1;
ALTER TABLE bookmarks ADD COLUMN created_at TEXT;   -- only if missing
PRAGMA user_version = 1;
```

Backfill is automatic via the constant defaults, so it's safe on a populated DB — `ADD COLUMN` with a constant default never rewrites rows.

## Behaviour
- `mw remember` / `mw mark` record `author_kind=human`; the MCP `remember` tool records `agent` plus the client name captured from the `initialize` handshake.
- Retrieval surfaces render provenance: *"remembered by Claude Code on 2026-07-12 during session #41"* — `mw search`, MCP `search_memory`/`get_context`, and the dashboard API.
- Dashboard gains an agent-only filter plus delete/approve affordances (`list_lessons`, `delete_lesson`, `approve_lesson` tauri commands).
- Optional `review_agent_memories = true` (default **off**): agent memories start unapproved and are excluded from retrieval until approved.

MCP tool schema changes are additive only.

## Verification
`cargo build --workspace` / `cargo test --workspace` pass, including a populated-fixture migration test and the three required cases: MCP remember → agent row, CLI remember → human row, review mode hides unapproved from search.

Review-mode filtering applies to retrieval surfaces but deliberately **not** to diagnostic ones (`mw doctor`, `mw export`).

Frontend TS was not typechecked (no `node_modules` available); it's outside `cargo test`.
