### PR TITLE
chore: release 0.6.2 — CLI points at memorywhale-core post-rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale"
-version = "0.6.0"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale-cli"
-version = "0.6.0"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale-cli"
-version = "0.6.0"
+version = "0.6.2"
 description = "MemoryWhale CLI — local-first terminal memory. Record commands, sessions, and output into local SQLite; browse them in a built-in web dashboard. Nothing is uploaded."
 authors = ["Isabel Wu <wuisabel@usc.edu>"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale"
-version = "0.6.0"
+version = "0.6.2"
 description = "A Rust/Tauri visual second brain for local knowledge graphs"
 authors = ["MemoryWhale"]
 license = "MIT"


### PR DESCRIPTION
Bumps `memorywhale-cli` and the desktop app to **0.6.1**.

**Why:** the published `memorywhale-cli` 0.6.0 predates the `mw-memory` → `memorywhale-core` rename and still resolves `mw-memory ^0.2.0` on crates.io. This bump lets the next `cargo publish` build the CLI against `memorywhale-core 0.2.5` (already published), closing the rename loop.

**What changes**
- `crates/mw-cli/Cargo.toml`: 0.6.0 → 0.6.1 (dep is already `memorywhale-core = "0.2.5"`)
- `src-tauri/Cargo.toml`: 0.6.0 → 0.6.1 (version coherence; not published)
- `Cargo.lock` regenerated

**Release flow after merge:** tag `v0.6.1` → `release.yml` builds binaries, bumps the Homebrew formula, and publishes `memorywhale-core` (idempotent skip, already up) then `memorywhale-cli` 0.6.1.

**Follow-up:** once 0.6.1 is on crates.io, yank the last live `mw-memory` version (0.2.2) — safe then, since no current CLI resolves it anymore.