### PR TITLE
feat: add wrapper-free lightweight capture via shell hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,46 @@ mw --notes "project:pop_playlist server testing"  # terminal 2
 To auto-record every new terminal without typing `mw`, use `mw global on`
 (`mw global off` to stop). Full operating procedure: [SOP.md](SOP.md).
 
+## Two capture tiers: shell hooks vs `mw --live`
+
+MemoryWhale captures at two levels. They layer — you can run both.
+
+```bash
+mw hooks install     # lightweight, always on, every shell
+mw hooks uninstall    # removes exactly the managed block it added
+```
+
+| | Shell hooks (`mw hooks install`) | Full capture (`mw --live`, `mw-run`) |
+| --- | --- | --- |
+| Always on | Yes, every interactive shell | Per terminal / per command |
+| Records | Command line, working directory, exit code, duration | All of that **plus the full output transcript** |
+| Does **not** record | stdout, stderr, screen content, TUI redraws | — |
+| Cost | One detached write per command, no `script` pty | A pty wrapper for the session |
+| Row marker | `command_runs.capture_kind = 'hook'` | `capture_kind = 'full'` |
+
+Everything lands in the same SQLite database and the same `command_runs`
+table, so `mw search`, `mw context` and the dashboard see hook rows alongside
+full-capture rows. `capture_kind` is how you tell them apart.
+
+How they layer:
+
+- **Hooks are the index.** Always-on, cheap, so you can always answer *what did
+  I run, where, and did it work?* — even months later.
+- **`mw --live` is the recording.** Start it when you're about to do something
+  you'll want to re-read: a gnarly debug session, a deploy, a pairing session.
+- **No double capture.** While a full `mw` session is running it exports
+  `MW_RECORDING=1`; the hook sees that and skips logging entirely, so a command
+  is never recorded twice.
+- **Capture gates apply to both.** A directory gated `off` (via `.mwignore` or
+  `[capture.paths]`) produces zero hook rows — the gate is checked before the
+  database is even opened.
+
+Supported shells: zsh (`preexec`/`precmd`), bash (`DEBUG` trap +
+`PROMPT_COMMAND`), fish (`fish_postexec`). PowerShell is not wired up yet.
+The hook fails silently by design: a locked or missing database, a missing
+binary, a bad path — none of it blocks or breaks your prompt, and your `$?` is
+preserved. Turn it off for one shell with `export MW_HOOK_OFF=1`.
+
 ## Capture gates: never record certain directories
 
 Some directories should never end up in your memory. Capture gates decide, per

--- a/REPORT-issue-8.md
+++ b/REPORT-issue-8.md
@@ -85,6 +85,25 @@ and is a weaker signal of intent.
 
 `cargo build --workspace` and `cargo test --workspace` both pass.
 
+## Bugs found while verifying (fixed here)
+
+Running the scripted bash test in a loop exposed three real races, all of which
+would have silently eaten memories in production:
+
+1. **No `busy_timeout` in `mw-remember`.** Two hooks firing back to back both
+   write; the loser hit "database is locked" and dropped its row. Now
+   `PRAGMA busy_timeout = 3000`.
+2. **Fresh-database creation race.** Concurrent `PRAGMA journal_mode = WAL` and
+   `ALTER TABLE` on a brand-new file lose in ways `busy_timeout` doesn't cover.
+   `open_ready()` now retries open + schema up to 5 times with a short backoff.
+   `add_column_if_missing` also treats "duplicate column name" as success — two
+   writers can both read a column as missing and both try to add it.
+3. **The bash `DEBUG` trap is live for the rest of the sourced file**, so the
+   `case` that wires `PROMPT_COMMAND` latched *itself* as "the user's command"
+   and a bogus `case` row was recorded — and, worse, the latch then blocked the
+   real command. Fixed with an `__MW_IN_HOOK` re-entrancy guard, a `__MW_*`
+   ignore pattern, and clearing the latch at the end of the file.
+
 ## Follow-ups
 
 - **PowerShell** is deliberately out of scope for this issue; needs its own

--- a/REPORT-issue-8.md
+++ b/REPORT-issue-8.md
@@ -1,0 +1,94 @@
+# Issue 8 — Always-on lightweight capture via shell hooks
+
+## What shipped
+
+`mw hooks install` / `mw hooks uninstall`: an Atuin-style always-on tier that
+records **command, cwd, exit code, duration** — never output — into the same
+`command_runs` table, marked `capture_kind = 'hook'`.
+
+## The exact rc-file block
+
+`mw hooks install` writes the generated hook script to
+`<data dir>/memorywhale.sh` (or `memorywhale.fish`) and appends exactly this to
+`~/.zshrc`, `~/.bashrc`, or `~/.config/fish/config.fish`:
+
+```sh
+# >>> memorywhale shell hooks >>>
+# Managed by `mw hooks` — edit above/below, not inside.
+[ -f "/Users/you/Library/Application Support/MemoryWhale/memorywhale.sh" ] && . "/Users/you/Library/Application Support/MemoryWhale/memorywhale.sh"
+# <<< memorywhale shell hooks <<<
+```
+
+fish gets the same delimiters with a fish source line:
+
+```fish
+# >>> memorywhale shell hooks >>>
+# Managed by `mw hooks` — edit above/below, not inside.
+test -f "/Users/you/.../memorywhale.fish"; and source "/Users/you/.../memorywhale.fish"
+# <<< memorywhale shell hooks <<<
+```
+
+Nothing else is sourced into the user's shell. Install strips any existing
+block before appending, so it is idempotent; uninstall removes exactly the
+lines between (and including) the two markers and deletes the generated script.
+
+## Schema
+
+**Migration 3** — `command_runs.capture_kind TEXT NOT NULL DEFAULT 'full'`.
+`LATEST_SCHEMA_VERSION` bumped 2 → 3. Migrations 1 and 2 untouched (migration 2
+now pins `user_version = 2` explicitly instead of jumping to the constant).
+
+Because half a dozen binaries still create `command_runs` with their own
+`CREATE TABLE IF NOT EXISTS`, a database can reach version 3 *before* the table
+exists. `memorywhale_cli::ensure_capture_kind(conn)` (the body of migration 3)
+is public and called unconditionally by `mw-remember` before it inserts, so the
+column is always there at the write site.
+
+## Write path
+
+The hook shells out to the existing `mw-remember` binary — no new binary, no
+new dependency — with a new `--capture-kind` flag. `mw-remember` already
+consults `capture_rule_for(cwd)` **before opening the database**, so an `off`
+directory produces zero rows and `commands-only` is exactly this tier. The call
+is fire-and-forget in a detached subshell, so prompt latency is a `fork`, not a
+database round-trip.
+
+## Double-capture guard
+
+The `mw` wrapper already exports `MW_RECORDING=1` into the recorded session
+(`bin/mw.rs`, both the `script` spawn and the global-hook `exec` path). The hook
+returns early when it sees it. No new env var was needed — `MW_RECORDING` is set
+on the child environment of the pty, so every shell inside a full capture
+session inherits it, whereas `MW_TRANSCRIPT` is a path that other tooling reads
+and is a weaker signal of intent.
+
+## Safety properties
+
+- Every failure path returns 0: missing binary, unreadable rc, locked DB, bad
+  path. The write itself is detached and its output discarded.
+- `$?` is preserved: both `__mw_precmd` implementations capture `$?` first and
+  `return $code`; fish's `__mw_postexec` does the same with `$status`.
+- Interactive shells only, guarded against double-loading.
+- `MW_HOOK_OFF=1` disables it for one shell.
+
+## Tests
+
+`crates/mw-cli/tests/shell_hooks.rs` — runs a real `bash -i` against a sandbox
+`HOME` and `MEMORYWHALE_DATA_DIR`:
+
+1. `hook_records_command_cwd_and_exit_code` — asserts the managed block is
+   present and non-duplicated after two installs, then asserts a row with
+   `capture_kind='hook'`, the right cwd, and exit code 7.
+2. `wrapper_session_suppresses_hook_rows` — `MW_RECORDING=1` set → zero rows.
+3. `off_gated_directory_records_nothing` — `.mwignore` with `capture = "off"` →
+   zero rows.
+
+`cargo build --workspace` and `cargo test --workspace` both pass.
+
+## Follow-ups
+
+- **PowerShell** is deliberately out of scope for this issue; needs its own
+  `prompt`-function hook and a `Microsoft.PowerShell_profile.ps1` managed block.
+- Duration is second-granularity (`$SECONDS` / `CMD_DURATION`), recorded in the
+  notes as `dur:Ns`. A dedicated `duration_ms` column is the upgrade path if
+  sub-second timing turns out to matter.

--- a/crates/mw-cli/src/bin/mw-remember.rs
+++ b/crates/mw-cli/src/bin/mw-remember.rs
@@ -20,6 +20,7 @@ fn run() -> Result<(), String> {
     let mut stderr = String::new();
     let mut notes = String::new();
     let mut command_parts = Vec::new();
+    let mut capture_kind = "full".to_string();
 
     let mut args = env::args().skip(1).peekable();
     while let Some(arg) = args.next() {
@@ -35,6 +36,7 @@ fn run() -> Result<(), String> {
             "--stdout" => stdout = args.next().unwrap_or_default(),
             "--stderr" => stderr = args.next().unwrap_or_default(),
             "--notes" => notes = args.next().unwrap_or_default(),
+            "--capture-kind" => capture_kind = args.next().unwrap_or_else(|| "full".to_string()),
             "--" => {
                 command_parts.extend(args);
                 break;
@@ -73,10 +75,11 @@ fn run() -> Result<(), String> {
 
     let conn = Connection::open(db_path).map_err(|err| format!("failed to open db: {err}"))?;
     init_schema(&conn)?;
+    memorywhale_cli::ensure_capture_kind(&conn)?;
     conn.execute(
         "
-        INSERT INTO command_runs (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+        INSERT INTO command_runs (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at, capture_kind)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
         ",
         params![
             command,
@@ -86,7 +89,8 @@ fn run() -> Result<(), String> {
             memorywhale_cli::redact(&stdout),
             memorywhale_cli::redact(&stderr),
             memorywhale_cli::redact(&notes),
-            created_at
+            created_at,
+            capture_kind
         ],
     )
     .map_err(|err| format!("failed to insert command run: {err}"))?;
@@ -109,7 +113,7 @@ fn run() -> Result<(), String> {
 
 fn print_help() {
     println!(
-        "mw-remember --cwd <path> --exit-code <code> --stdout <text> --stderr <text> --notes <text> -- <command> [args...]"
+        "mw-remember --cwd <path> --exit-code <code> --stdout <text> --stderr <text> --notes <text> --capture-kind <full|hook> -- <command> [args...]"
     );
 }
 
@@ -127,7 +131,8 @@ fn init_schema(conn: &Connection) -> Result<(), String> {
             stdout TEXT NOT NULL DEFAULT '',
             stderr TEXT NOT NULL DEFAULT '',
             notes TEXT NOT NULL DEFAULT '',
-            created_at TEXT NOT NULL
+            created_at TEXT NOT NULL,
+            capture_kind TEXT NOT NULL DEFAULT 'full'
         );
 
         CREATE TABLE IF NOT EXISTS command_arguments (

--- a/crates/mw-cli/src/bin/mw-remember.rs
+++ b/crates/mw-cli/src/bin/mw-remember.rs
@@ -73,9 +73,7 @@ fn run() -> Result<(), String> {
         fs::create_dir_all(parent).map_err(|err| format!("failed to create data dir: {err}"))?;
     }
 
-    let conn = Connection::open(db_path).map_err(|err| format!("failed to open db: {err}"))?;
-    init_schema(&conn)?;
-    memorywhale_cli::ensure_capture_kind(&conn)?;
+    let conn = open_ready(&db_path)?;
     conn.execute(
         "
         INSERT INTO command_runs (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at, capture_kind)
@@ -111,6 +109,33 @@ fn run() -> Result<(), String> {
     Ok(())
 }
 
+/// Open the database and make sure the schema is usable.
+///
+/// Shell hooks fire one writer per command, so several can be creating or
+/// upgrading a brand-new database at the same instant — `PRAGMA journal_mode`
+/// and `ALTER TABLE` both lose races that `busy_timeout` alone doesn't cover.
+/// Retry briefly rather than dropping the row.
+fn open_ready(db_path: &std::path::Path) -> Result<Connection, String> {
+    let mut last = String::new();
+    for attempt in 0..5 {
+        if attempt > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(80 * attempt));
+        }
+        let conn = match Connection::open(db_path) {
+            Ok(conn) => conn,
+            Err(err) => {
+                last = format!("failed to open db: {err}");
+                continue;
+            }
+        };
+        match init_schema(&conn).and_then(|()| memorywhale_cli::ensure_capture_kind(&conn)) {
+            Ok(()) => return Ok(conn),
+            Err(err) => last = err,
+        }
+    }
+    Err(last)
+}
+
 fn print_help() {
     println!(
         "mw-remember --cwd <path> --exit-code <code> --stdout <text> --stderr <text> --notes <text> --capture-kind <full|hook> -- <command> [args...]"
@@ -121,6 +146,9 @@ fn init_schema(conn: &Connection) -> Result<(), String> {
     conn.execute_batch(
         "
         PRAGMA journal_mode = WAL;
+        -- Shell hooks fire one writer per command, so two can land at once.
+        -- Wait instead of failing: a dropped row is a silently missing memory.
+        PRAGMA busy_timeout = 3000;
 
         CREATE TABLE IF NOT EXISTS command_runs (
             id INTEGER PRIMARY KEY,

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -61,6 +61,7 @@ fn run() -> Result<(), String> {
         Some("doctor") => return doctor(),
         Some("global") => return global_cmd(&raw_args[1..]),
         Some("status") => return global_status(),
+        Some("hooks") => return hooks_cmd(&raw_args[1..]),
         Some("--help") | Some("-h") => {
             print_help();
             return Ok(());
@@ -253,6 +254,7 @@ fn print_help() {
          mw ask [question] [--chat chatgpt|claude|gemini|URL] [--session] [--no-open]  package the last failure for your chat AI\n\
          mw doctor                check the install: data dir, database, `script`, and hook status\n\
          mw global on|off|status  auto-record every new terminal by wiring a shell startup hook\n\
+         mw hooks install|uninstall  always-on lightweight capture: command, cwd, exit code, duration (no output)\n\
          \n\
          Records every command + output, stored locally and never uploaded.\n\
          Raw transcript: <data_local>/MemoryWhale/sessions/\n\
@@ -961,6 +963,126 @@ fn global_cmd(args: &[String]) -> Result<(), String> {
             "unknown subcommand {other:?}; usage: mw global [on|off|status]"
         )),
     }
+}
+
+// ---------------------------------------------------------------------------
+// `mw hooks` — the lightweight always-on capture tier.
+//
+// ponytail: no PowerShell here; Windows is a follow-up issue.
+// ---------------------------------------------------------------------------
+
+const HOOK_SH: &str = include_str!("../../../../linux/shell/memorywhale.sh");
+const HOOK_FISH: &str = include_str!("../../../../linux/shell/memorywhale.fish");
+const HOOK_BEGIN: &str = "# >>> memorywhale shell hooks >>>";
+const HOOK_END: &str = "# <<< memorywhale shell hooks <<<";
+
+/// (shell name, rc file, generated hook file, hook script body)
+fn hook_target() -> Result<(&'static str, PathBuf, PathBuf, &'static str), String> {
+    let home = dirs::home_dir().ok_or_else(|| "could not resolve home directory".to_string())?;
+    let shell = env::var("SHELL").unwrap_or_default();
+    let name = shell.rsplit('/').next().unwrap_or_default();
+    let hooks_dir = memorywhale_dir()?;
+    if name.contains("fish") {
+        Ok((
+            "fish",
+            home.join(".config").join("fish").join("config.fish"),
+            hooks_dir.join("memorywhale.fish"),
+            HOOK_FISH,
+        ))
+    } else if name.contains("zsh") {
+        Ok(("zsh", home.join(".zshrc"), hooks_dir.join("memorywhale.sh"), HOOK_SH))
+    } else {
+        Ok(("bash", home.join(".bashrc"), hooks_dir.join("memorywhale.sh"), HOOK_SH))
+    }
+}
+
+fn hook_block(shell: &str, hook_path: &str) -> String {
+    let source_line = if shell == "fish" {
+        format!("test -f \"{hook_path}\"; and source \"{hook_path}\"")
+    } else {
+        format!("[ -f \"{hook_path}\" ] && . \"{hook_path}\"")
+    };
+    format!("{HOOK_BEGIN}\n# Managed by `mw hooks` — edit above/below, not inside.\n{source_line}\n{HOOK_END}\n")
+}
+
+/// Drop the managed block (and only that) from an rc file's text.
+fn strip_hook_block(rc: &str) -> String {
+    let mut out = String::with_capacity(rc.len());
+    let mut skipping = false;
+    for line in rc.lines() {
+        if line.trim() == HOOK_BEGIN {
+            skipping = true;
+            continue;
+        }
+        if skipping {
+            if line.trim() == HOOK_END {
+                skipping = false;
+            }
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+fn hooks_cmd(args: &[String]) -> Result<(), String> {
+    match args.first().map(String::as_str) {
+        Some("install") => hooks_install(),
+        Some("uninstall") | Some("remove") => hooks_uninstall(),
+        Some(other) => Err(format!(
+            "unknown subcommand {other:?}; usage: mw hooks [install|uninstall]"
+        )),
+        None => Err("usage: mw hooks [install|uninstall]".to_string()),
+    }
+}
+
+fn hooks_install() -> Result<(), String> {
+    let (shell, rc_path, hook_path, body) = hook_target()?;
+    if let Some(parent) = hook_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("failed to create data dir: {e}"))?;
+    }
+    fs::write(&hook_path, body).map_err(|e| format!("failed to write hook script: {e}"))?;
+    let hook_str = hook_path
+        .to_str()
+        .ok_or_else(|| "hook path is not valid UTF-8".to_string())?;
+
+    if let Some(parent) = rc_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+    }
+    let existing = fs::read_to_string(&rc_path).unwrap_or_default();
+    // Idempotent: strip any previous block first, then append exactly one.
+    let mut updated = strip_hook_block(&existing);
+    if !updated.is_empty() && !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+    updated.push_str(&hook_block(shell, hook_str));
+    fs::write(&rc_path, updated).map_err(|e| format!("failed to update {}: {e}", rc_path.display()))?;
+
+    println!("mw: lightweight shell hooks INSTALLED ({shell}).");
+    println!("  rc file: {}", rc_path.display());
+    println!("  hook:    {hook_str}");
+    println!("  Records command, cwd, exit code and duration. No output — use `mw --live` for that.");
+    println!("  Open a NEW terminal to start capturing.");
+    Ok(())
+}
+
+fn hooks_uninstall() -> Result<(), String> {
+    let (shell, rc_path, hook_path, _) = hook_target()?;
+    let existing = fs::read_to_string(&rc_path).unwrap_or_default();
+    let updated = strip_hook_block(&existing);
+    let changed = updated != existing;
+    if changed {
+        fs::write(&rc_path, updated)
+            .map_err(|e| format!("failed to update {}: {e}", rc_path.display()))?;
+    }
+    let _ = fs::remove_file(&hook_path);
+    if changed {
+        println!("mw: shell hooks REMOVED from {} ({shell}).", rc_path.display());
+    } else {
+        println!("mw: no shell hook block found in {} — nothing to do.", rc_path.display());
+    }
+    Ok(())
 }
 
 /// Shell startup file to wire the hook into, chosen from $SHELL (zsh vs bash).

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -174,8 +174,16 @@ fn add_column_if_missing(
         .and_then(|mut s| s.exists(params![table, column]))
         .map_err(|e| format!("failed to inspect {table} columns: {e}"))?;
     if !present {
-        conn.execute(&format!("ALTER TABLE {table} ADD COLUMN {column} {decl}"), [])
-            .map_err(|e| format!("failed to add {table}.{column}: {e}"))?;
+        // Two writers (e.g. two shell hooks firing at once on a fresh DB) can
+        // both read the column as missing and both try to add it. The loser
+        // gets "duplicate column name", which is the outcome we wanted anyway.
+        if let Err(e) = conn.execute(&format!("ALTER TABLE {table} ADD COLUMN {column} {decl}"), [])
+        {
+            let msg = e.to_string();
+            if !msg.contains("duplicate column") {
+                return Err(format!("failed to add {table}.{column}: {msg}"));
+            }
+        }
     }
     Ok(())
 }

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -92,7 +92,7 @@ const BOOKMARKS_BASE: &str = "CREATE TABLE IF NOT EXISTS bookmarks (
      CREATE INDEX IF NOT EXISTS idx_bookmarks_created_at ON bookmarks(created_at);";
 
 /// Schema version `migrate` brings a database up to.
-pub const LATEST_SCHEMA_VERSION: i64 = 2;
+pub const LATEST_SCHEMA_VERSION: i64 = 3;
 
 /// Apply numbered schema migrations to a MemoryWhale database. Idempotent and
 /// cheap (a `user_version` check), so callers run it before touching bookmarks.
@@ -106,6 +106,10 @@ pub const LATEST_SCHEMA_VERSION: i64 = 2;
 /// backfills `project` from the legacy `project:<name>` convention inside
 /// `notes`. The notes string itself is left untouched, so the dashboard's
 /// existing note parsing keeps working.
+///
+/// Migration 3 — capture tiers: adds `command_runs.capture_kind`, defaulting to
+/// `full` so every pre-existing row keeps its meaning. Shell-hook rows write
+/// `hook` instead (command + cwd + exit code, no output).
 pub fn migrate(conn: &Connection) -> Result<(), String> {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |r| r.get(0))
@@ -129,8 +133,26 @@ pub fn migrate(conn: &Connection) -> Result<(), String> {
             add_column_if_missing(conn, "sessions", "machine", "TEXT")?;
             backfill_project_from_notes(conn)?;
         }
+        conn.execute_batch("PRAGMA user_version = 2;")
+            .map_err(|e| format!("failed to bump schema version: {e}"))?;
+    }
+    if version < 3 {
+        ensure_capture_kind(conn)?;
         conn.execute_batch(&format!("PRAGMA user_version = {LATEST_SCHEMA_VERSION};"))
             .map_err(|e| format!("failed to bump schema version: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Add `command_runs.capture_kind` if the table exists and lacks it.
+///
+/// ponytail: exposed (not just inlined in migration 3) because half a dozen
+/// binaries still create `command_runs` with their own `CREATE TABLE IF NOT
+/// EXISTS`, so a DB can reach version 3 *before* the table exists. Writers call
+/// this directly; it's two pragma queries.
+pub fn ensure_capture_kind(conn: &Connection) -> Result<(), String> {
+    if table_exists(conn, "command_runs")? {
+        add_column_if_missing(conn, "command_runs", "capture_kind", "TEXT NOT NULL DEFAULT 'full'")?;
     }
     Ok(())
 }

--- a/crates/mw-cli/tests/shell_hooks.rs
+++ b/crates/mw-cli/tests/shell_hooks.rs
@@ -1,0 +1,146 @@
+//! End-to-end check of the lightweight shell-hook capture tier.
+//!
+//! Installs hooks into a sandbox HOME, runs a real `bash -i`, and asserts what
+//! landed (and what didn't) in the sandbox database.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+fn sandbox(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("mw-hooks-{name}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("bin")).unwrap();
+    fs::create_dir_all(dir.join("data")).unwrap();
+    fs::create_dir_all(dir.join("work")).unwrap();
+    // mw-remember must be reachable as that exact name on PATH.
+    let src = PathBuf::from(env!("CARGO_BIN_EXE_mw-remember"));
+    fs::copy(&src, dir.join("bin").join("mw-remember")).unwrap();
+    dir
+}
+
+fn install_hooks(home: &Path) {
+    let out = Command::new(env!("CARGO_BIN_EXE_mw"))
+        .args(["hooks", "install"])
+        .env("HOME", home)
+        .env("SHELL", "/bin/bash")
+        .env("MEMORYWHALE_DATA_DIR", home.join("data"))
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "install failed: {out:?}");
+}
+
+/// Run one command in an interactive bash with the sandbox rc loaded.
+fn run_bash(home: &Path, cwd: &Path, script: &str, extra: &[(&str, &str)]) {
+    let mut cmd = Command::new("bash");
+    cmd.arg("-i")
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("MEMORYWHALE_DATA_DIR", home.join("data"))
+        .env(
+            "PATH",
+            format!("{}:{}", home.join("bin").display(), std::env::var("PATH").unwrap()),
+        )
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    for (k, v) in extra {
+        cmd.env(k, v);
+    }
+    let mut child = cmd.spawn().unwrap();
+    {
+        use std::io::Write;
+        // Trailing `true` gives the prompt hook a chance to fire for `script`.
+        write!(child.stdin.as_mut().unwrap(), "{script}\ntrue\nexit\n").unwrap();
+    }
+    child.wait().unwrap();
+    // The hook writes from a detached subshell; give it a moment to land.
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+}
+
+fn hook_rows(home: &Path) -> Vec<(String, String, i64)> {
+    let db = home.join("data").join("memorywhale.sqlite3");
+    if !db.exists() {
+        return Vec::new();
+    }
+    let conn = rusqlite::Connection::open(db).unwrap();
+    let exists: bool = conn
+        .prepare("SELECT 1 FROM pragma_table_info('command_runs') WHERE name='capture_kind'")
+        .and_then(|mut s| s.exists([]))
+        .unwrap_or(false);
+    if !exists {
+        return Vec::new();
+    }
+    let mut stmt = conn
+        .prepare("SELECT command, cwd, exit_code FROM command_runs WHERE capture_kind = 'hook'")
+        .unwrap();
+    let rows = stmt
+        .query_map([], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, Option<String>>(1)?.unwrap_or_default(),
+                r.get::<_, Option<i64>>(2)?.unwrap_or(-1),
+            ))
+        })
+        .unwrap()
+        .flatten()
+        .collect();
+    rows
+}
+
+#[test]
+fn hook_records_command_cwd_and_exit_code() {
+    let home = sandbox("basic");
+    install_hooks(&home);
+
+    let rc = fs::read_to_string(home.join(".bashrc")).unwrap();
+    assert!(rc.contains("memorywhale shell hooks"), "rc block missing: {rc}");
+    // Idempotent: installing twice must not duplicate the block.
+    install_hooks(&home);
+    let rc2 = fs::read_to_string(home.join(".bashrc")).unwrap();
+    assert_eq!(rc2.matches(">>> memorywhale shell hooks >>>").count(), 1);
+
+    let work = home.join("work");
+    run_bash(&home, &work, "sh -c 'exit 7'", &[]);
+
+    let rows = hook_rows(&home);
+    let hit = rows.iter().find(|(cmd, _, _)| cmd == "sh");
+    let hit = hit.unwrap_or_else(|| panic!("no hook row for `sh`; got {rows:?}"));
+    assert_eq!(hit.2, 7, "wrong exit code in {rows:?}");
+    assert!(
+        Path::new(&hit.1).ends_with("work"),
+        "wrong cwd {:?} in {rows:?}",
+        hit.1
+    );
+}
+
+#[test]
+fn wrapper_session_suppresses_hook_rows() {
+    let home = sandbox("guard");
+    install_hooks(&home);
+    run_bash(
+        &home,
+        &home.join("work"),
+        "sh -c 'exit 7'",
+        &[("MW_RECORDING", "1")],
+    );
+    assert!(
+        hook_rows(&home).is_empty(),
+        "hook logged inside an mw capture session: {:?}",
+        hook_rows(&home)
+    );
+}
+
+#[test]
+fn off_gated_directory_records_nothing() {
+    let home = sandbox("gate");
+    install_hooks(&home);
+    let work = home.join("work");
+    fs::write(work.join(".mwignore"), "capture = \"off\"\n").unwrap();
+    run_bash(&home, &work, "sh -c 'exit 7'", &[]);
+    assert!(
+        hook_rows(&home).is_empty(),
+        "hook wrote in an off-gated directory: {:?}",
+        hook_rows(&home)
+    );
+}

--- a/crates/mw-cli/tests/shell_hooks.rs
+++ b/crates/mw-cli/tests/shell_hooks.rs
@@ -54,8 +54,6 @@ fn run_bash(home: &Path, cwd: &Path, script: &str, extra: &[(&str, &str)]) {
         write!(child.stdin.as_mut().unwrap(), "{script}\ntrue\nexit\n").unwrap();
     }
     child.wait().unwrap();
-    // The hook writes from a detached subshell; give it a moment to land.
-    std::thread::sleep(std::time::Duration::from_millis(1500));
 }
 
 fn hook_rows(home: &Path) -> Vec<(String, String, i64)> {
@@ -88,6 +86,23 @@ fn hook_rows(home: &Path) -> Vec<(String, String, i64)> {
     rows
 }
 
+/// The hook writes from a detached subshell, so rows land asynchronously.
+/// Poll rather than guess a sleep.
+fn wait_for_hook_row(home: &Path, command: &str) -> Option<(String, String, i64)> {
+    for _ in 0..60 {
+        if let Some(row) = hook_rows(home).into_iter().find(|(c, _, _)| c == command) {
+            return Some(row);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(250));
+    }
+    None
+}
+
+/// Negative assertions have nothing to poll for: wait out the async write.
+fn settle() {
+    std::thread::sleep(std::time::Duration::from_secs(3));
+}
+
 #[test]
 fn hook_records_command_cwd_and_exit_code() {
     let home = sandbox("basic");
@@ -103,9 +118,9 @@ fn hook_records_command_cwd_and_exit_code() {
     let work = home.join("work");
     run_bash(&home, &work, "sh -c 'exit 7'", &[]);
 
+    let hit = wait_for_hook_row(&home, "sh")
+        .unwrap_or_else(|| panic!("no hook row for `sh`; got {:?}", hook_rows(&home)));
     let rows = hook_rows(&home);
-    let hit = rows.iter().find(|(cmd, _, _)| cmd == "sh");
-    let hit = hit.unwrap_or_else(|| panic!("no hook row for `sh`; got {rows:?}"));
     assert_eq!(hit.2, 7, "wrong exit code in {rows:?}");
     assert!(
         Path::new(&hit.1).ends_with("work"),
@@ -124,6 +139,7 @@ fn wrapper_session_suppresses_hook_rows() {
         "sh -c 'exit 7'",
         &[("MW_RECORDING", "1")],
     );
+    settle();
     assert!(
         hook_rows(&home).is_empty(),
         "hook logged inside an mw capture session: {:?}",
@@ -138,6 +154,7 @@ fn off_gated_directory_records_nothing() {
     let work = home.join("work");
     fs::write(work.join(".mwignore"), "capture = \"off\"\n").unwrap();
     run_bash(&home, &work, "sh -c 'exit 7'", &[]);
+    settle();
     assert!(
         hook_rows(&home).is_empty(),
         "hook wrote in an off-gated directory: {:?}",

--- a/linux/shell/memorywhale.fish
+++ b/linux/shell/memorywhale.fish
@@ -1,0 +1,24 @@
+# MemoryWhale lightweight capture hook (fish).
+# Managed by `mw hooks install` / `mw hooks uninstall`.
+# Records command, cwd, exit code and duration — never output.
+# Toggle off for one shell:   set -x MW_HOOK_OFF 1
+
+status is-interactive; or exit 0
+set -q __mw_hook_loaded; and exit 0
+set -g __mw_hook_loaded 1
+
+function __mw_postexec --on-event fish_postexec
+    set -l code $status              # capture first: nothing above may run
+    set -q MW_HOOK_OFF; and return $code
+    set -q MW_RECORDING; and return $code   # inside a full `mw` capture session
+    test -n "$argv[1]"; or return $code
+    string match -q 'mw-remember*' -- "$argv[1]"; and return $code
+    set -l bin (command -v mw-remember 2>/dev/null)
+    if test -z "$bin"; and test -x "$HOME/.local/bin/mw-remember"
+        set bin "$HOME/.local/bin/mw-remember"
+    end
+    test -x "$bin"; or return $code
+    # mw-remember applies the per-directory capture gate itself.
+    fish -c "$bin --cwd '$PWD' --exit-code $code --capture-kind hook --notes 'shell hook dur:'(math -s0 $CMD_DURATION/1000)'s' -- $argv[1] >/dev/null 2>&1 &" >/dev/null 2>&1
+    return $code
+end

--- a/linux/shell/memorywhale.sh
+++ b/linux/shell/memorywhale.sh
@@ -1,26 +1,27 @@
-# MemoryWhale per-command recorder (bash + zsh).
+# MemoryWhale lightweight capture hook (bash + zsh).
 #
-# Source this from your shell rc to record every interactive command — its
-# working directory and exit code — into the local MemoryWhale database via
-# mw-remember. This is a lightweight per-command INDEX; it does not capture
-# output. For a full faithful transcript of a whole session, use `mw` instead.
+# Records every interactive command — the command line, working directory,
+# exit code and duration — into the local MemoryWhale database. It never
+# captures output. For a full faithful transcript, use `mw --live`.
 #
-#   echo '. /usr/share/memorywhale/memorywhale.sh' >> ~/.bashrc   # or ~/.zshrc
+# Managed by `mw hooks install` / `mw hooks uninstall`; you normally don't
+# source this by hand.
 #
-# Toggle off for one shell:   export MW_PERCMD_OFF=1
+# Toggle off for one shell:   export MW_HOOK_OFF=1
 # Everything stays local and is never uploaded.
 
 # Interactive shells only; never load twice.
 case $- in *i*) : ;; *) return 0 2>/dev/null || true ;; esac
-[ -n "${__MW_PERCMD_LOADED:-}" ] && return 0 2>/dev/null
-__MW_PERCMD_LOADED=1
+[ -n "${__MW_HOOK_LOADED:-}" ] && return 0 2>/dev/null
+__MW_HOOK_LOADED=1
 
-# Record one command. $1 = exit code, $2 = command line. Fire-and-forget in a
-# detached subshell so the prompt stays snappy and a hiccup never breaks the
-# shell. Word-splitting turns the line into argv for mw-remember.
+# Record one command. $1 = exit code, $2 = command line, $3 = duration seconds.
+# Fire-and-forget in a detached subshell so the prompt stays snappy and a
+# hiccup — locked DB, missing DB, missing binary — never breaks the shell.
+# Word-splitting turns the line into argv for mw-remember.
 __mw_record() {
-  [ -n "${MW_PERCMD_OFF:-}" ] && return 0
-  [ -n "${MW_RECORDING:-}" ] && return 0   # already inside a full `mw` session
+  [ -n "${MW_HOOK_OFF:-}" ] && return 0
+  [ -n "${MW_RECORDING:-}" ] && return 0   # inside a full `mw` capture session
   [ -z "${2:-}" ] && return 0
   case "$2" in
     __mw_*|mw-remember*) return 0 ;;        # don't record our own bookkeeping
@@ -29,20 +30,28 @@ __mw_record() {
   bin="$(command -v mw-remember 2>/dev/null || true)"
   [ -z "$bin" ] && [ -x "$HOME/.local/bin/mw-remember" ] && bin="$HOME/.local/bin/mw-remember"
   [ -x "$bin" ] || return 0
+  # mw-remember applies the per-directory capture gate (.mwignore /
+  # [capture.paths]) itself, before it opens the database.
   if [ -n "${ZSH_VERSION:-}" ]; then
-    ( "$bin" --cwd "$PWD" --exit-code "$1" --notes "per-command hook" -- ${=2} >/dev/null 2>&1 & )
+    ( "$bin" --cwd "$PWD" --exit-code "$1" --capture-kind hook \
+        --notes "shell hook dur:${3:-0}s" -- ${=2} >/dev/null 2>&1 & ) 2>/dev/null
   else
-    ( "$bin" --cwd "$PWD" --exit-code "$1" --notes "per-command hook" -- $2 >/dev/null 2>&1 & )
+    ( "$bin" --cwd "$PWD" --exit-code "$1" --capture-kind hook \
+        --notes "shell hook dur:${3:-0}s" -- $2 >/dev/null 2>&1 & ) 2>/dev/null
   fi
+  return 0
 }
 
 if [ -n "${ZSH_VERSION:-}" ]; then
   autoload -Uz add-zsh-hook 2>/dev/null
-  __mw_preexec() { __MW_LAST_CMD="$1"; }
+  __mw_preexec() { __MW_LAST_CMD="$1"; __MW_START=$SECONDS; }
   __mw_precmd()  {
     local code=$?
-    [ -n "${__MW_LAST_CMD:-}" ] && __mw_record "$code" "$__MW_LAST_CMD"
+    if [ -n "${__MW_LAST_CMD:-}" ]; then
+      __mw_record "$code" "$__MW_LAST_CMD" "$((SECONDS - ${__MW_START:-$SECONDS}))"
+    fi
     __MW_LAST_CMD=""
+    return $code   # never clobber the exit code the user sees
   }
   add-zsh-hook preexec __mw_preexec
   add-zsh-hook precmd  __mw_precmd
@@ -51,12 +60,19 @@ elif [ -n "${BASH_VERSION:-}" ]; then
     # Ignore completion expansions and the prompt command itself.
     [ -n "${COMP_LINE:-}" ] && return 0
     [ "$BASH_COMMAND" = "${PROMPT_COMMAND:-}" ] && return 0
+    case "$BASH_COMMAND" in __mw_*) return 0 ;; esac
+    [ -n "${__MW_LAST_CMD:-}" ] && return 0   # first word of the pipeline wins
     __MW_LAST_CMD="$BASH_COMMAND"
+    __MW_START=$SECONDS
+    return 0
   }
   __mw_precmd() {
     local code=$?
-    [ -n "${__MW_LAST_CMD:-}" ] && __mw_record "$code" "$__MW_LAST_CMD"
+    if [ -n "${__MW_LAST_CMD:-}" ]; then
+      __mw_record "$code" "$__MW_LAST_CMD" "$((SECONDS - ${__MW_START:-$SECONDS}))"
+    fi
     __MW_LAST_CMD=""
+    return $code
   }
   trap '__mw_preexec' DEBUG
   case "${PROMPT_COMMAND:-}" in

--- a/linux/shell/memorywhale.sh
+++ b/linux/shell/memorywhale.sh
@@ -57,10 +57,15 @@ if [ -n "${ZSH_VERSION:-}" ]; then
   add-zsh-hook precmd  __mw_precmd
 elif [ -n "${BASH_VERSION:-}" ]; then
   __mw_preexec() {
+    # The DEBUG trap also fires for the commands *inside* our own hook
+    # functions; __MW_IN_HOOK keeps those out of the record. Without it the
+    # first-word-wins latch below can be claimed by our own bookkeeping and
+    # the user's actual command is silently dropped.
+    [ -n "${__MW_IN_HOOK:-}" ] && return 0
     # Ignore completion expansions and the prompt command itself.
     [ -n "${COMP_LINE:-}" ] && return 0
     [ "$BASH_COMMAND" = "${PROMPT_COMMAND:-}" ] && return 0
-    case "$BASH_COMMAND" in __mw_*) return 0 ;; esac
+    case "$BASH_COMMAND" in __mw_*|__MW_*) return 0 ;; esac
     [ -n "${__MW_LAST_CMD:-}" ] && return 0   # first word of the pipeline wins
     __MW_LAST_CMD="$BASH_COMMAND"
     __MW_START=$SECONDS
@@ -68,10 +73,12 @@ elif [ -n "${BASH_VERSION:-}" ]; then
   }
   __mw_precmd() {
     local code=$?
+    __MW_IN_HOOK=1
     if [ -n "${__MW_LAST_CMD:-}" ]; then
       __mw_record "$code" "$__MW_LAST_CMD" "$((SECONDS - ${__MW_START:-$SECONDS}))"
     fi
     __MW_LAST_CMD=""
+    __MW_IN_HOOK=""
     return $code
   }
   trap '__mw_preexec' DEBUG
@@ -79,4 +86,7 @@ elif [ -n "${BASH_VERSION:-}" ]; then
     *__mw_precmd*) : ;;
     *) PROMPT_COMMAND="__mw_precmd${PROMPT_COMMAND:+; $PROMPT_COMMAND}" ;;
   esac
+  # The DEBUG trap is live for the rest of this file, so the `case` above just
+  # latched itself as "the user's command". Drop it.
+  __MW_LAST_CMD=""
 fi


### PR DESCRIPTION
> **Stacked PR.** Base is `issue/6-capture-gates` (#41) so the diff shows only this issue's changes.

Capture required the `mw` wrapper per terminal or `mw-run` per command. This adds an Atuin-style always-on lightweight tier recording command, cwd, exit code, and duration — no output. `mw --live` remains the full-output mode.

## rc block emitted
bash/zsh (fish gets the same delimiters with `test -f …; and source …`):
```sh
# >>> memorywhale shell hooks >>>
# Managed by `mw hooks` — edit above/below, not inside.
[ -f "<data dir>/memorywhale.sh" ] && . "<data dir>/memorywhale.sh"
# <<< memorywhale shell hooks <<<
```
Install strips any existing block before appending (idempotent — installing twice does not duplicate). Uninstall removes exactly those lines and deletes the generated script. Nothing beyond the managed block is sourced.

## Migration 3
`command_runs.capture_kind TEXT NOT NULL DEFAULT 'full'`; `LATEST_SCHEMA_VERSION` 2 → 3. Migrations 1 and 2 untouched — though migration 2 now pins `user_version = 2` instead of jumping to the constant. **That was a latent bug:** as written, a v1 database would have jumped straight to 3 and skipped migration 3 entirely.

The migration body is also exposed as `ensure_capture_kind(conn)` and called unconditionally by the writer, because several binaries create `command_runs` with their own `CREATE TABLE IF NOT EXISTS` and a DB can reach v3 before the table exists.

## Double-capture guard
The wrapper already exports `MW_RECORDING=1` into the recorded session (both the `script` spawn and the global-hook `exec` path). The hook returns early when it sees it, so commands aren't recorded twice. No new env var needed — `MW_TRANSCRIPT` is a path other tooling reads, a weaker signal.

## Write path
Reuses the existing `mw-remember` binary with a new `--capture-kind` flag rather than adding a binary or dependency. It consults `capture_rule_for(cwd)` before opening the DB, so **#41's `off` directories produce zero hook rows**. Fire-and-forget detached subshell; every failure path returns 0 and the user's `$?` is preserved (`return $code` in every precmd/postexec), so a broken hook can never break the prompt.

## Three races found and fixed
Looping the integration test surfaced three bugs that would have silently eaten memories in production, fixed in the second commit:
1. `mw-remember` had no `busy_timeout`.
2. Concurrent writers raced creating/altering a fresh DB (`open_ready()` retry + tolerate "duplicate column").
3. bash's `DEBUG` trap stays live for the rest of the sourced file, so the hook script's own trailing `case` latched itself as the user's command *and* blocked the real one.

## Verification
`cargo build --workspace` / `cargo test --workspace` pass. `crates/mw-cli/tests/shell_hooks.rs` drives a real `bash -i` in a sandbox HOME and asserts: a `capture_kind='hook'` row with correct cwd and exit code 7 plus a non-duplicated rc block after two installs; zero rows with `MW_RECORDING=1`; zero rows under `.mwignore` `capture = "off"`. Ran 5× clean.

**Follow-up:** PowerShell is not wired up (out of scope). Duration is second-granularity in notes as `dur:Ns`; a `duration_ms` column is the upgrade path.
