### PR TITLE
feat: make memorywhale-core embeddable — rustdoc, embed example, feature-gate embeddings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/memorywhale-core/Cargo.toml
+++ b/crates/memorywhale-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale-core"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 description = "Explainable retrieval for MemoryWhale: a MemoryEngine interface, a built-in scorer that ranks memories with per-signal reasons, and an optional MemPalace backend over MCP."
 license = "MIT"
@@ -12,13 +12,17 @@ default = []
 # Talk to a local `mempalace-mcp` server as an MCP client. Off by default and
 # dependency-free: it only enables code that already-present crates cover.
 mempalace = []
+# Semantic similarity via a network embedder (the Ollama-backed `OllamaEmbedder`).
+# Off by default: the lexical/BM25 path needs no embedder and no network. Pulls
+# in `ureq` (the only crate used solely by the embedding path).
+embeddings = ["dep:ureq"]
 
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-ureq = { version = "2", features = ["json"] }
+ureq = { version = "2", features = ["json"], optional = true }
 # The one SQLite loader (memorywhale_core::sqlite) lives here so the CLI and desktop
 # share it. bundled = no system libsqlite3 needed (matches the other crates).
 rusqlite = { version = "0.32", features = ["bundled"] }
@@ -27,3 +31,14 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 # memorywhale.sqlite3 into an eval_data.json gold-set skeleton.
 [dev-dependencies]
 dirs = "5"
+
+# These examples drive the Ollama embedder, so they need the `embeddings` feature
+# (and thus `ureq`). Gating them keeps the default `cargo test` build ureq-free.
+# `embed`, `benchmark`, and `dump_eval` need no feature and stay auto-discovered.
+[[example]]
+name = "recall"
+required-features = ["embeddings"]
+
+[[example]]
+name = "eval"
+required-features = ["embeddings"]

--- a/crates/memorywhale-core/README.md
+++ b/crates/memorywhale-core/README.md
@@ -37,7 +37,26 @@ for sm in engine.retrieve(&query, 3) {
     for reason in sm.reasons() {
         println!("  · {reason}");   // explainable per-signal scores
     }
+    // sm.explain() prints the full per-signal breakdown.
 }
 ```
 
-See `examples/` for semantic (Ollama) recall and the ranking benchmark.
+Run it end to end — a few memories, a query, and the full per-signal
+`explain()` breakdown of the winner:
+
+```
+cargo run -p memorywhale-core --example embed
+```
+
+## Features
+
+Both off by default:
+
+- `embeddings` — semantic similarity via a local Ollama embedder
+  (`BuiltinEngine::with_embedder`). Off, retrieval is purely lexical/BM25 and
+  pulls in no network dependency (`ureq`).
+- `mempalace` — route retrieval through a local MemPalace `mempalace-mcp`
+  server. Adds no dependencies.
+
+See `examples/` for the `embed` walkthrough above, semantic (Ollama) recall
+(`--features embeddings`), and the deterministic ranking benchmark.

--- a/crates/memorywhale-core/examples/embed.rs
+++ b/crates/memorywhale-core/examples/embed.rs
@@ -1,0 +1,64 @@
+//! Embedding `memorywhale-core` in your own code.
+//!
+//!   cargo run -p memorywhale-core --example embed
+//!
+//! Build a few `Memory` items, construct a `BuiltinEngine`, run a `Query`, and
+//! print the top results *with their explainable per-signal scores*. Fully
+//! deterministic: no network, no ML embeddings — the default lexical/BM25 path.
+
+use chrono::{Duration, TimeZone, Utc};
+use memorywhale_core::engine::{BuiltinEngine, MemoryEngine};
+use memorywhale_core::{Memory, Query};
+
+fn main() {
+    // A fixed "now" so the recency signal (and the whole run) is reproducible.
+    let now = Utc.with_ymd_and_hms(2026, 6, 27, 12, 0, 0).unwrap();
+
+    let mem = |id: i64, text: &str, days_ago: i64, mentions: u32, importance: f32, tags: &[&str]| {
+        Memory {
+            id,
+            text: text.into(),
+            created_at: now - Duration::days(days_ago + 5),
+            last_used: now - Duration::days(days_ago),
+            mentions,
+            importance,
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            embedding: None, // lexical/BM25 path — no embeddings needed
+        }
+    };
+
+    let memories = vec![
+        mem(1, "Use Tokio for the async runtime.", 3, 6, 0.60, &["rust", "tokio"]),
+        mem(2, "Decided to use Postgres instead of SQLite for the API.", 9, 3, 0.55, &["db", "api"]),
+        mem(3, "I ate pizza for lunch.", 40, 1, 0.02, &[]),
+        mem(4, "Prefer Axum for HTTP services in Rust.", 25, 2, 0.40, &["rust", "axum"]),
+    ];
+
+    // Build the engine and query it. `task_tags` activates the task-relevance
+    // signal for memories tagged "rust".
+    let engine = BuiltinEngine::new(memories);
+    let query = Query::new("which async runtime should I use in rust?", now)
+        .with_task(vec!["rust".into()]);
+
+    println!("query: {:?}   (engine: {})\n", query.text, engine.name());
+
+    let top = engine.retrieve(&query, 3);
+    println!("top {} results — retrieved because…\n", top.len());
+    for (rank, hit) in top.iter().enumerate() {
+        println!(
+            "  {}. [{:>3}%] {}",
+            rank + 1,
+            hit.percent(),
+            hit.memory.text
+        );
+        for reason in hit.reasons() {
+            println!("        · {reason}");
+        }
+        println!();
+    }
+
+    // Full per-signal breakdown for the winner — the `memory explain <id>` view.
+    if let Some(winner) = top.first() {
+        println!("{}", winner.explain());
+    }
+}

--- a/crates/memorywhale-core/src/embed.rs
+++ b/crates/memorywhale-core/src/embed.rs
@@ -11,7 +11,7 @@ pub trait Embedder: Send + Sync {
     fn name(&self) -> &str;
 }
 
-/// Cosine similarity in [0,1] (negatives clamped to 0 — we only care about
+/// Cosine similarity in `[0,1]` (negatives clamped to 0 — we only care about
 /// "how related," not "how opposite").
 pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
     if a.is_empty() || b.is_empty() || a.len() != b.len() {
@@ -52,11 +52,18 @@ pub fn bytes_to_vec(b: &[u8]) -> Vec<f32> {
 
 /// Local-first embedder backed by Ollama's `/api/embeddings`.
 /// Run e.g. `ollama pull nomic-embed-text` first.
+///
+/// Behind the off-by-default `embeddings` feature (it's the only thing here that
+/// makes a network call, via `ureq`). The pure helpers above — [`cosine`],
+/// [`vec_to_bytes`], [`bytes_to_vec`], and the [`Embedder`] trait — are always
+/// available, so a caller can supply precomputed embeddings without the feature.
+#[cfg(feature = "embeddings")]
 pub struct OllamaEmbedder {
     endpoint: String,
     model: String,
 }
 
+#[cfg(feature = "embeddings")]
 impl OllamaEmbedder {
     pub fn new(model: impl Into<String>) -> Self {
         Self {
@@ -71,12 +78,14 @@ impl OllamaEmbedder {
     }
 }
 
+#[cfg(feature = "embeddings")]
 impl Default for OllamaEmbedder {
     fn default() -> Self {
         Self::new("nomic-embed-text")
     }
 }
 
+#[cfg(feature = "embeddings")]
 impl Embedder for OllamaEmbedder {
     fn name(&self) -> &str {
         "ollama"

--- a/crates/memorywhale-core/src/engine.rs
+++ b/crates/memorywhale-core/src/engine.rs
@@ -8,16 +8,18 @@
 //! change.
 
 use std::collections::HashMap;
+#[cfg(feature = "embeddings")]
 use std::sync::Arc;
 
 use rusqlite::Connection;
 
+#[cfg(feature = "embeddings")]
 use crate::embed::Embedder;
 use crate::scorer::score_with_lexical;
 use crate::{Memory, Query, ScoredMemory, Weights};
 
 /// Build an in-memory SQLite FTS5 index over `memories`, MATCH `query`, and
-/// return a per-id keyword relevance in [0,1] derived from SQLite's `bm25` rank.
+/// return a per-id keyword relevance in `[0,1]` derived from SQLite's `bm25` rank.
 ///
 /// The index has two columns — `text` (the memory body) and `tags` (its tags,
 /// space-joined). Tags are explicit user/agent signal, so a query term that only
@@ -109,7 +111,12 @@ fn fts_match_expr(query: &str) -> String {
         .join(" OR ")
 }
 
+/// The retrieval backend interface MemoryWhale owns. Implemented by
+/// [`BuiltinEngine`] (the default explainable scorer) and, behind the
+/// `mempalace` feature, `MemPalaceEngine`. Callers depend on this trait, so the
+/// backend is swappable without touching call sites.
 pub trait MemoryEngine {
+    /// A short backend label (e.g. `"builtin"`, `"builtin+embeddings"`).
     fn name(&self) -> &str;
     /// Return the top-`k` memories for the query, each with its score + reasons.
     fn retrieve(&self, query: &Query, k: usize) -> Vec<ScoredMemory>;
@@ -120,11 +127,14 @@ pub trait MemoryEngine {
 /// The default, zero-setup engine: scores an in-memory set with the explainable
 /// scorer. (A SQLite-backed variant just loads `memories` from the DB first.)
 ///
-/// With an [`Embedder`] attached, similarity becomes semantic (cosine over
-/// embeddings); without one, it falls back to lexical term overlap.
+/// Without the `embeddings` feature this is the lexical/BM25 engine, end of
+/// story. With the feature, an `Embedder` can be attached via `with_embedder`
+/// and similarity becomes semantic (cosine over embeddings), falling back to
+/// lexical when a memory or query isn't embedded.
 pub struct BuiltinEngine {
     pub memories: Vec<Memory>,
     pub weights: Weights,
+    #[cfg(feature = "embeddings")]
     embedder: Option<Arc<dyn Embedder>>,
 }
 
@@ -133,6 +143,7 @@ impl BuiltinEngine {
         Self {
             memories,
             weights: Weights::default(),
+            #[cfg(feature = "embeddings")]
             embedder: None,
         }
     }
@@ -144,6 +155,10 @@ impl BuiltinEngine {
 
     /// Attach an embedder and precompute embeddings for every memory that lacks
     /// one. Returns an error if embedding fails (e.g. Ollama not running).
+    ///
+    /// Only present with the `embeddings` feature; without it the engine is
+    /// purely lexical/BM25.
+    #[cfg(feature = "embeddings")]
     pub fn with_embedder(mut self, embedder: Arc<dyn Embedder>) -> anyhow::Result<Self> {
         for m in &mut self.memories {
             if m.embedding.is_none() {
@@ -155,18 +170,25 @@ impl BuiltinEngine {
     }
 
     /// Embed the query text if an embedder is attached (best-effort).
+    #[cfg(feature = "embeddings")]
     fn query_embedding(&self, query: &Query) -> Option<Vec<f32>> {
         self.embedder.as_ref().and_then(|e| e.embed(&query.text).ok())
+    }
+
+    /// No embedder without the feature — retrieval is always lexical/BM25.
+    #[cfg(not(feature = "embeddings"))]
+    fn query_embedding(&self, _query: &Query) -> Option<Vec<f32>> {
+        None
     }
 }
 
 impl MemoryEngine for BuiltinEngine {
     fn name(&self) -> &str {
+        #[cfg(feature = "embeddings")]
         if self.embedder.is_some() {
-            "builtin+embeddings"
-        } else {
-            "builtin"
+            return "builtin+embeddings";
         }
+        "builtin"
     }
 
     fn retrieve(&self, query: &Query, k: usize) -> Vec<ScoredMemory> {

--- a/crates/memorywhale-core/src/lib.rs
+++ b/crates/memorywhale-core/src/lib.rs
@@ -4,11 +4,61 @@
 //! *why* — a blended score over interpretable signals (similarity, recency,
 //! importance, reinforcement, task-relevance), each with a human-readable reason.
 //!
-//! Everything is behind a [`engine::MemoryEngine`] interface that MemoryWhale
+//! # The core flow
+//!
+//! 1. Build [`Memory`] items — in code, or via [`sqlite::load_memories`] from a
+//!    MemoryWhale database.
+//! 2. Wrap them in an [`engine::BuiltinEngine`] (the default, zero-setup engine).
+//! 3. Run a [`Query`] through [`engine::MemoryEngine::retrieve`].
+//! 4. Read back [`ScoredMemory`] values: a blended `score`, plus the per-signal
+//!    [`Signal`] breakdown. [`ScoredMemory::reasons`] gives the ranked
+//!    "retrieved because…" strings; [`ScoredMemory::explain`] the full audit.
+//!
+//! ```
+//! use chrono::Utc;
+//! use memorywhale_core::engine::{BuiltinEngine, MemoryEngine};
+//! use memorywhale_core::{Memory, Query};
+//!
+//! let now = Utc::now();
+//! let mems = vec![Memory {
+//!     id: 1,
+//!     text: "Use Tokio for the async runtime.".into(),
+//!     created_at: now,
+//!     last_used: now,
+//!     mentions: 6,
+//!     importance: 0.6,
+//!     tags: vec!["rust".into(), "tokio".into()],
+//!     embedding: None,
+//! }];
+//! let engine = BuiltinEngine::new(mems);
+//! let hits = engine.retrieve(&Query::new("async runtime", now), 5);
+//! assert_eq!(hits[0].memory.id, 1);
+//! // hits[0].reasons() explains *why* it was retrieved.
+//! ```
+//!
+//! See `examples/embed.rs` for a fuller, runnable walkthrough.
+//!
+//! # Signal model
+//!
+//! The distinctive design lives in [`scorer`]: relevance is a **weighted mean
+//! over the applicable signals** (a missing context, like no task tags, drops
+//! out of the average rather than scoring zero), and each signal carries a
+//! human-readable reason. See that module for the per-signal definitions.
+//!
+//! # Pluggable backends
+//!
+//! Everything is behind an [`engine::MemoryEngine`] interface that MemoryWhale
 //! owns, so the storage/retrieval backend is pluggable: the built-in scorer by
 //! default, or — with the off-by-default `mempalace` feature — an
 //! `engine::MemPalaceEngine` that talks to a local `mempalace-mcp` server over
 //! MCP. Callers never change.
+//!
+//! # Features
+//!
+//! - `embeddings` (off by default) — semantic similarity via a network embedder
+//!   (`embed::OllamaEmbedder` + `BuiltinEngine::with_embedder`). Off, retrieval
+//!   is purely lexical/BM25 and pulls in no network dependency.
+//! - `mempalace` (off by default) — the MemPalace MCP backend above.
 
 pub mod embed;
 pub mod engine;
@@ -31,7 +81,7 @@ pub struct Memory {
     pub last_used: DateTime<Utc>,
     /// How many times it has been reinforced (mentioned/used).
     pub mentions: u32,
-    /// Stored importance weight in [0,1].
+    /// Stored importance weight in `[0,1]`.
     pub importance: f32,
     /// Links / entities / repo associations (used for task relevance and graph).
     pub tags: Vec<String>,
@@ -70,7 +120,9 @@ impl Query {
     }
 }
 
-/// How much each signal counts toward the blended score.
+/// How much each signal counts toward the blended score. These are the mixing
+/// weights of the weighted mean in [`scorer`]; [`Weights::default`] is the tuned
+/// production blend. Pass a custom set via [`engine::BuiltinEngine::with_weights`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Weights {
     pub similarity: f32,
@@ -92,12 +144,15 @@ impl Default for Weights {
     }
 }
 
-/// One interpretable scoring signal and its contribution.
+/// One interpretable scoring signal and its contribution. A [`ScoredMemory`]
+/// carries one per signal (similarity, recency, importance, reinforcement,
+/// task). [`Signal::contribution`] is its `weight × score` share of the blend,
+/// or `0` when the signal doesn't apply.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Signal {
     pub name: String,
     pub weight: f32,
-    /// Raw signal strength in [0,1].
+    /// Raw signal strength in `[0,1]`.
     pub score: f32,
     /// Whether this signal applies (e.g. task-relevance is inert with no task).
     pub applicable: bool,
@@ -115,11 +170,14 @@ impl Signal {
     }
 }
 
-/// A memory with its blended score and the signals that produced it.
+/// A memory with its blended score and the signals that produced it — the unit
+/// of explainable retrieval. Use [`ScoredMemory::reasons`] for the ranked
+/// "retrieved because…" strings, or [`ScoredMemory::explain`] for the full
+/// per-signal audit.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScoredMemory {
     pub memory: Memory,
-    /// Blended relevance in [0,1].
+    /// Blended relevance in `[0,1]`.
     pub score: f32,
     pub signals: Vec<Signal>,
 }

--- a/crates/memorywhale-core/src/scorer.rs
+++ b/crates/memorywhale-core/src/scorer.rs
@@ -1,9 +1,30 @@
 //! The explainable scorer: turn a (memory, query) pair into a blended score plus
 //! the interpretable signals behind it.
 //!
-//! Each signal returns a strength in [0,1] and a human-readable `detail`. The
-//! blended score is the weighted mean over *applicable* signals, so a missing
-//! context (e.g. no task tags) neither helps nor unfairly penalizes.
+//! # The signal model
+//!
+//! Relevance is a **weighted mean over the *applicable* signals**. Each signal
+//! yields a strength in `[0,1]`, a mixing [`Weights`] weight, and a
+//! human-readable `detail`; the blend is `Σ(weight × score) / Σ(weight)` taken
+//! only over signals that apply. So a missing context (e.g. no task tags) drops
+//! out of the average — it neither helps nor unfairly penalizes — instead of
+//! counting as a zero. This is what makes every result explainable: the score is
+//! literally the sum of named, inspectable contributions.
+//!
+//! The five signals:
+//!
+//! - **similarity** — how well the text matches the query. Semantic cosine over
+//!   embeddings when available, else FTS5 BM25 keyword relevance, else a
+//!   term-overlap fallback.
+//! - **recency** — exponential decay from `last_used`, halving every
+//!   `query.half_life_days`.
+//! - **importance** — the memory's stored importance weight, used directly.
+//! - **reinforcement** — mention count, log-scaled and capped.
+//! - **task-relevance** — overlap between the memory's tags and the query's task
+//!   tags; *inapplicable* (drops out) when there is no task context.
+//!
+//! Each contributes a reason string, surfaced via [`ScoredMemory::reasons`] and
+//! [`ScoredMemory::explain`].
 
 use std::collections::HashSet;
 
@@ -27,7 +48,7 @@ pub fn score(
 }
 
 /// Like [`score`], but with `lexical_sim`: a precomputed lexical relevance in
-/// [0,1] (the engine derives it from an in-memory SQLite FTS5 BM25 index over
+/// `[0,1]` (the engine derives it from an in-memory SQLite FTS5 BM25 index over
 /// the whole memory set). When present it *is* the similarity signal in the
 /// non-semantic path — proper keyword relevance instead of Jaccard term
 /// overlap. `None` falls back to term overlap for callers without an index.

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -21,7 +21,7 @@ dirs = "5"
 # MCP server, with a builtin fallback when that server is unreachable.
 # `version` (alongside `path`) is required so `cargo publish` can resolve the
 # dependency from crates.io — publish memorywhale-core first, then this crate.
-memorywhale-core = { path = "../memorywhale-core", version = "0.2.4", features = ["mempalace"] }
+memorywhale-core = { path = "../memorywhale-core", version = "0.2.5", features = ["mempalace"] }
 regex = "1"
 # Pure-Rust interactive terminal UI (`mw tui`) — no system libraries, so it
 # keeps the bare-machine / Jetson build story intact. Bundles crossterm.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,10 @@ anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5"
 memorywhale-cli = { path = "../crates/mw-cli" }
-memorywhale-core = { path = "../crates/memorywhale-core" }
+# The desktop app is the embedding consumer: it caches Ollama vectors and calls
+# `with_embedder`, so it enables the (otherwise off-by-default) `embeddings`
+# feature. The CLI leaves this off, keeping `ureq` out of the CLI build.
+memorywhale-core = { path = "../crates/memorywhale-core", features = ["embeddings"] }
 regex = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Makes `crates/memorywhale-core` a legible, embeddable library. Three cohesive parts:

## 1. Rustdoc pass on the public API
- Crate-level docs: the core flow (build `Memory` → `BuiltinEngine` → `Query` → `ScoredMemory` with per-signal reasons), a runnable doctest, and a features section.
- Documented the public types (`Memory`, `Query`, `ScoredMemory`, `Signal`, `Weights`), the `MemoryEngine` trait + `BuiltinEngine`, and the `sqlite` loaders.
- **Signal model** (`scorer.rs`): documented that relevance is a weighted mean over the *applicable* signals — similarity, recency (half-life), importance, reinforcement, task-relevance — each contributing a human-readable reason. Fixed the stale `[0,1]` broken-intra-doc-link warnings along the way; `cargo doc` is now clean.

## 2. `examples/embed.rs`
A deterministic, network-free example: builds a few `Memory` items, constructs a `BuiltinEngine`, runs a `Query`, and prints the top results with their explainable per-signal scores via `reasons()` / `explain()`. This is the minimal README example; the README now shows the same snippet and points at it.

## 3. Feature-gate the ML embedding path
- `ureq` is now `optional`; new off-by-default `embeddings = ["dep:ureq"]` feature.
- `OllamaEmbedder` (the only `ureq` user) and `BuiltinEngine::with_embedder` / its `embedder` field / `query_embedding` are gated behind `embeddings`. The pure helpers (`cosine`, `vec_to_bytes`, `bytes_to_vec`, the `Embedder` trait) stay always-available because the default scorer path uses `cosine`. With the feature off, the engine is purely lexical/BM25 and `with_embedder` simply doesn't exist.
- `src-tauri` (the embedding consumer) enables the feature; `memorywhale-cli` stays on defaults, so **`ureq` drops out of the default and CLI builds**.
- The two Ollama-driven examples (`recall`, `eval`) now declare `required-features = ["embeddings"]` so the default `cargo test` build stays `ureq`-free.

Version bump `0.2.4` → `0.2.5` (mw-cli's version requirement updated to match).

## Verification
- `cargo build -p memorywhale-core` (default): compiles; `ureq` absent from the default and CLI dep trees.
- `cargo build -p memorywhale-core --features embeddings`: compiles.
- `cargo build --workspace` (src-tauri pulls embeddings): compiles.
- `cargo test --workspace` and `cargo test -p memorywhale-core --features embeddings`: pass.
- `cargo run -p memorywhale-core --example embed`: prints explainable scores.
- Retrieval benchmark reproduces byte-identically (`git diff --exit-code benchmarks/results benchmarks/results_intent` clean).

Scoring behavior and DB schema unchanged.
