### PR TITLE
chore: add CodeRabbit config for automatic PR review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,39 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai
+# Automatic AI review on every PR. Tuned for this Rust workspace.
+language: en-US
+reviews:
+  profile: chill            # substantive findings, not nitpicks
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+  # Skip generated / vendored / large committed artifacts — no value reviewing these.
+  path_filters:
+    - "!**/target/**"
+    - "!**/node_modules/**"
+    - "!Cargo.lock"
+    - "!package-lock.json"
+    - "!src-tauri/gen/**"
+    - "!benchmarks/results/**"
+    - "!benchmarks/results_intent/**"
+    - "!benchmarks/shortcut_results/**"
+    - "!assets/**"
+  path_instructions:
+    - path: "crates/**/*.rs"
+      instructions: >
+        Focus on correctness and data-integrity: SQLite migration ordering and
+        PRAGMA user_version pins (each migration must pin its own literal version,
+        never the LATEST constant), version bumps on published crates, secret
+        redaction before writes, and unsafe blocks. Do NOT flag deliberate
+        `ponytail:` shortcuts — they document intentional simplifications with a
+        stated ceiling. Prefer reuse of existing helpers over new abstractions.
+    - path: ".github/workflows/**"
+      instructions: >
+        Watch for pipeline exit-code masking (e.g. `cmd | tee` without
+        `set -o pipefail`) and publish ordering (path-dependency crates must be
+        published before their dependents).
+chat:
+  auto_reply: true


### PR DESCRIPTION
Adds `.coderabbit.yaml` so CodeRabbit reviews every PR consistently once the GitHub App is installed on the repo (that install step is done from coderabbit.ai / GitHub Marketplace — it's account-level and can't be committed).

## What the config does
- **chill profile** — substantive findings, not style nitpicks; no request-changes gate, no poem.
- **auto-review** on non-draft PRs.
- **path filters** — skips `target/`, `node_modules/`, lockfiles, `src-tauri/gen/`, committed `benchmarks/results*`, and `assets/`.
- **path instructions** encoding the gotchas that actually bit us in recent PRs: SQLite migration-pin discipline (pin the literal version, not the `LATEST` constant), version bumps on published crates, secret redaction, workflow `pipefail`/publish-ordering — and an explicit note to **not** flag deliberate `ponytail:` shortcuts.

Note: installing the CodeRabbit GitHub App on `wuisabel-gif/MemWhale` is the one manual step (grant it repo access from coderabbit.ai). This PR just makes its reviews match how this repo is maintained.