### PR TITLE
Release prep for v0.5.0: version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "mw-memory"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale-cli"
-version = "0.4.0"
+version = "0.5.0"
 description = "MemoryWhale CLI — local-first terminal memory. Record commands, sessions, and output into local SQLite; browse them in a built-in web dashboard. Nothing is uploaded."
 authors = ["Isabel Wu <wuisabel@usc.edu>"]
 license = "MIT"

--- a/crates/mw-memory/Cargo.toml
+++ b/crates/mw-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mw-memory"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Explainable retrieval for MemoryWhale: a MemoryEngine interface, a built-in scorer that ranks memories with per-signal reasons, and an optional MemPalace backend over MCP."
 license = "MIT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorywhale",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorywhale",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.5.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale"
-version = "0.4.0"
+version = "0.5.0"
 description = "A Rust/Tauri visual second brain for local knowledge graphs"
 authors = ["MemoryWhale"]
 license = "MIT"


### PR DESCRIPTION
Mechanical prep so v0.5.0 is one tag away.

## Changes
- `memorywhale-cli` 0.4.0 → **0.5.0** (the release version; tags track this crate)
- `memorywhale` (src-tauri) 0.4.0 → **0.5.0**
- `mw-memory` 0.1.0 → **0.2.0** — minor bump for new public API (sqlite loader, mempalace engine, error fingerprinting)
- `Cargo.lock` refreshed; `package-lock.json` synced to `package.json`'s 0.2.1 (was stale at 0.1.0)

## Verified
- `cargo build --workspace` + **46 tests** green
- `npm run build` (tsc typecheck + vite) passes — clears the dashboard typecheck gate
- Migration chain auto-upgrades to v4 from every prior version

## Not touched (by design)
- Frontend `package.json` / `tauri.conf.json` stay at 0.2.1 — they're on a separate version track from the CLI/release, unchanged since before v0.4.0. Flag if you want them unified to 0.5.0.
- Homebrew `Formula/memorywhale.rb` — auto-bumped by `release.yml` on tag.

## To release after this merges
```
git checkout main && git pull
git tag v0.5.0 && git push origin v0.5.0
```
Release notes drafted separately (paste into the GitHub release body).