### PR TITLE
feat: mw tui — interactive terminal browser for memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,7 +116,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -141,7 +147,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -167,7 +173,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -423,6 +429,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +508,20 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -580,6 +615,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -811,7 +871,7 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever",
  "precomputed-hash",
  "selectors",
@@ -868,6 +928,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embed-resource"
@@ -1022,6 +1088,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1457,6 +1529,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -1753,12 +1836,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1784,6 +1889,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1974,6 +2088,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1998,6 +2118,15 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2054,6 +2183,7 @@ dependencies = [
  "dirs 5.0.1",
  "libc",
  "mw-memory",
+ "ratatui",
  "regex",
  "rusqlite",
  "serde",
@@ -2083,6 +2213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2472,6 +2603,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,7 +2739,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2718,6 +2855,27 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.13.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2908,6 +3066,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2915,7 +3086,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2959,6 +3130,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3231,6 +3408,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,6 +3527,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,6 +3561,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "subtle"
@@ -3788,7 +4014,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4223,6 +4449,29 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "untrusted"
@@ -5213,7 +5462,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -21,6 +21,9 @@ dirs = "5"
 # MCP server, with a builtin fallback when that server is unreachable.
 mw-memory = { path = "../mw-memory", features = ["mempalace"] }
 regex = "1"
+# Pure-Rust interactive terminal UI (`mw tui`) — no system libraries, so it
+# keeps the bare-machine / Jetson build story intact. Bundles crossterm.
+ratatui = "0.29"
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -57,6 +57,7 @@ fn run() -> Result<(), String> {
         Some("agent") => return agent_cmd(&raw_args[1..]),
         Some("ask") => return ask_cmd(&raw_args[1..]),
         Some("search") => return search_memory(&raw_args[1..]),
+        Some("tui") => return memorywhale_cli::tui::run(),
         Some("git-fix") => return git_fix_cmd(&raw_args[1..]),
         Some("doctor") => return doctor(),
         Some("global") => return global_cmd(&raw_args[1..]),
@@ -269,6 +270,7 @@ fn print_help() {
          mw push <ssh-host>       send this machine's memory to a teammate (scp + remote mw import)\n\
          mw pull <ssh-host> [path] copy another machine's memory here and merge it (scp + import)\n\
          mw search <text> [--explain] [--project X] [--machine Y] [--since 7d]  rank commands, sessions, and notes by relevance (--explain shows why)\n\
+         mw tui                   interactive terminal browser: type to search, arrow keys to move, Enter to reveal the command\n\
          mw git-fix [id]          diagnose the last failed git command (or one by id): what happened, the fix, seen before?\n\
          mw context [project:name] [--last-error] [--limit N]  print a compact digest to paste into an AI agent\n\
          mw agent [session-id]    export a full session as agent-ready text to paste later (default: latest)\n\

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -1,5 +1,7 @@
 //! Shared helpers for the MemoryWhale CLI binaries.
 
+pub mod tui;
+
 use chrono::Utc;
 use regex::Regex;
 use rusqlite::{params, Connection};

--- a/crates/mw-cli/src/tui.rs
+++ b/crates/mw-cli/src/tui.rs
@@ -1,0 +1,312 @@
+//! `mw tui` — an interactive terminal browser for your MemoryWhale memory.
+//!
+//! Type to search (ranked live by the same engine as `mw search`), arrow keys
+//! (or Ctrl-n/Ctrl-p) to move, Enter to reveal the replay/show command for the
+//! selected item, Esc or Ctrl-c to quit. Runs entirely in the terminal — no
+//! browser, no server.
+
+use chrono::{DateTime, Utc};
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
+use ratatui::Frame;
+use rusqlite::Connection;
+
+use mw_memory::engine::{BuiltinEngine, MemoryEngine};
+use mw_memory::sqlite::{decode_id, load_memories, Source};
+use mw_memory::{Query, ScoredMemory};
+
+/// How many results to hold in the list — plenty for browsing, cheap to rank.
+const MAX_RESULTS: usize = 500;
+
+struct App {
+    engine: BuiltinEngine,
+    now: DateTime<Utc>,
+    query: String,
+    results: Vec<ScoredMemory>,
+    state: ListState,
+    /// Footer line: keybinding hint, or the last "reveal" action.
+    status: String,
+}
+
+impl App {
+    fn new(engine: BuiltinEngine) -> Self {
+        let mut app = App {
+            engine,
+            now: Utc::now(),
+            query: String::new(),
+            results: Vec::new(),
+            state: ListState::default(),
+            status: String::new(),
+        };
+        app.recompute();
+        app
+    }
+
+    /// Re-rank against the current query. Empty query ranks by recency/importance
+    /// (a "recent memory" browse). A non-empty query both *reranks* by relevance
+    /// and *narrows* to memories that actually contain a query term — otherwise
+    /// the engine returns everything (just reordered), which reads wrong for a
+    /// search box.
+    fn recompute(&mut self) {
+        let q = Query::new(&self.query, self.now);
+        let mut hits = self.engine.retrieve(&q, MAX_RESULTS);
+        let terms: Vec<String> =
+            self.query.to_lowercase().split_whitespace().map(String::from).collect();
+        if !terms.is_empty() {
+            hits.retain(|sm| {
+                let text = sm.memory.text.to_lowercase();
+                terms.iter().any(|t| text.contains(t))
+            });
+        }
+        self.results = hits;
+        self.state.select((!self.results.is_empty()).then_some(0));
+        self.status.clear();
+    }
+
+    fn move_sel(&mut self, delta: isize) {
+        if self.results.is_empty() {
+            return;
+        }
+        let len = self.results.len() as isize;
+        let cur = self.state.selected().unwrap_or(0) as isize;
+        self.state.select(Some((cur + delta).rem_euclid(len) as usize));
+    }
+
+    fn selected(&self) -> Option<&ScoredMemory> {
+        self.state.selected().and_then(|i| self.results.get(i))
+    }
+
+    /// Show the shell command that acts on the selected memory (its whole point:
+    /// browse here, then run it in your shell).
+    fn reveal_action(&mut self) {
+        if let Some(sm) = self.selected() {
+            let (source, id) = decode_id(sm.memory.id);
+            self.status = match source {
+                Source::Command => format!("  ⮑ replay it:  mw replay {id}"),
+                Source::Session => format!("  ⮑ open it:  mw show {id}"),
+                Source::Note => format!("  ⮑ remembered note #{id}"),
+                other => format!("  ⮑ {} #{id}", other.tag()),
+            };
+        }
+    }
+}
+
+/// First non-empty line of a memory, trimmed and capped for a list row.
+fn snippet(text: &str, max: usize) -> String {
+    text.lines()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or("")
+        .trim()
+        .chars()
+        .take(max)
+        .collect()
+}
+
+fn render(app: &mut App, f: &mut Frame) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(1), Constraint::Length(1)])
+        .split(f.area());
+
+    // Search box.
+    let search = Paragraph::new(Line::from(vec![
+        Span::styled("search ", Style::default().fg(Color::Cyan)),
+        Span::raw(&app.query),
+        Span::styled("▏", Style::default().fg(Color::Cyan)), // cursor
+    ]))
+    .block(Block::default().borders(Borders::ALL).title(" MemoryWhale "));
+    f.render_widget(search, rows[0]);
+
+    // Body: results list | detail preview.
+    let body = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+        .split(rows[1]);
+
+    let items: Vec<ListItem> = app
+        .results
+        .iter()
+        .map(|sm| {
+            let (source, _) = decode_id(sm.memory.id);
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("{:>3}% ", sm.percent()), Style::default().fg(Color::Cyan)),
+                Span::styled(format!("{:<8} ", source.tag()), Style::default().fg(Color::DarkGray)),
+                Span::raw(snippet(&sm.memory.text, 48)),
+            ]))
+        })
+        .collect();
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(" {} results ", app.results.len())),
+        )
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .highlight_symbol("▶ ");
+    f.render_stateful_widget(list, body[0], &mut app.state);
+
+    // Detail of the selected memory.
+    let detail = match app.selected() {
+        None => Paragraph::new("(no matches — try a different search, or capture some commands first)"),
+        Some(sm) => {
+            let (source, id) = decode_id(sm.memory.id);
+            let mut lines = vec![
+                Line::from(vec![
+                    Span::styled(format!("[{}] ", source.tag()), Style::default().fg(Color::Yellow)),
+                    Span::styled(format!("#{id}  "), Style::default().fg(Color::DarkGray)),
+                    Span::styled(format!("{}% match", sm.percent()), Style::default().fg(Color::Cyan)),
+                ]),
+                Line::from(""),
+            ];
+            for line in sm.memory.text.lines() {
+                lines.push(Line::raw(line.to_string()));
+            }
+            let reasons = sm.reasons();
+            if !reasons.is_empty() {
+                lines.push(Line::from(""));
+                lines.push(Line::styled("why this ranked here:", Style::default().fg(Color::DarkGray)));
+                for r in reasons {
+                    lines.push(Line::styled(format!("  • {r}"), Style::default().fg(Color::DarkGray)));
+                }
+            }
+            Paragraph::new(lines).wrap(Wrap { trim: false })
+        }
+    };
+    f.render_widget(detail.block(Block::default().borders(Borders::ALL).title(" detail ")), body[1]);
+
+    // Footer: keybindings, or the revealed action.
+    let footer = if app.status.is_empty() {
+        "type to search · ↑/↓ move · Enter reveal command · Esc quit".to_string()
+    } else {
+        app.status.clone()
+    };
+    f.render_widget(Paragraph::new(footer).style(Style::default().fg(Color::DarkGray)), rows[2]);
+}
+
+fn event_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Result<(), String> {
+    loop {
+        terminal.draw(|f| render(app, f)).map_err(|e| format!("draw failed: {e}"))?;
+        let Event::Key(key) = event::read().map_err(|e| format!("input failed: {e}"))? else {
+            continue;
+        };
+        if key.kind != KeyEventKind::Press {
+            continue;
+        }
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        match key.code {
+            KeyCode::Esc => return Ok(()),
+            KeyCode::Char('c') if ctrl => return Ok(()),
+            KeyCode::Down => app.move_sel(1),
+            KeyCode::Up => app.move_sel(-1),
+            KeyCode::Char('n') if ctrl => app.move_sel(1),
+            KeyCode::Char('p') if ctrl => app.move_sel(-1),
+            KeyCode::Enter => app.reveal_action(),
+            KeyCode::Backspace => {
+                app.query.pop();
+                app.recompute();
+            }
+            // Any other Ctrl-chord is ignored so it can't leak into the query.
+            KeyCode::Char(c) if !ctrl => {
+                app.query.push(c);
+                app.recompute();
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Entry point for `mw tui`.
+pub fn run() -> Result<(), String> {
+    let conn =
+        Connection::open(crate::database_path()?).map_err(|e| format!("failed to open memory db: {e}"))?;
+    let _ = crate::migrate(&conn);
+    let mems = load_memories(&conn);
+    if mems.is_empty() {
+        return Err("no memories yet — run some commands with `mw` first".to_string());
+    }
+    let mut app = App::new(BuiltinEngine::new(mems));
+
+    // ratatui::init() enters raw mode + the alternate screen and installs a
+    // panic hook that restores the terminal; restore() undoes it on exit.
+    let mut terminal = ratatui::init();
+    let result = event_loop(&mut terminal, &mut app);
+    ratatui::restore();
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mw_memory::Memory;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn mem(id: i64, text: &str) -> Memory {
+        Memory {
+            id,
+            text: text.into(),
+            created_at: Utc::now(),
+            last_used: Utc::now(),
+            mentions: 1,
+            importance: 0.5,
+            tags: vec![],
+            embedding: None,
+        }
+    }
+
+    fn app_with(texts: &[(i64, &str)]) -> App {
+        let mems = texts.iter().map(|(id, t)| mem(*id, t)).collect();
+        App::new(BuiltinEngine::new(mems))
+    }
+
+    #[test]
+    fn snippet_takes_first_nonempty_line_and_caps() {
+        assert_eq!(snippet("\n\n  hello world  \nsecond", 100), "hello world");
+        assert_eq!(snippet("abcdefgh", 3), "abc");
+        assert_eq!(snippet("   ", 10), "");
+    }
+
+    #[test]
+    fn empty_query_browses_all_typing_narrows() {
+        let mut app = app_with(&[(1, "cargo build failed"), (2, "git push rejected"), (3, "cargo test flaky")]);
+        assert_eq!(app.results.len(), 3, "empty query shows everything");
+
+        app.query = "cargo".into();
+        app.recompute();
+        assert_eq!(app.results.len(), 2, "narrows to memories containing the term");
+        assert!(app.results.iter().all(|sm| sm.memory.text.contains("cargo")));
+
+        app.query = "nonexistent".into();
+        app.recompute();
+        assert!(app.results.is_empty());
+        assert_eq!(app.state.selected(), None);
+    }
+
+    #[test]
+    fn navigation_wraps_around() {
+        let mut app = app_with(&[(1, "a"), (2, "b"), (3, "c")]);
+        assert_eq!(app.state.selected(), Some(0));
+        app.move_sel(-1);
+        assert_eq!(app.state.selected(), Some(2), "up from the top wraps to the bottom");
+        app.move_sel(1);
+        assert_eq!(app.state.selected(), Some(0), "down from the bottom wraps to the top");
+    }
+
+    #[test]
+    fn renders_without_panicking_and_shows_chrome() {
+        let mut app = app_with(&[(1, "cargo build failed with E0308")]);
+        let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+        terminal.draw(|f| render(&mut app, f)).unwrap();
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains("MemoryWhale"), "header present");
+        assert!(text.contains("results"), "results count present");
+        assert!(text.contains("cargo build failed"), "the memory is shown");
+    }
+
+    fn buffer_text(buf: &ratatui::buffer::Buffer) -> String {
+        buf.content().iter().map(|c| c.symbol()).collect()
+    }
+}

--- a/crates/mw-cli/src/tui.rs
+++ b/crates/mw-cli/src/tui.rs
@@ -27,8 +27,10 @@ struct App {
     query: String,
     results: Vec<ScoredMemory>,
     state: ListState,
-    /// Footer line: keybinding hint, or the last "reveal" action.
+    /// The last "reveal" action (the shell command for the selected memory).
     status: String,
+    /// Whether the F1 help overlay is open.
+    show_help: bool,
 }
 
 impl App {
@@ -40,6 +42,7 @@ impl App {
             results: Vec::new(),
             state: ListState::default(),
             status: String::new(),
+            show_help: false,
         };
         app.recompute();
         app
@@ -108,7 +111,13 @@ fn snippet(text: &str, max: usize) -> String {
 fn render(app: &mut App, f: &mut Frame) {
     let rows = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(3), Constraint::Min(1), Constraint::Length(1)])
+        // search box · body · status line · key bar
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
         .split(f.area());
 
     // Search box.
@@ -177,13 +186,106 @@ fn render(app: &mut App, f: &mut Frame) {
     };
     f.render_widget(detail.block(Block::default().borders(Borders::ALL).title(" detail ")), body[1]);
 
-    // Footer: keybindings, or the revealed action.
-    let footer = if app.status.is_empty() {
-        "type to search · ↑/↓ move · Enter reveal command · Esc quit".to_string()
+    // Status line: the revealed action, or a gentle nudge toward it.
+    let status = if app.status.is_empty() {
+        Line::styled(
+            "  press Enter on a result to get its shell command",
+            Style::default().fg(Color::DarkGray),
+        )
     } else {
-        app.status.clone()
+        Line::styled(app.status.clone(), Style::default().fg(Color::Green))
     };
-    f.render_widget(Paragraph::new(footer).style(Style::default().fg(Color::DarkGray)), rows[2]);
+    f.render_widget(Paragraph::new(status), rows[2]);
+
+    // Key bar: always visible, so the controls never disappear.
+    f.render_widget(Paragraph::new(key_bar()), rows[3]);
+
+    // F1 help overlay, drawn last so it sits on top.
+    if app.show_help {
+        render_help(f);
+    }
+}
+
+/// The always-on key hints. Full list lives in the F1 overlay.
+fn key_bar() -> Line<'static> {
+    let key = |k: &'static str| Span::styled(k, Style::default().fg(Color::Cyan));
+    let sep = || Span::styled("  ·  ", Style::default().fg(Color::DarkGray));
+    Line::from(vec![
+        Span::raw(" "),
+        key("type"),
+        Span::raw(" search"),
+        sep(),
+        key("↑↓"),
+        Span::raw(" move"),
+        sep(),
+        key("Enter"),
+        Span::raw(" command"),
+        sep(),
+        key("F1"),
+        Span::raw(" help"),
+        sep(),
+        key("Esc"),
+        Span::raw(" quit"),
+    ])
+}
+
+/// A centred rectangle `pct_x` × `pct_y` percent of `area`, for the help popup.
+fn centered_rect(pct_x: u16, pct_y: u16, area: ratatui::layout::Rect) -> ratatui::layout::Rect {
+    let vert = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - pct_y) / 2),
+            Constraint::Percentage(pct_y),
+            Constraint::Percentage((100 - pct_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - pct_x) / 2),
+            Constraint::Percentage(pct_x),
+            Constraint::Percentage((100 - pct_x) / 2),
+        ])
+        .split(vert[1])[1]
+}
+
+fn render_help(f: &mut Frame) {
+    use ratatui::widgets::Clear;
+    let area = centered_rect(70, 70, f.area());
+    let row = |k: &'static str, desc: &'static str| {
+        Line::from(vec![
+            Span::styled(format!("  {k:<16}"), Style::default().fg(Color::Cyan)),
+            Span::raw(desc),
+        ])
+    };
+    let lines = vec![
+        Line::from(""),
+        row("type", "search your memory as you type"),
+        row("↑ / ↓", "move up / down the results"),
+        row("Ctrl-n / Ctrl-p", "move down / up (alternative)"),
+        row("Backspace", "delete a search character"),
+        row("Enter", "reveal the selected item's shell command"),
+        row("F1", "toggle this help"),
+        row("Esc / Ctrl-c", "quit"),
+        Line::from(""),
+        Line::styled(
+            "  Browse here, then run the revealed command in your shell.",
+            Style::default().fg(Color::DarkGray),
+        ),
+        Line::styled(
+            "  Start it any time with:  mw tui",
+            Style::default().fg(Color::DarkGray),
+        ),
+        Line::from(""),
+        Line::styled("  press Esc or F1 to close", Style::default().fg(Color::Yellow)),
+    ];
+    let popup = Paragraph::new(lines).wrap(Wrap { trim: false }).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" MemoryWhale TUI — commands "),
+    );
+    f.render_widget(Clear, area); // blank whatever's behind the popup
+    f.render_widget(popup, area);
 }
 
 fn event_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Result<(), String> {
@@ -196,7 +298,20 @@ fn event_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Result<
             continue;
         }
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+
+        // While the help overlay is open it's modal: Esc/F1/Enter close it, and
+        // nothing else (so typed keys don't leak into the query behind it).
+        if app.show_help {
+            if matches!(key.code, KeyCode::Esc | KeyCode::F(1) | KeyCode::Enter)
+                || (ctrl && key.code == KeyCode::Char('c'))
+            {
+                app.show_help = false;
+            }
+            continue;
+        }
+
         match key.code {
+            KeyCode::F(1) => app.show_help = true,
             KeyCode::Esc => return Ok(()),
             KeyCode::Char('c') if ctrl => return Ok(()),
             KeyCode::Down => app.move_sel(1),
@@ -304,6 +419,22 @@ mod tests {
         assert!(text.contains("MemoryWhale"), "header present");
         assert!(text.contains("results"), "results count present");
         assert!(text.contains("cargo build failed"), "the memory is shown");
+        // The key bar is always visible so the controls never disappear.
+        assert!(text.contains("F1"), "key bar shows help hint");
+        assert!(text.contains("quit"), "key bar shows how to exit");
+    }
+
+    #[test]
+    fn help_overlay_lists_commands_and_how_to_exit() {
+        let mut app = app_with(&[(1, "cargo build failed")]);
+        app.show_help = true;
+        let mut terminal = Terminal::new(TestBackend::new(100, 24)).unwrap();
+        terminal.draw(|f| render(&mut app, f)).unwrap();
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains("commands"), "overlay titled with commands");
+        assert!(text.contains("search your memory"), "explains search");
+        assert!(text.contains("quit"), "explains how to exit");
+        assert!(text.contains("mw tui"), "tells how to start it");
     }
 
     fn buffer_text(buf: &ratatui::buffer::Buffer) -> String {


### PR DESCRIPTION
A real terminal UI, not the browser pane. `mw tui` opens an interactive `ratatui`/`crossterm` browser over your memory — runs entirely in the terminal.

## What it does
- **Type to search** — ranked live by the same `BuiltinEngine` as `mw search`, then narrowed to memories that actually contain a query term (so the list genuinely filters).
- **Arrow keys** / Ctrl-n / Ctrl-p to move; wraps around.
- **Enter** reveals the `mw replay <id>` / `mw show <id>` command for the selected item — browse here, run it in your shell.
- **Esc** / Ctrl-c to quit.

Three-pane layout: search box · results list (score + source + snippet) · detail pane with the full memory and the engine's *"why this ranked here"* reasons.

```
┌ MemoryWhale ─────────────────────────────────────────────────┐
│search cargo▏                                                  │
└──────────────────────────────────────────────────────────────┘
┌ 1 results ─────────────┐┌ detail ─────────────────────────────┐
│▶  46% command  cargo bu││[command] #7  46% match              │
│                        ││cargo build --release failed: linker │
│                        ││why this ranked here:                │
│                        ││  • last used today                  │
│                        ││  • 17% term overlap (lexical)       │
└────────────────────────┘└─────────────────────────────────────┘
  ⮑ replay it:  mw replay 7
```

## Notes
- `ratatui` is **pure-Rust (no system libraries)**, consistent with the deliberate "no GTK/WebKit" constraint that keeps `cargo install` and Jetson aarch64 builds working on a bare machine.
- Errors (missing/empty DB) surface **before** entering raw mode, and `ratatui::init` installs a panic-restoring hook — a failure never leaves your terminal wedged.
- Headless tests via `TestBackend`: renders without panic + shows chrome, empty-query-browses / typing-narrows, list wraparound. Full workspace suite green.

## Follow-ups (not in this PR)
- Scope filters (`--project`/`--since`) and paging inside the TUI.
- Optional: make bare `mw` launch the TUI; a color pass on the plain-text CLI output.