### PR TITLE
feat: make MemPalace usable end-to-end (search-tool fix + sync bridge)

### DIFF
--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -57,6 +57,7 @@ fn run() -> Result<(), String> {
         Some("agent") => return agent_cmd(&raw_args[1..]),
         Some("ask") => return ask_cmd(&raw_args[1..]),
         Some("search") => return search_memory(&raw_args[1..]),
+        Some("sync-mempalace") => return sync_mempalace(&raw_args[1..]),
         Some("git-fix") => return git_fix_cmd(&raw_args[1..]),
         Some("doctor") => return doctor(),
         Some("global") => return global_cmd(&raw_args[1..]),
@@ -269,6 +270,7 @@ fn print_help() {
          mw push <ssh-host>       send this machine's memory to a teammate (scp + remote mw import)\n\
          mw pull <ssh-host> [path] copy another machine's memory here and merge it (scp + import)\n\
          mw search <text> [--explain] [--project X] [--machine Y] [--since 7d]  rank commands, sessions, and notes by relevance (--explain shows why)\n\
+         mw sync-mempalace [--wing NAME] [--dry-run]  push local memories into a running MemPalace server (needs mempalace_command in config)\n\
          mw git-fix [id]          diagnose the last failed git command (or one by id): what happened, the fix, seen before?\n\
          mw context [project:name] [--last-error] [--limit N]  print a compact digest to paste into an AI agent\n\
          mw agent [session-id]    export a full session as agent-ready text to paste later (default: latest)\n\
@@ -1718,6 +1720,74 @@ fn print_external_hits(query: &str, hits: &[mw_memory::ScoredMemory], explain: b
     }
 }
 
+/// Push local memories into a running MemPalace server so it can search your
+/// terminal history semantically. Maps each memory to a MemPalace drawer:
+/// `--wing` (default "memorywhale") groups them, and the source kind (command /
+/// session / note / …) becomes the room. `mempalace_checkpoint` on the server
+/// side semantic-dedups, so re-running is safe and only files what's new.
+fn sync_mempalace(args: &[String]) -> Result<(), String> {
+    let mut wing = "memorywhale".to_string();
+    let mut limit: usize = 0; // 0 = all
+    let mut dry_run = false;
+    let mut iter = args.iter();
+    while let Some(a) = iter.next() {
+        match a.as_str() {
+            "--wing" => wing = iter.next().ok_or("--wing needs a value")?.clone(),
+            "--limit" => limit = iter.next().and_then(|v| v.parse().ok()).ok_or("--limit needs a number")?,
+            "--dry-run" => dry_run = true,
+            other => return Err(format!("unexpected argument {other:?}; run mw --help")),
+        }
+    }
+
+    let argv = memorywhale_cli::mempalace_argv()
+        .ok_or("no mempalace_command configured in config.toml")?;
+    let (cmd, rest) = argv.split_first().expect("mempalace_argv is non-empty");
+
+    let conn = open_session_db()?;
+    let _ = memorywhale_cli::migrate(&conn);
+    let mut mems = mw_memory::sqlite::load_memories(&conn);
+    if limit > 0 && mems.len() > limit {
+        mems.truncate(limit);
+    }
+    let drawers: Vec<mw_memory::engine::Drawer> = mems
+        .iter()
+        .filter(|m| !m.text.trim().is_empty())
+        .map(|m| {
+            let (source, _) = mw_memory::sqlite::decode_id(m.id);
+            mw_memory::engine::Drawer {
+                wing: wing.clone(),
+                room: source.tag().to_string(),
+                content: m.text.clone(),
+            }
+        })
+        .collect();
+
+    if drawers.is_empty() {
+        println!("Nothing to sync (no memories found).");
+        return Ok(());
+    }
+    if dry_run {
+        let mut by_room: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
+        for d in &drawers {
+            *by_room.entry(d.room.as_str()).or_default() += 1;
+        }
+        println!("Would file {} drawer(s) into wing {wing:?} (server dedups):", drawers.len());
+        for (room, n) in by_room {
+            println!("  {room}: {n}");
+        }
+        return Ok(());
+    }
+
+    let tool = memorywhale_cli::mempalace_checkpoint_tool();
+    let outcome = mw_memory::engine::checkpoint(cmd, rest, &tool, &drawers)
+        .map_err(|e| format!("mempalace sync failed: {e:#}"))?;
+    println!(
+        "Synced to MemPalace (wing {wing:?}): {} added, {} already present, {} error(s).",
+        outcome.added, outcome.duplicates, outcome.errors
+    );
+    Ok(())
+}
+
 fn search_memory(args: &[String]) -> Result<(), String> {
     let (scope, args) = Scope::take(args)?;
     let explain = args.iter().any(|a| a == "--explain");
@@ -1736,7 +1806,8 @@ fn search_memory(args: &[String]) -> Result<(), String> {
     // the builtin engine over local memory, so a misconfig never hard-fails.
     if let Some(argv) = memorywhale_cli::mempalace_command() {
         let (cmd, rest) = argv.split_first().expect("mempalace_command is non-empty");
-        let eng = mw_memory::engine::MemPalaceEngine::new(cmd.clone(), rest.to_vec());
+        let eng = mw_memory::engine::MemPalaceEngine::new(cmd.clone(), rest.to_vec())
+            .with_tool(memorywhale_cli::mempalace_search_tool());
         match eng.try_retrieve(&mw_memory::Query::new(&query, Utc::now()), 20) {
             Ok(hits) => {
                 print_external_hits(&query, &hits, explain);

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -456,9 +456,28 @@ pub fn mempalace_command() -> Option<Vec<String>> {
     if config_value("engine")?.trim() != "mempalace" {
         return None;
     }
+    mempalace_argv()
+}
+
+/// The MCP server argv, regardless of whether `engine = "mempalace"` is set —
+/// used by `mw sync-mempalace`, which pushes to MemPalace even when search
+/// still runs on the builtin engine.
+pub fn mempalace_argv() -> Option<Vec<String>> {
     let cmd = config_value("mempalace_command").unwrap_or_else(|| "mempalace-mcp".into());
     let argv: Vec<String> = cmd.split_whitespace().map(str::to_string).collect();
     (!argv.is_empty()).then_some(argv)
+}
+
+/// MemPalace's search tool name. The real server exposes `mempalace_search`
+/// (not `search`), so that's the default; overridable via `mempalace_tool` in
+/// config for a differently-named server.
+pub fn mempalace_search_tool() -> String {
+    config_value("mempalace_tool").unwrap_or_else(|| "mempalace_search".into())
+}
+
+/// MemPalace's batch-write tool name, used by `mw sync-mempalace`.
+pub fn mempalace_checkpoint_tool() -> String {
+    config_value("mempalace_checkpoint_tool").unwrap_or_else(|| "mempalace_checkpoint".into())
 }
 
 fn config_value(key: &str) -> Option<String> {
@@ -1001,6 +1020,28 @@ mod tests {
             mempalace_command(),
             Some(vec!["npx".into(), "mempalace-mcp".into(), "--stdio".into()])
         );
+
+        std::env::remove_var("MEMORYWHALE_DATA_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mempalace_tool_names_default_to_real_server() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = fresh_data_dir("mempalace-tools");
+
+        // Defaults match the real MemPalace server (not the generic "search").
+        assert_eq!(mempalace_search_tool(), "mempalace_search");
+        assert_eq!(mempalace_checkpoint_tool(), "mempalace_checkpoint");
+
+        // Overridable for a differently-named server.
+        std::fs::write(
+            dir.join("config.toml"),
+            "mempalace_tool = \"custom_search\"\nmempalace_checkpoint_tool = \"custom_write\"\n",
+        )
+        .unwrap();
+        assert_eq!(mempalace_search_tool(), "custom_search");
+        assert_eq!(mempalace_checkpoint_tool(), "custom_write");
 
         std::env::remove_var("MEMORYWHALE_DATA_DIR");
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/mw-memory/src/engine.rs
+++ b/crates/mw-memory/src/engine.rs
@@ -272,6 +272,56 @@ impl MemoryEngine for MemPalaceEngine {
     }
 }
 
+/// One item to file into MemPalace: a verbatim `content` string placed under a
+/// `wing` (project) and `room` (aspect). Mirrors `mempalace_add_drawer` inputs.
+#[cfg(feature = "mempalace")]
+pub struct Drawer {
+    pub wing: String,
+    pub room: String,
+    pub content: String,
+}
+
+/// Outcome of a checkpoint push, parsed from the tool's summary.
+#[cfg(feature = "mempalace")]
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct CheckpointOutcome {
+    pub added: usize,
+    pub duplicates: usize,
+    pub errors: usize,
+}
+
+/// Push memories into a running MemPalace server in one batch via its
+/// `mempalace_checkpoint` tool (which semantic-dedups, then files the
+/// non-duplicates). Spawns `command args…`, does the MCP handshake, and calls
+/// `tool` once with all items. Returns the server's added/duplicate/error tally.
+#[cfg(feature = "mempalace")]
+pub fn checkpoint(
+    command: &str,
+    args: &[String],
+    tool: &str,
+    items: &[Drawer],
+) -> anyhow::Result<CheckpointOutcome> {
+    use serde_json::{json, Value};
+    let mut client = crate::mcp::McpClient::spawn(command, args)?;
+    let payload = json!({
+        "items": items
+            .iter()
+            .map(|d| json!({"wing": d.wing, "room": d.room, "content": d.content}))
+            .collect::<Vec<_>>(),
+        "added_by": "memorywhale",
+    });
+    let text = client.call_tool(tool, payload)?;
+    // The summary is JSON with added/duplicates/errors arrays; tolerate shape
+    // drift by counting whatever arrays are present rather than requiring them.
+    let v: Value = serde_json::from_str(&text).unwrap_or(Value::Null);
+    let count = |k: &str| v.get(k).and_then(Value::as_array).map(Vec::len).unwrap_or(0);
+    Ok(CheckpointOutcome {
+        added: count("added"),
+        duplicates: count("duplicates"),
+        errors: count("errors"),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,6 +392,20 @@ mod tests {
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].memory.id, 143);
         assert!(hits[0].reasons()[0].starts_with("mempalace semantic score"));
+    }
+
+    #[cfg(all(feature = "mempalace", unix))]
+    #[test]
+    fn checkpoint_pushes_and_parses_the_summary() {
+        let script =
+            concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/fake-mempalace-checkpoint.sh");
+        let items = vec![
+            Drawer { wing: "memorywhale".into(), room: "command".into(), content: "cargo build failed".into() },
+            Drawer { wing: "memorywhale".into(), room: "note".into(), content: "the fix was X".into() },
+        ];
+        let out = checkpoint("sh", &[script.to_string()], "mempalace_checkpoint", &items).unwrap();
+        // Fixture reports two added, one duplicate, no errors.
+        assert_eq!(out, CheckpointOutcome { added: 2, duplicates: 1, errors: 0 });
     }
 
     #[cfg(feature = "mempalace")]

--- a/crates/mw-memory/tests/fixtures/fake-mempalace-checkpoint.sh
+++ b/crates/mw-memory/tests/fixtures/fake-mempalace-checkpoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# A fake `mempalace-mcp` for the checkpoint path: handshake + one
+# `mempalace_checkpoint` call. Response ids match the client's request order
+# (initialize = 1, tools/call = 2). No network, no real mempalace.
+while IFS= read -r line; do
+  case "$line" in
+    *'"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"mempalace","version":"fake"}}}'
+      ;;
+    *'mempalace_checkpoint'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"added\":[{\"drawer_id\":\"a\"},{\"drawer_id\":\"b\"}],\"duplicates\":[{\"drawer_id\":\"c\"}],\"errors\":[]}"}]}}'
+      ;;
+  esac
+done


### PR DESCRIPTION
Makes `engine = "mempalace"` actually work against the real MemPalace server, and adds the missing corpus bridge.

## Bug fix — activation was broken against the real server
The real MemPalace ([github.com/MemPalace/mempalace](https://github.com/MemPalace/mempalace)) exposes tools named `mempalace_search` / `mempalace_checkpoint`, but our client defaulted to calling a tool named `search`. So `engine = "mempalace"` always failed the tools/list check and silently fell back to builtin — it only worked against the test fixture (which also named its tool `search`).

Now the search tool name is configurable and defaults to the real name:
```toml
engine = "mempalace"
mempalace_command = "mempalace-mcp"
mempalace_tool = "mempalace_search"          # default; override for a custom server
```

## New — `mw sync-mempalace`, the corpus bridge
MemPalace searches *its own* store. This command pushes your local memories into it so `mw search` (via mempalace) actually returns your terminal history:
```
mw sync-mempalace [--wing NAME] [--limit N] [--dry-run]
```
- Loads memories through the shared SQLite loader, files them via `mempalace_checkpoint` (batch + **server-side semantic dedup**, so re-runs only add what's new).
- Maps each memory to a MemPalace drawer: `--wing` (default `memorywhale`) groups them; the source kind (command / session / note / …) becomes the **room**.
- `--dry-run` shows the mapping without contacting the server; a missing server gives a clear error.

## Verification
- End-to-end demo: dry-run mapping, real sync ("2 added, 0 already present, 0 errors") against a fake checkpoint server, clear error when unconfigured.
- **48 tests** green, incl. new `checkpoint()` (over a fake MCP server fixture) and the tool-name config defaults/overrides.
- `mw-memory`'s `checkpoint()` is feature-gated; the MCP client stays encapsulated. Default build unchanged.