### PR TITLE
feat: make the MemPalace engine usable via config, with builtin fallback

### DIFF
--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -15,7 +15,11 @@ categories = ["command-line-utilities", "development-tools"]
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5"
-mw-memory = { path = "../mw-memory" }
+# The `mempalace` feature adds no dependencies (std process + serde_json +
+# anyhow, all already present), so it's enabled unconditionally: it lets
+# `engine = "mempalace"` in config.toml route search through a local MemPalace
+# MCP server, with a builtin fallback when that server is unreachable.
+mw-memory = { path = "../mw-memory", features = ["mempalace"] }
 regex = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -1689,6 +1689,35 @@ impl Scope {
     }
 }
 
+/// Render hits from an external engine (MemPalace) — no local ids, so no
+/// `mw replay/show` action or provenance lookup; the reason string already
+/// carries the source ("mempalace semantic score 0.87").
+fn print_external_hits(query: &str, hits: &[mw_memory::ScoredMemory], explain: bool) {
+    println!("# matches for {query:?}  (mempalace)\n");
+    if hits.is_empty() {
+        println!("(none)");
+        return;
+    }
+    for sm in hits {
+        let snippet: String = sm
+            .memory
+            .text
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .unwrap_or("")
+            .trim()
+            .chars()
+            .take(100)
+            .collect();
+        println!("{:>3}%  [mempalace] {}", sm.percent(), snippet);
+        if explain {
+            for reason in sm.reasons() {
+                println!("      {reason}");
+            }
+        }
+    }
+}
+
 fn search_memory(args: &[String]) -> Result<(), String> {
     let (scope, args) = Scope::take(args)?;
     let explain = args.iter().any(|a| a == "--explain");
@@ -1700,6 +1729,25 @@ fn search_memory(args: &[String]) -> Result<(), String> {
         );
     }
     let query = terms.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(" ");
+
+    // External semantic engine (MemPalace), if the user opted in via config. It
+    // ranks server-side over its own corpus, so the local scope filters don't
+    // apply. If the server is unreachable we print a notice and fall through to
+    // the builtin engine over local memory, so a misconfig never hard-fails.
+    if let Some(argv) = memorywhale_cli::mempalace_command() {
+        let (cmd, rest) = argv.split_first().expect("mempalace_command is non-empty");
+        let eng = mw_memory::engine::MemPalaceEngine::new(cmd.clone(), rest.to_vec());
+        match eng.try_retrieve(&mw_memory::Query::new(&query, Utc::now()), 20) {
+            Ok(hits) => {
+                print_external_hits(&query, &hits, explain);
+                return Ok(());
+            }
+            Err(e) => {
+                eprintln!("mw: mempalace unavailable ({e:#}); using the local engine");
+            }
+        }
+    }
+
     // Opening the db migrates it, so the provenance and scope columns exist
     // before the loader reads them; the loader also skips unapproved notes.
     let conn = open_session_db()?;

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -243,6 +243,23 @@ pub fn machine_name() -> String {
 }
 
 /// A `key = "value"` line from `<data dir>/config.toml`, unquoted.
+/// When the user has opted into the external MemPalace semantic engine, returns
+/// the argv to spawn its MCP server; otherwise `None` (use the builtin engine).
+///
+/// `<data dir>/config.toml`:
+/// ```toml
+/// engine = "mempalace"
+/// mempalace_command = "mempalace-mcp"   # optional; may include args, e.g. "npx mempalace-mcp"
+/// ```
+pub fn mempalace_command() -> Option<Vec<String>> {
+    if config_value("engine")?.trim() != "mempalace" {
+        return None;
+    }
+    let cmd = config_value("mempalace_command").unwrap_or_else(|| "mempalace-mcp".into());
+    let argv: Vec<String> = cmd.split_whitespace().map(str::to_string).collect();
+    (!argv.is_empty()).then_some(argv)
+}
+
 fn config_value(key: &str) -> Option<String> {
     let text = std::fs::read_to_string(data_dir().ok()?.join("config.toml")).ok()?;
     text.lines().find_map(|line| {
@@ -755,6 +772,37 @@ mod tests {
     fn keeps_label_hides_value() {
         assert_eq!(redact("API_KEY=abcdef123456"), "API_KEY=[REDACTED]");
         assert_eq!(redact("password: hunter2secret"), "password: [REDACTED]");
+    }
+
+    #[test]
+    fn mempalace_command_reads_config() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = fresh_data_dir("mempalace-cfg");
+
+        // No config → builtin (None).
+        assert!(mempalace_command().is_none());
+
+        // engine set but not mempalace → still None.
+        std::fs::write(dir.join("config.toml"), "engine = \"builtin\"\n").unwrap();
+        assert!(mempalace_command().is_none());
+
+        // Opted in, default command.
+        std::fs::write(dir.join("config.toml"), "engine = \"mempalace\"\n").unwrap();
+        assert_eq!(mempalace_command(), Some(vec!["mempalace-mcp".to_string()]));
+
+        // Opted in with an override that carries args.
+        std::fs::write(
+            dir.join("config.toml"),
+            "engine = \"mempalace\"\nmempalace_command = \"npx mempalace-mcp --stdio\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            mempalace_command(),
+            Some(vec!["npx".into(), "mempalace-mcp".into(), "--stdio".into()])
+        );
+
+        std::env::remove_var("MEMORYWHALE_DATA_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
The MemPalace MCP client shipped feature-gated (#43) but was never invoked — every search path used `BuiltinEngine`. This wires it into `mw search`.

## Usage
```toml
# <data dir>/config.toml
engine = "mempalace"
mempalace_command = "mempalace-mcp"   # optional; may include args, e.g. "npx mempalace-mcp --stdio"
```

## Behaviour
- `mw-cli` enables `mw-memory`'s `mempalace` feature. It adds **no dependencies** (std process + serde_json + anyhow, all already present), so it's on unconditionally rather than behind a rebuild flag.
- With `engine = "mempalace"`, `mw search` routes through a local MemPalace MCP server and renders its own relevance as the score (`--explain` shows `mempalace semantic score 0.87`).
- If the server is unreachable, `mw search` prints a one-line notice and **falls back to the builtin engine** over local memory — a misconfig never hard-fails.
- No engine config → byte-identical to before.

## Verification
Config reader test (default / override-with-args / opt-out) + end-to-end against the fake MCP server fixture (routing, `--explain`, missing-server fallback). Full suite green; enabling the feature also runs `mw-memory`'s 17 mempalace tests under `cargo test --workspace`.

## Known limits (flagged, not hidden)
- **CLI only** — `mw-mcp` still uses builtin; wiring it is the same branch at two call sites.
- **Separate corpus** — MemPalace searches its own memory, not local SQLite; results replace local ones (with fallback) rather than merging.