### PR TITLE
test: prove secret-scrub and capture-gate invariants at the write boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ all land on the same version.
 **Windows:** run it inside [WSL](https://learn.microsoft.com/windows/wsl/) —
 MemoryWhale is a Linux binary there, so the one-line install above works as-is
 from your WSL shell. (A native Windows build isn't available yet; the session
-recorder relies on Unix `script`.)
+recorder relies on Unix `script`, and a native ConPTY transcript recorder isn't
+implemented — PowerShell shell hooks still capture commands.)
 
 First run: type `mw` — it explains itself and offers to auto-record every new
 terminal. That's the whole setup.

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -1546,7 +1546,14 @@ mod tests {
         std::env::remove_var("MEMORYWHALE_REVIEW_AGENT_MEMORIES");
         let dir = fresh_data_dir("remember-test");
 
-        let id = remember("the fix: API_KEY=abcdef123456 in .env", Some("/tmp/repo")).unwrap();
+        // A few distinct secret shapes in one note; the fake credentials are
+        // hand-authored, never real. Assert both that the scrub fired AND that
+        // no raw secret survived into the stored row — this is the end-to-end
+        // guarantee `redact()`'s own unit tests can't make.
+        let secrets = ["abcdef123456", "ghp_0123456789abcdefghijABCDEF", "hunter2secret"];
+        let note = "the fix: API_KEY=abcdef123456, token ghp_0123456789abcdefghijABCDEF, \
+                    password: hunter2secret in .env";
+        let id = remember(note, Some("/tmp/repo")).unwrap();
         assert!(id > 0);
 
         let conn = Connection::open(dir.join("memorywhale.sqlite3")).unwrap();
@@ -1558,6 +1565,9 @@ mod tests {
             )
             .unwrap();
         assert!(label.contains("[REDACTED]"), "secret should be redacted: {label}");
+        for secret in secrets {
+            assert!(!label.contains(secret), "raw secret {secret:?} landed in the db row: {label}");
+        }
         assert_eq!(cwd.as_deref(), Some("/tmp/repo"));
 
         std::env::remove_var("MEMORYWHALE_DATA_DIR");

--- a/crates/mw-cli/tests/privacy.rs
+++ b/crates/mw-cli/tests/privacy.rs
@@ -1,0 +1,67 @@
+//! End-to-end privacy check for the command-capture write path.
+//!
+//! `redact()` has unit tests, and `remember()` (the bookmarks path) is covered
+//! in the lib test module. The gap this closes: a captured command's
+//! stdout/stderr flows through the `mw-remember` binary into the `command_runs`
+//! table — prove the scrub actually fires on that path, so a secret printed by
+//! a recorded command never lands raw in the DB. (`mw-run` shares the identical
+//! `redact()`-before-INSERT into `command_runs`.)
+
+use rusqlite::Connection;
+use std::process::Command;
+
+// Hand-authored fake credentials — never real. One per shape `secret_patterns`
+// handles: an assignment, a GitHub token, and an AWS access-key id.
+const SECRETS: [&str; 3] = [
+    "hunter2secret",                 // password: <value>
+    "ghp_0123456789abcdefghijABCDEF", // GitHub token
+    "AKIAABCDEFGHIJKLMNOP",           // AWS access key id
+];
+
+#[test]
+fn command_capture_stdout_stderr_is_redacted_in_db() {
+    let dir = std::env::temp_dir().join(format!("mw-privacy-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let stdout = format!("logging in with password: {} then done", SECRETS[0]);
+    let stderr = format!("token {} and key {} leaked", SECRETS[1], SECRETS[2]);
+
+    let out = Command::new(env!("CARGO_BIN_EXE_mw-remember"))
+        .env("MEMORYWHALE_DATA_DIR", &dir)
+        .args([
+            "--cwd",
+            dir.to_str().unwrap(),
+            "--exit-code",
+            "0",
+            "--stdout",
+            &stdout,
+            "--stderr",
+            &stderr,
+            "--",
+            "printenv",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "mw-remember failed: {out:?}");
+
+    let conn = Connection::open(dir.join("memorywhale.sqlite3")).unwrap();
+    let (db_stdout, db_stderr): (String, String) = conn
+        .query_row(
+            "SELECT stdout, stderr FROM command_runs ORDER BY id DESC LIMIT 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+
+    let stored = format!("{db_stdout}\n{db_stderr}");
+    assert!(stored.contains("[REDACTED]"), "scrub never fired: {stored}");
+    for secret in SECRETS {
+        assert!(
+            !stored.contains(secret),
+            "raw secret {secret:?} landed in command_runs: {stored}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Test-hardening PR. Proves MemoryWhale's two privacy invariants at the actual write boundary — not just in isolated `redact()`/parser unit tests. No behavior changes.

## What landed

1. **Scrub-before-SQLite, end-to-end** — extended `remember_writes_and_redacts` (lib test module). It already hit the real `remember()` write path and opened the resulting DB, but only covered one secret shape and only asserted `[REDACTED]` was *present*. Now it feeds three hand-authored fake secrets (`API_KEY=...`, a `ghp_` GitHub token, `password: ...`) in one note and asserts each raw secret substring is **absent** from the stored `bookmarks` row. If redaction were removed, this fails.

2. **Command-capture scrub** — new `crates/mw-cli/tests/privacy.rs` :: `command_capture_stdout_stderr_is_redacted_in_db`. Runs the `mw-remember` binary (via `CARGO_BIN_EXE_mw-remember` + a temp `MEMORYWHALE_DATA_DIR`) with secrets in `--stdout`/`--stderr`, then asserts the stored `command_runs` row is redacted and contains no raw secret. This closes the transcript-recorder gap: no existing test proved captured command output is scrubbed before storage. (`mw-run` shares the identical `redact()`-before-INSERT into `command_runs`.)

3. **Windows ConPTY known-limitation** — one line added to the README's Windows note: the native ConPTY transcript recorder isn't implemented; PowerShell shell hooks still capture commands.

## Already covered — deliberately skipped

The **capture-gate enforcement** invariant is already fully proven by `off_directory_writes_zero_rows` (gated dir → skip error + zero rows + control dir records), `mwignore_beats_global_config_beats_default`, and `symlinked_cwd_still_hits_the_gate`. No new test — that would be redundant.

## Constraints honored

`MEMORYWHALE_NO_REDACT` is never set; scrubbing is never weakened. All secret fixtures are hand-authored fakes. No new dependencies, no version bumps, no changes to Formula/ install.sh/ release.yml/ CI.

## Verification
- `cargo test -p memorywhale-cli` ✅
- `cargo test --workspace` ✅
- `cargo build --workspace` ✅