### PR TITLE
docs: mention mw tui in README and CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,18 @@ mw --live                             # same, but autosaved — survives SSH dro
 mw-run -- cargo check                 # run one command, capture its output + exit code
 mw list && mw show 1                  # inspect recorded sessions
 mw search "linker error"              # find it across commands, output, and transcripts
+mw tui                                # interactive terminal browser — type to search, Enter to act
 mw remember "the fix was X"           # save a conclusion so it doesn't get re-derived
 mw git-fix                            # diagnose the last failed git command: what, why, the fix
 mw context --last-error               # the most recent failure, with its exact error
 mw-serve                              # web dashboard (works headless, e.g. on a Jetson)
 ```
+
+`mw tui` opens an interactive terminal browser — no web page, no server. Type
+to search (ranked live), arrow keys to move, **Enter** to reveal the
+`mw replay`/`mw show` command for the selected memory, **F1** for help, **Esc**
+to quit. The detail pane shows the full memory plus *why* it ranked where it
+did.
 
 Every command run stores the command, each argument as a searchable row, the
 cwd, exit code, stdout, stderr, and your notes. Captured output is scrubbed for

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -13,6 +13,7 @@ mw --live --notes "project:demo"      # autosave to SQLite every few seconds
 mw list                               # list recorded sessions
 mw show 1                             # print the full transcript of a session
 mw search "linker error"              # search commands, output, notes, transcripts
+mw tui                                # interactive terminal browser (type to search, Enter to act, F1 help, Esc quit)
 mw git-fix                            # diagnose the last failed git command: what, why, the fix
 mw mark "before the risky flash"      # bookmark the current debugging moment
 mw remember "the fix was passing --features vendored-ssl"  # save a lesson/conclusion


### PR DESCRIPTION
Adds `mw tui` (the interactive terminal browser shipped in v0.5.0) to the README's sixty-second tour — with a short callout on type-to-search, Enter-to-reveal-command, F1 help, Esc quit — and to the command list in `docs/CLI.md` so the two stay in sync.