### PR TITLE
Release prep for v0.6.0: version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale-cli"
-version = "0.5.0"
+version = "0.6.0"
 description = "MemoryWhale CLI — local-first terminal memory. Record commands, sessions, and output into local SQLite; browse them in a built-in web dashboard. Nothing is uploaded."
 authors = ["Isabel Wu <wuisabel@usc.edu>"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale"
-version = "0.5.0"
+version = "0.6.0"
 description = "A Rust/Tauri visual second brain for local knowledge graphs"
 authors = ["MemoryWhale"]
 license = "MIT"


### PR DESCRIPTION
Mechanical prep so v0.6.0 is one tag away.

## Changes
- `memorywhale-cli` 0.5.0 → **0.6.0** (the release version; tags track this crate)
- `memorywhale` (src-tauri) 0.5.0 → **0.6.0**
- `mw-memory` stays **0.2.2** — already incremented by the feature PRs (#55 → 0.2.1, #58 → 0.2.2); mw-cli's `^0.2.0` requirement permits it
- `Cargo.lock` refreshed

## What's in v0.6.0 (merged since v0.5.0)
FTS5 BM25 as the search similarity signal + intent benchmark (#55), `similar_failures` MCP tool (#54), TUI review loop (#56), idempotent-by-id `sync-mempalace` (#58), Windows PowerShell hooks (#57), docs index + hygiene (#53).

## Verified
- `cargo build --workspace` + full test suite green (64 tests)
- Migration chain auto-upgrades v0→v5 on a populated legacy DB (mempalace_sync created, scopes backfilled, notes preserved)

## To release after this merges
```
git checkout main && git pull
git tag v0.6.0 && git push origin v0.6.0
```
The fixed release workflow will build the matrix, bump Homebrew, and **publish to crates.io** (mw-memory 0.2.2 first, then memorywhale-cli 0.6.0 — the pipeline that was silently broken at 0.5.0 is fixed). Release notes drafted separately (paste into the GitHub release body).

## Not touched (by design)
Frontend `package.json` / `tauri.conf.json` stay at 0.2.1 — separate version track, unchanged since before v0.4.0.