### PR TITLE
fix: repair crates.io publishing (silently broken since the mw-memory split)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,16 +116,32 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
+          # pipefail so `cargo publish … | tee` reflects cargo's exit code, not
+          # tee's — without it a failed publish silently reports success.
+          set -o pipefail
           if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
             echo "CARGO_REGISTRY_TOKEN not set — skipping crates.io publish."
             echo "Add the secret to enable automatic publishing:"
             echo "  gh secret set CARGO_REGISTRY_TOKEN"
             exit 0
           fi
-          if cargo publish -p memorywhale-cli 2>&1 | tee publish.log; then
-            echo "published to crates.io"
-          elif grep -q "already exists" publish.log; then
-            echo "this version is already on crates.io — nothing to do."
-          else
-            exit 1
-          fi
+          publish() {
+            # Success, or "already on crates.io" (idempotent re-runs), else fail.
+            if cargo publish -p "$1" 2>&1 | tee publish.log; then
+              echo "published $1"
+            elif grep -qi "already exists\|already uploaded" publish.log; then
+              echo "$1 is already on crates.io — nothing to do."
+            else
+              return 1
+            fi
+          }
+          # mw-memory must land first: memorywhale-cli depends on it by version.
+          publish mw-memory || exit 1
+          # crates.io needs a moment to index the new version before the CLI can
+          # resolve it; retry the CLI a few times to ride out that lag.
+          for attempt in 1 2 3 4 5; do
+            if publish memorywhale-cli; then exit 0; fi
+            echo "retrying memorywhale-cli in 20s (crates.io indexing lag)…"
+            sleep 20
+          done
+          exit 1

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -19,7 +19,9 @@ dirs = "5"
 # anyhow, all already present), so it's enabled unconditionally: it lets
 # `engine = "mempalace"` in config.toml route search through a local MemPalace
 # MCP server, with a builtin fallback when that server is unreachable.
-mw-memory = { path = "../mw-memory", features = ["mempalace"] }
+# `version` (alongside `path`) is required so `cargo publish` can resolve the
+# dependency from crates.io — publish mw-memory first, then this crate.
+mw-memory = { path = "../mw-memory", version = "0.2.0", features = ["mempalace"] }
 regex = "1"
 # Pure-Rust interactive terminal UI (`mw tui`) — no system libraries, so it
 # keeps the bare-machine / Jetson build story intact. Bundles crossterm.

--- a/crates/mw-memory/Cargo.toml
+++ b/crates/mw-memory/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 edition = "2021"
 description = "Explainable retrieval for MemoryWhale: a MemoryEngine interface, a built-in scorer that ranks memories with per-signal reasons, and an optional MemPalace backend over MCP."
 license = "MIT"
+repository = "https://github.com/wuisabel-gif/MemWhale"
 
 [features]
 default = []

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["MemoryWhale"]
 license = "MIT"
 edition = "2021"
 default-run = "memorywhale"
+# The desktop app is never published to crates.io (it needs Tauri/GTK/WebKit);
+# this also means its path dependency on mw-memory needs no version.
+publish = false
 
 [lib]
 name = "memorywhale_lib"


### PR DESCRIPTION
`cargo install memorywhale-cli` is stuck at 0.4.0 — every release since has silently failed to publish while the CI job reported success. Three causes, all fixed here.

## Root cause (the sneaky one)
```bash
if cargo publish -p memorywhale-cli 2>&1 | tee publish.log; then
```
Without `pipefail`, the pipeline's exit code is **tee's (0)**, not cargo's. So when `cargo publish` failed, the script took the *success* branch, printed "published to crates.io", and the job went green — publishing nothing. Fixed with `set -o pipefail`.

## Why it started failing at 0.5.0
Issue #1 added `mw-memory` as a dependency of `mw-cli`. A path dependency with **no version** can't be published, and `mw-memory` itself was never on crates.io. So:
- `mw-memory` dep now carries `version = "0.2.0"` (alongside `path`).
- The workflow publishes **`mw-memory` first**, then retries `memorywhale-cli` to ride out crates.io indexing lag.

## Also
- `src-tauri` → `publish = false` (needs Tauri/GTK; never published, so its path dep needs no version).
- `mw-memory` gains a `repository` field.

## Verification
`cargo publish -p mw-memory --dry-run` packages + verifies cleanly. The `memorywhale-cli` dry-run's `no matching package named mw-memory` is the **expected** proof of the publish-order requirement — it resolves once `mw-memory` is on the registry.

## To actually get 0.5.0 (or later) onto crates.io
The `CARGO_REGISTRY_TOKEN` secret is already set. Because the `v0.5.0` tag still points at the *old* workflow, the clean path after merging this is to cut a fresh patch tag (e.g. `v0.5.1`) so the fixed job runs — or publish `0.5.0` manually: `cargo publish -p mw-memory` then `cargo publish -p memorywhale-cli`.