### PR TITLE
feat: document + test the MCP surface, add stats tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ npm install && npm run tauri:dev # full desktop app (needs Tauri system deps)
 ## Documentation
 
 - [docs/CLI.md](docs/CLI.md) — full command reference for every `mw*` binary.
+- [docs/MCP.md](docs/MCP.md) — wire the `mw-mcp` server into an agent; the six tools it exposes.
 - [VISION.md](VISION.md) — where the project is headed and why.
 - [PHILOSOPHY.md](PHILOSOPHY.md) — the communication and memory ideas behind it.
 - [ECOSYSTEM.md](ECOSYSTEM.md) — how the pieces (CLI, dashboard, integrations) fit together.

--- a/crates/mw-cli/src/bin/mw-mcp.rs
+++ b/crates/mw-cli/src/bin/mw-mcp.rs
@@ -6,7 +6,7 @@
 //   claude mcp add memorywhale -- mw-mcp
 //
 // Tools exposed: recent_errors, search_memory, get_context, remember,
-// similar_failures.
+// similar_failures, stats.
 
 use chrono::Utc;
 use memorywhale_core::engine::MemoryEngine;
@@ -113,6 +113,11 @@ fn tool_defs() -> Value {
                 "error_text": {"type": "string", "description": "the error/stderr output you hit"},
                 "command": {"type": "string", "description": "optional: the command that produced it, e.g. cargo build — enables an exact fingerprint match"}
             }, "required": ["error_text"]}
+        },
+        {
+            "name": "stats",
+            "description": "Health/liveness check for the memory store: confirm it's reachable and populated before relying on the other tools. Returns total memory count, how many are recorded failures, the most-recent memory timestamp (or \"none\"), and the database file path.",
+            "inputSchema": {"type": "object", "properties": {}}
         }
     ])
 }
@@ -158,20 +163,24 @@ fn call_tool(name: &str, args: &Value, client_name: Option<&str>) -> Result<Stri
             let conn = open()?;
             Ok(similar_failures_report(&conn, error_text, scope_arg(args, "command")))
         }
+        "stats" => stats(),
         other => Err(format!("unknown tool: {other}")),
     }
 }
 
 fn recent_errors(limit: i64) -> Result<String, String> {
     let conn = open()?;
-    let mut stmt = conn
-        .prepare(
-            "SELECT argv_json, cwd, exit_code, stderr, notes, created_at
+    // A brand-new store has only the bookmarks table; `command_runs` appears
+    // once something is recorded. Treat its absence as "no failures yet" (same
+    // graceful-read convention as `load_memories`) rather than erroring.
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT argv_json, cwd, exit_code, stderr, notes, created_at
              FROM command_runs
              WHERE exit_code IS NOT NULL AND exit_code != 0
              ORDER BY id DESC LIMIT ?1",
-        )
-        .map_err(|e| e.to_string())?;
+    ) else {
+        return Ok("(no failed commands recorded)".to_string());
+    };
     let rows = stmt
         .query_map(params![limit], |r| {
             Ok((
@@ -352,6 +361,48 @@ fn remember_tool(text: &str, client_name: Option<&str>) -> Result<String, String
     ))
 }
 
+/// Liveness/health summary an agent can call to confirm the store is reachable
+/// and populated. Reads only counts and timestamps — never memory text — so it
+/// leaks nothing beyond how much is stored and when it was last written.
+fn stats() -> Result<String, String> {
+    let path = memorywhale_cli::database_path()?;
+    let conn = open()?;
+    Ok(stats_summary(&conn, &path.display().to_string()))
+}
+
+/// The stats payload as compact JSON. Counts are cheap (`COUNT(*)`, `MAX`) and
+/// tolerate a fresh DB where `command_runs` doesn't exist yet: a failed query
+/// (missing table) reads as zero / "none" rather than an error.
+fn stats_summary(conn: &Connection, db_path: &str) -> String {
+    let count = |sql: &str| conn.query_row(sql, [], |r| r.get::<_, i64>(0)).unwrap_or(0);
+    let max_ts = |sql: &str| {
+        conn.query_row(sql, [], |r| r.get::<_, Option<String>>(0))
+            .ok()
+            .flatten()
+    };
+    let memories =
+        count("SELECT COUNT(*) FROM command_runs") + count("SELECT COUNT(*) FROM bookmarks");
+    let errors =
+        count("SELECT COUNT(*) FROM command_runs WHERE exit_code IS NOT NULL AND exit_code != 0");
+    // ISO-8601 timestamps sort lexicographically, so the string max is the most
+    // recent across both writable sources.
+    let latest = [
+        max_ts("SELECT MAX(created_at) FROM command_runs"),
+        max_ts("SELECT MAX(created_at) FROM bookmarks"),
+    ]
+    .into_iter()
+    .flatten()
+    .max()
+    .unwrap_or_else(|| "none".to_string());
+    json!({
+        "memories": memories,
+        "errors": errors,
+        "latest": latest,
+        "db": db_path,
+    })
+    .to_string()
+}
+
 /// Report whether an error the agent just hit has been seen before.
 /// With a `command` we fingerprint exactly like the stored rows and read the
 /// evidence-only insight (occurrences + how often a later run resolved it).
@@ -529,5 +580,38 @@ mod tests {
         // Never-seen error is reported plainly.
         let miss = similar_failures_report(&conn, "error: something brand new", Some("cargo"));
         assert!(miss.to_lowercase().contains("never seen"), "miss: {miss}");
+    }
+
+    /// stats reflects what's in the store: total count, error subset, latest ts,
+    /// and the db path — and an empty DB returns zeros/"none" without erroring.
+    #[test]
+    fn stats_summarizes_counts_and_empty_db() {
+        // Empty DB: no tables at all → graceful zeros and "none".
+        let empty = Connection::open_in_memory().unwrap();
+        let out = stats_summary(&empty, "/tmp/mw.sqlite3");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["memories"], 0);
+        assert_eq!(v["errors"], 0);
+        assert_eq!(v["latest"], "none");
+        assert_eq!(v["db"], "/tmp/mw.sqlite3");
+
+        // Populated: two runs, one a failure.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE command_runs (
+                id INTEGER PRIMARY KEY, command TEXT NOT NULL, argv_json TEXT NOT NULL DEFAULT '[]',
+                cwd TEXT, exit_code INTEGER, stdout TEXT NOT NULL DEFAULT '',
+                stderr TEXT NOT NULL DEFAULT '', notes TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT '', error_fingerprint TEXT);
+             INSERT INTO command_runs (command, exit_code, created_at)
+                 VALUES ('cargo build', 0, '2026-07-20T10:00:00Z');
+             INSERT INTO command_runs (command, exit_code, created_at)
+                 VALUES ('cargo build', 101, '2026-07-21T10:00:00Z');",
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&stats_summary(&conn, "/tmp/mw.sqlite3")).unwrap();
+        assert_eq!(v["memories"], 2);
+        assert_eq!(v["errors"], 1);
+        assert_eq!(v["latest"], "2026-07-21T10:00:00Z");
     }
 }

--- a/crates/mw-cli/tests/mcp_server.rs
+++ b/crates/mw-cli/tests/mcp_server.rs
@@ -1,0 +1,127 @@
+//! End-to-end check of the `mw-mcp` server over real stdio.
+//!
+//! Spawns the actual binary against a hermetic temp data dir (via
+//! `MEMORYWHALE_DATA_DIR`, the same env the server reads to resolve its DB),
+//! speaks newline-delimited JSON-RPC 2.0 on its stdin/stdout, and asserts that
+//! `tools/list` advertises all six tools and that each one returns a non-error
+//! response — including on a fresh, empty database.
+#![cfg(unix)]
+
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+const TOOLS: [&str; 6] = [
+    "recent_errors",
+    "search_memory",
+    "get_context",
+    "remember",
+    "similar_failures",
+    "stats",
+];
+
+/// Minimal valid arguments for each tool — enough to pass its required-field
+/// check. Everything here must succeed against an empty store.
+fn args_for(tool: &str) -> Value {
+    match tool {
+        "search_memory" => json!({"query": "linker error"}),
+        "remember" => json!({"text": "integration-test lesson"}),
+        "similar_failures" => json!({"error_text": "error: linking with cc failed"}),
+        _ => json!({}),
+    }
+}
+
+#[test]
+fn server_lists_and_calls_all_six_tools_on_empty_db() {
+    let dir = std::env::temp_dir().join(format!("mw-mcp-it-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mw-mcp"))
+        .env("MEMORYWHALE_DATA_DIR", &dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mw-mcp");
+
+    // Build the request batch: initialize, tools/list, then a call per tool.
+    // ids: 1 = initialize, 2 = tools/list, 3.. = one per tool (in TOOLS order).
+    let mut requests = vec![
+        json!({"jsonrpc": "2.0", "id": 1, "method": "initialize",
+               "params": {"clientInfo": {"name": "integration-test"}}}),
+        json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    ];
+    for (i, tool) in TOOLS.iter().enumerate() {
+        requests.push(json!({
+            "jsonrpc": "2.0", "id": 3 + i as i64, "method": "tools/call",
+            "params": {"name": tool, "arguments": args_for(tool)}
+        }));
+    }
+
+    // Write every request line-delimited, then close stdin so the server hits
+    // EOF and exits its loop after replying.
+    let mut stdin = child.stdin.take().unwrap();
+    for req in &requests {
+        writeln!(stdin, "{req}").unwrap();
+    }
+    drop(stdin);
+
+    // Read all response lines on a worker thread so a hang fails the test via
+    // the recv timeout instead of blocking CI forever.
+    let stdout = child.stdout.take().unwrap();
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            if line.trim().is_empty() {
+                continue;
+            }
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    // Collect one response per request id (8 total: initialize + list + 6 calls).
+    let mut by_id: std::collections::HashMap<i64, Value> = std::collections::HashMap::new();
+    while by_id.len() < requests.len() {
+        let line = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("timed out waiting for an mw-mcp response");
+        let v: Value = serde_json::from_str(&line).expect("valid JSON-RPC line");
+        if let Some(id) = v.get("id").and_then(Value::as_i64) {
+            by_id.insert(id, v);
+        }
+    }
+    let _ = child.wait();
+
+    // tools/list must advertise all six tool names.
+    let list = &by_id[&2];
+    assert!(list.get("error").is_none(), "tools/list errored: {list}");
+    let names: Vec<&str> = list["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|t| t.get("name").and_then(Value::as_str))
+        .collect();
+    for tool in TOOLS {
+        assert!(names.contains(&tool), "tools/list missing {tool}: {names:?}");
+    }
+    assert_eq!(names.len(), 6, "expected exactly 6 tools, got {names:?}");
+
+    // Every tools/call — on the empty DB — echoes its id, has a result, no error.
+    for (i, tool) in TOOLS.iter().enumerate() {
+        let id = 3 + i as i64;
+        let resp = &by_id[&id];
+        assert_eq!(resp["id"].as_i64(), Some(id), "{tool}: id not echoed: {resp}");
+        assert!(resp.get("error").is_none(), "{tool} returned an error: {resp}");
+        assert!(resp.get("result").is_some(), "{tool} has no result: {resp}");
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -130,7 +130,7 @@ add/update/skip breakdown without contacting the server.
 mw-serve [--host addr] [--port n] [--token secret]  # web dashboard
 mw-view <id>                                        # open one memory directly
 mw-recover                                          # recover interrupted recordings
-mw-mcp                                              # MCP server for AI agents (stdio): recent_errors, search_memory, get_context, remember, similar_failures
+mw-mcp                                              # MCP server for AI agents (stdio): recent_errors, search_memory, get_context, remember, similar_failures, stats — see docs/MCP.md
 ```
 
 ## Data location

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,73 @@
+# MCP reference
+
+`mw-mcp` is a [Model Context Protocol](https://modelcontextprotocol.io) server
+that exposes your MemoryWhale store to a coding agent (Claude Code, Codex,
+Cursor, …) directly — so instead of you pasting past errors and fixes into the
+chat, the agent queries them itself. It speaks newline-delimited JSON-RPC 2.0
+over stdio and is read-mostly: the only tool that writes is `remember`, and it
+saves a single note.
+
+If you're working from a source checkout, the binary is
+`cargo run -p memorywhale-cli --bin mw-mcp --`; installed, it's just `mw-mcp` on
+your PATH (see the README's Install section). It reads the same local database
+as the `mw` CLI — nothing leaves your machine.
+
+## Wire it into an agent
+
+Claude Code, one line:
+
+```bash
+claude mcp add memorywhale -- mw-mcp
+```
+
+Or add a stanza to an MCP config (`claude_desktop_config.json`, `.mcp.json`, or
+your agent's equivalent) pointing at the installed binary:
+
+```json
+{
+  "mcpServers": {
+    "memorywhale": {
+      "command": "mw-mcp"
+    }
+  }
+}
+```
+
+No arguments, no API key. If `mw-mcp` isn't on your PATH, use its absolute path
+as `"command"`.
+
+## Tools
+
+All six take a JSON object and return text (JSON-RPC `result.content[].text`).
+Required args are noted; everything else is optional.
+
+| Tool | Purpose | Args | Returns |
+| --- | --- | --- | --- |
+| `recent_errors` | Recent failed commands (non-zero exit) with their error output — start here when debugging a recurring failure. | `limit` (int, default 8) | A list of failed runs: command, exit code, cwd, the salient stderr line, and any note. |
+| `search_memory` | Search remembered commands, sessions, and notes for a term, ranked by the explainable engine. | `query` (string, **required**); `project`, `machine` (string, optional scope) | Ranked hits with a score, a snippet, and the reasons each ranked where it did. |
+| `get_context` | The most relevant remembered memory, engine-ranked, optionally scoped. | `project`, `machine` (string, optional) | Up to 8 ranked hits, each with score, snippet, and reasons. |
+| `remember` | Save a freeform lesson or conclusion so future sessions don't re-derive it. | `text` (string, **required**) | Confirmation with the new memory id; findable later via `search_memory`/`get_context`. |
+| `similar_failures` | Check whether an error you just hit has occurred before, and whether a later run resolved it. | `error_text` (string, **required**); `command` (string, optional — enables an exact fingerprint match) | Evidence-only history: occurrence count, how often a later run of the same command succeeded, and a pointer to a concrete past occurrence. |
+| `stats` | Health/liveness check: confirm the store is reachable and populated before relying on the other tools. | none | JSON: total memory count, how many are recorded failures, the most-recent memory timestamp (or `"none"`), and the database file path. |
+
+A fresh, empty store is handled gracefully — reads return empty results (and
+`stats` returns zero counts) rather than erroring.
+
+## The loop
+
+The point isn't any single tool — it's the loop between them:
+
+1. The agent runs a command and hits an error.
+2. It calls `similar_failures` (or `search_memory`) to check whether this
+   failure has been seen before, and whether a later run resolved it.
+3. Once it figures out *why* it failed or *how* the fix worked, it calls
+   `remember` to record that conclusion.
+4. Next time the same error shows up — in a later session, or on a teammate's
+   machine that imported the store — `similar_failures`/`search_memory` surface
+   the fix instead of the agent re-deriving it from scratch.
+
+Whether having the memory in hand actually changes whether an agent solves a
+failure is measured in
+[benchmarks/agent_eval/AGENT_EVAL.md](../benchmarks/agent_eval/AGENT_EVAL.md);
+whether the right memory is retrievable in the first place is measured by the
+retrieval benchmarks in [benchmarks/BENCHMARKS.md](../benchmarks/BENCHMARKS.md).


### PR DESCRIPTION
Makes the `mw-mcp` server a real, documented, tested product surface. One concern: the MCP surface.

## What's here

**A sixth tool — `stats`.** A health/liveness check an agent can call to know the store is alive and populated before relying on the other tools. Returns total memory count, error-type count, the most-recent memory timestamp (or `"none"`), and the db file path. Wired into `tools/list` and `tools/call` exactly like the existing five (same JSON shapes, same `Result<String, String>` convention). Reads only counts/timestamps — no memory text — so it preserves the local-only / no-content-leak invariants. Graceful on an empty store (zeros / "none", no panic).

Along the way, `recent_errors` is made graceful when `command_runs` doesn't exist yet on a fresh DB — matching the `load_memories` read convention instead of erroring.

**An integration test that drives the real binary.** `crates/mw-cli/tests/mcp_server.rs` spawns the actual `mw-mcp` binary (`env!("CARGO_BIN_EXE_mw-mcp")`) against a hermetic temp data dir via `MEMORYWHALE_DATA_DIR`, speaks newline-delimited JSON-RPC over its stdin/stdout, sends `initialize` + `tools/list` (asserting all six tool names) + a `tools/call` per tool, and asserts each response echoes its id, has a `result`, and no `error`. Covers the empty-DB path (fresh store returns empty results / zero counts). Responses are read on a worker thread with a `recv` timeout so a hang fails the test instead of blocking CI. Unix-gated like the repo's other integration tests.

**Agent-facing docs — `docs/MCP.md`.** What the server is, the one-liner + config stanza to wire it into an agent, a table of all six tools grounded in the actual code, and the record→retrieve loop (agent hits an error → `remember` records it → `similar_failures`/`search_memory` surface the fix), pointing at the agent eval as evidence. Linked from the README's Documentation list and from CLI.md.

## Constraints respected

No version bumps, no new dependencies, no changes to `Formula/` / `install.sh` / workflows. Privacy invariants preserved.

## Verification

- `cargo build -p memorywhale-cli --bin mw-mcp` ✅
- `cargo test -p memorywhale-cli` ✅ (new `stats` unit test + integration test pass)
- `cargo test --workspace` ✅ (nothing regressed)
- `cargo build --workspace` ✅