### PR TITLE
docs: add Ask DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>
   <a href="https://github.com/wuisabel-gif/MemWhale/releases"><img src="https://img.shields.io/github/v/release/wuisabel-gif/MemWhale?color=2b43dd&label=release" alt="release"/></a>
   <a href="https://crates.io/crates/memorywhale-cli"><img src="https://img.shields.io/crates/v/memorywhale-cli?color=2b43dd&label=crates.io" alt="crates.io"/></a>
+  <a href="https://deepwiki.com/wuisabel-gif/MemWhale"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"/></a>
   <img src="https://img.shields.io/badge/license-MIT-2b43dd" alt="license MIT"/>
   <img src="https://img.shields.io/badge/Rust-000000?logo=rust&logoColor=white" alt="Rust"/>
   <img src="https://img.shields.io/badge/SQLite-003B57?logo=sqlite&logoColor=white" alt="SQLite"/>


### PR DESCRIPTION
Adds the standard **Ask DeepWiki** badge to the README badge row, linking to `deepwiki.com/wuisabel-gif/MemWhale` and matching the existing HTML badge style.

Badge SVG verified (HTTP 200, `image/svg+xml`). Note: the linked page shows "not indexed" until the repo is indexed once on DeepWiki — after that the badge points at the generated wiki.