### PR TITLE
refactor: centralize SQLite ownership in the CLI

### DIFF
--- a/crates/mw-cli/README.md
+++ b/crates/mw-cli/README.md
@@ -17,6 +17,15 @@ mw context --last-error  # a paste-ready digest for an AI agent
 mw-serve                 # local web dashboard (works headless, e.g. on a Jetson)
 ```
 
+## Storage boundary
+
+`memorywhale_cli::storage` is the only production owner of the SQLite
+connection policy and base schema. Every CLI binary opens the database through
+that module, which applies WAL mode, foreign keys, a shared busy timeout, the
+canonical tables and indexes, and numbered migrations. Table definitions and
+connection pragmas stay out of individual binaries so every entry point
+converges fresh and partially upgraded databases to the same shape.
+
 Full documentation, the web dashboard, team sharing, and AI-agent integration:
 <https://github.com/wuisabel-gif/MemWhale>.
 

--- a/crates/mw-cli/src/bin/mw-mcp.rs
+++ b/crates/mw-cli/src/bin/mw-mcp.rs
@@ -123,12 +123,7 @@ fn tool_defs() -> Value {
 }
 
 fn open() -> Result<Connection, String> {
-    let path = memorywhale_cli::database_path()?;
-    let conn =
-        Connection::open(&path).map_err(|e| format!("failed to open {}: {e}", path.display()))?;
-    // Ensure bookmarks provenance columns exist so reads below can rely on them.
-    let _ = memorywhale_cli::migrate(&conn);
-    Ok(conn)
+    memorywhale_cli::storage::open()
 }
 
 fn call_tool(name: &str, args: &Value, client_name: Option<&str>) -> Result<String, String> {
@@ -547,20 +542,14 @@ mod tests {
     #[test]
     fn similar_failures_reports_counts_and_pointer() {
         let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch(
-            "CREATE TABLE command_runs (
-                id INTEGER PRIMARY KEY, command TEXT NOT NULL, argv_json TEXT NOT NULL DEFAULT '[]',
-                cwd TEXT, exit_code INTEGER, stdout TEXT NOT NULL DEFAULT '',
-                stderr TEXT NOT NULL DEFAULT '', notes TEXT NOT NULL DEFAULT '',
-                created_at TEXT NOT NULL DEFAULT '', error_fingerprint TEXT);",
-        )
-        .unwrap();
+        memorywhale_cli::storage::initialize(&conn).unwrap();
         let err = "error[E0308]: mismatched types";
         let fp = memorywhale_cli::error_fingerprint("cargo", err).unwrap();
         let insert = |exit: i64, fp: Option<&str>| {
             conn.execute(
-                "INSERT INTO command_runs (command, cwd, exit_code, stderr, error_fingerprint)
-                 VALUES ('cargo', '/tmp/proj', ?1, ?2, ?3)",
+                "INSERT INTO command_runs
+                    (command, argv_json, cwd, exit_code, stderr, error_fingerprint, created_at)
+                 VALUES ('cargo', '[\"cargo\"]', '/tmp/proj', ?1, ?2, ?3, '')",
                 params![exit, err, fp],
             )
             .unwrap();
@@ -597,16 +586,12 @@ mod tests {
 
         // Populated: two runs, one a failure.
         let conn = Connection::open_in_memory().unwrap();
+        memorywhale_cli::storage::initialize(&conn).unwrap();
         conn.execute_batch(
-            "CREATE TABLE command_runs (
-                id INTEGER PRIMARY KEY, command TEXT NOT NULL, argv_json TEXT NOT NULL DEFAULT '[]',
-                cwd TEXT, exit_code INTEGER, stdout TEXT NOT NULL DEFAULT '',
-                stderr TEXT NOT NULL DEFAULT '', notes TEXT NOT NULL DEFAULT '',
-                created_at TEXT NOT NULL DEFAULT '', error_fingerprint TEXT);
-             INSERT INTO command_runs (command, exit_code, created_at)
-                 VALUES ('cargo build', 0, '2026-07-20T10:00:00Z');
-             INSERT INTO command_runs (command, exit_code, created_at)
-                 VALUES ('cargo build', 101, '2026-07-21T10:00:00Z');",
+            "INSERT INTO command_runs (command, argv_json, exit_code, created_at)
+                 VALUES ('cargo build', '[]', 0, '2026-07-20T10:00:00Z');
+             INSERT INTO command_runs (command, argv_json, exit_code, created_at)
+                 VALUES ('cargo build', '[]', 101, '2026-07-21T10:00:00Z');",
         )
         .unwrap();
         let v: Value = serde_json::from_str(&stats_summary(&conn, "/tmp/mw.sqlite3")).unwrap();

--- a/crates/mw-cli/src/bin/mw-recover.rs
+++ b/crates/mw-cli/src/bin/mw-recover.rs
@@ -11,7 +11,7 @@
 
 use chrono::{DateTime, Utc};
 use regex::Regex;
-use rusqlite::{params, Connection};
+use rusqlite::params;
 use std::fs;
 use std::path::PathBuf;
 use std::time::SystemTime;
@@ -68,8 +68,7 @@ pub fn recover_orphans(verbose: bool) -> Result<RecoveryReport, String> {
     if let Some(parent) = db_path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("create data dir: {e}"))?;
     }
-    let conn = Connection::open(&db_path).map_err(|e| format!("open db: {e}"))?;
-    init_schema(&conn)?;
+    let conn = memorywhale_cli::storage::open_path(&db_path)?;
 
     let mut recovered = 0;
     let mut deleted_empty = 0;
@@ -176,22 +175,6 @@ pub fn clean_transcript(input: &str) -> String {
     let s = csi.replace_all(&s, "");
     let s = s.replace('\r', "");
     ctrl.replace_all(&s, "").into_owned()
-}
-
-fn init_schema(conn: &Connection) -> Result<(), String> {
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS sessions (id INTEGER PRIMARY KEY, shell TEXT, cwd TEXT,
-            transcript_path TEXT NOT NULL DEFAULT '', transcript TEXT NOT NULL DEFAULT '',
-            notes TEXT NOT NULL DEFAULT '', started_at TEXT NOT NULL DEFAULT '',
-            ended_at TEXT NOT NULL DEFAULT '', byte_count INTEGER NOT NULL DEFAULT 0,
-            status TEXT NOT NULL DEFAULT 'finished');",
-    )
-    .map_err(|e| format!("init schema: {e}"))?;
-    let _ = conn.execute(
-        "ALTER TABLE sessions ADD COLUMN status TEXT NOT NULL DEFAULT 'finished'",
-        [],
-    );
-    Ok(())
 }
 
 fn data_base() -> Result<PathBuf, String> {

--- a/crates/mw-cli/src/bin/mw-remember.rs
+++ b/crates/mw-cli/src/bin/mw-remember.rs
@@ -112,8 +112,8 @@ fn run() -> Result<(), String> {
 /// Open the database and make sure the schema is usable.
 ///
 /// Shell hooks fire one writer per command, so several can be creating or
-/// upgrading a brand-new database at the same instant — `PRAGMA journal_mode`
-/// and `ALTER TABLE` both lose races that `busy_timeout` alone doesn't cover.
+/// upgrading a brand-new database at the same instant. Schema initialization
+/// can briefly lose a race even with the shared busy timeout.
 /// Retry briefly rather than dropping the row.
 fn open_ready(db_path: &std::path::Path) -> Result<Connection, String> {
     let mut last = String::new();
@@ -121,15 +121,8 @@ fn open_ready(db_path: &std::path::Path) -> Result<Connection, String> {
         if attempt > 0 {
             std::thread::sleep(std::time::Duration::from_millis(80 * attempt));
         }
-        let conn = match Connection::open(db_path) {
-            Ok(conn) => conn,
-            Err(err) => {
-                last = format!("failed to open db: {err}");
-                continue;
-            }
-        };
-        match init_schema(&conn).and_then(|()| memorywhale_cli::ensure_capture_kind(&conn)) {
-            Ok(()) => return Ok(conn),
+        match memorywhale_cli::storage::open_path(db_path) {
+            Ok(conn) => return Ok(conn),
             Err(err) => last = err,
         }
     }
@@ -140,43 +133,6 @@ fn print_help() {
     println!(
         "mw-remember --cwd <path> --exit-code <code> --stdout <text> --stderr <text> --notes <text> --capture-kind <full|hook> -- <command> [args...]"
     );
-}
-
-fn init_schema(conn: &Connection) -> Result<(), String> {
-    conn.execute_batch(
-        "
-        PRAGMA journal_mode = WAL;
-        -- Shell hooks fire one writer per command, so two can land at once.
-        -- Wait instead of failing: a dropped row is a silently missing memory.
-        PRAGMA busy_timeout = 3000;
-
-        CREATE TABLE IF NOT EXISTS command_runs (
-            id INTEGER PRIMARY KEY,
-            command TEXT NOT NULL,
-            argv_json TEXT NOT NULL,
-            cwd TEXT,
-            exit_code INTEGER,
-            stdout TEXT NOT NULL DEFAULT '',
-            stderr TEXT NOT NULL DEFAULT '',
-            notes TEXT NOT NULL DEFAULT '',
-            created_at TEXT NOT NULL,
-            capture_kind TEXT NOT NULL DEFAULT 'full'
-        );
-
-        CREATE TABLE IF NOT EXISTS command_arguments (
-            id INTEGER PRIMARY KEY,
-            command_run_id INTEGER NOT NULL,
-            position INTEGER NOT NULL,
-            value TEXT NOT NULL,
-            FOREIGN KEY(command_run_id) REFERENCES command_runs(id) ON DELETE CASCADE
-        );
-
-        CREATE INDEX IF NOT EXISTS idx_command_runs_command ON command_runs(command);
-        CREATE INDEX IF NOT EXISTS idx_command_runs_exit_code ON command_runs(exit_code);
-        CREATE INDEX IF NOT EXISTS idx_command_arguments_value ON command_arguments(value);
-        ",
-    )
-    .map_err(|err| format!("failed to initialize schema: {err}"))
 }
 
 fn append_environment_tags(notes: String) -> String {

--- a/crates/mw-cli/src/bin/mw-run.rs
+++ b/crates/mw-cli/src/bin/mw-run.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use rusqlite::{params, Connection};
+use rusqlite::params;
 use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
@@ -179,9 +179,7 @@ fn remember_command(
         fs::create_dir_all(parent).map_err(|err| format!("failed to create data dir: {err}"))?;
     }
 
-    let conn = Connection::open(db_path).map_err(|err| format!("failed to open db: {err}"))?;
-    init_schema(&conn)?;
-    memorywhale_cli::ensure_error_fingerprint(&conn)?;
+    let conn = memorywhale_cli::storage::open_path(&db_path)?;
     // Fingerprint failures only — a stable key that groups this error with prior
     // occurrences, so `mw context --last-error` can show its history. Computed
     // from the redacted stderr (what we store), so it matches the backfill path.
@@ -229,40 +227,6 @@ fn print_help() {
         "mw-run [--cwd <path>] [--notes <text>] -- <command> [args...]\n\
          mw-run runs a command, shows its output, and saves command/argv/cwd/exit code/stdout/stderr to MemoryWhale."
     );
-}
-
-fn init_schema(conn: &Connection) -> Result<(), String> {
-    conn.execute_batch(
-        "
-        PRAGMA journal_mode = WAL;
-        PRAGMA foreign_keys = ON;
-
-        CREATE TABLE IF NOT EXISTS command_runs (
-            id INTEGER PRIMARY KEY,
-            command TEXT NOT NULL,
-            argv_json TEXT NOT NULL,
-            cwd TEXT,
-            exit_code INTEGER,
-            stdout TEXT NOT NULL DEFAULT '',
-            stderr TEXT NOT NULL DEFAULT '',
-            notes TEXT NOT NULL DEFAULT '',
-            created_at TEXT NOT NULL
-        );
-
-        CREATE TABLE IF NOT EXISTS command_arguments (
-            id INTEGER PRIMARY KEY,
-            command_run_id INTEGER NOT NULL,
-            position INTEGER NOT NULL,
-            value TEXT NOT NULL,
-            FOREIGN KEY(command_run_id) REFERENCES command_runs(id) ON DELETE CASCADE
-        );
-
-        CREATE INDEX IF NOT EXISTS idx_command_runs_command ON command_runs(command);
-        CREATE INDEX IF NOT EXISTS idx_command_runs_exit_code ON command_runs(exit_code);
-        CREATE INDEX IF NOT EXISTS idx_command_arguments_value ON command_arguments(value);
-        ",
-    )
-    .map_err(|err| format!("failed to initialize schema: {err}"))
 }
 
 fn database_path() -> Result<PathBuf, String> {

--- a/crates/mw-cli/src/bin/mw-screenshot.rs
+++ b/crates/mw-cli/src/bin/mw-screenshot.rs
@@ -10,7 +10,7 @@
 //   mw-screenshot --command-run-id 12 --notes "Screen after failed cargo check"
 
 use chrono::Utc;
-use rusqlite::{params, Connection};
+use rusqlite::params;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -73,8 +73,7 @@ fn run() -> Result<(), String> {
         fs::create_dir_all(parent).map_err(|err| format!("failed to create data dir: {err}"))?;
     }
 
-    let conn = Connection::open(db_path).map_err(|err| format!("failed to open db: {err}"))?;
-    init_schema(&conn)?;
+    let conn = memorywhale_cli::storage::open_path(&db_path)?;
 
     if let Some(run_id) = command_run_id {
         let exists: i64 = conn
@@ -191,40 +190,6 @@ fn capture_screenshot(path: &Path) -> Result<(), String> {
         "screenshot capture failed ({last_err}); on a headless machine with no display this is expected — \
          record the terminal context with mw-remember instead"
     ))
-}
-
-fn init_schema(conn: &Connection) -> Result<(), String> {
-    conn.execute_batch(
-        "
-        PRAGMA journal_mode = WAL;
-
-        CREATE TABLE IF NOT EXISTS command_runs (
-            id INTEGER PRIMARY KEY,
-            command TEXT NOT NULL,
-            argv_json TEXT NOT NULL,
-            cwd TEXT,
-            exit_code INTEGER,
-            stdout TEXT NOT NULL DEFAULT '',
-            stderr TEXT NOT NULL DEFAULT '',
-            notes TEXT NOT NULL DEFAULT '',
-            created_at TEXT NOT NULL
-        );
-
-        CREATE TABLE IF NOT EXISTS screenshots (
-            id INTEGER PRIMARY KEY,
-            command_run_id INTEGER,
-            file_path TEXT NOT NULL,
-            cwd TEXT,
-            notes TEXT NOT NULL DEFAULT '',
-            captured_at TEXT NOT NULL,
-            FOREIGN KEY(command_run_id) REFERENCES command_runs(id) ON DELETE SET NULL
-        );
-
-        CREATE INDEX IF NOT EXISTS idx_screenshots_command_run_id ON screenshots(command_run_id);
-        CREATE INDEX IF NOT EXISTS idx_screenshots_captured_at ON screenshots(captured_at);
-        ",
-    )
-    .map_err(|err| format!("failed to initialize schema: {err}"))
 }
 
 fn memorywhale_dir() -> Result<PathBuf, String> {

--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -269,7 +269,6 @@ fn dashboard(query: &str) -> String {
             )
         }
     };
-    let _ = init_min_schema(&conn);
 
     let mut body =
         String::from("<div class=\"eyebrow\">MemoryWhale</div>\n<h1>Terminal memory</h1>\n");
@@ -853,7 +852,6 @@ fn project_page(raw_name: &str) -> String {
         Ok(c) => c,
         Err(e) => return page("Project", &format!("<p>{}</p>", esc(&e))),
     };
-    let _ = init_min_schema(&conn);
 
     let mut items: Vec<(String, String)> = Vec::new(); // (timestamp, row html)
 
@@ -946,7 +944,6 @@ fn repo_page(raw_name: &str) -> String {
         Ok(c) => c,
         Err(e) => return page("Repo", &format!("<p>{}</p>", esc(&e))),
     };
-    let _ = init_min_schema(&conn);
     let roots = discovered_repo_roots(&conn);
 
     let mut items: Vec<(String, String)> = Vec::new(); // (timestamp, row html)
@@ -1282,7 +1279,6 @@ struct Graph {
 /// commands are marked as bridges. One node per command (not per run).
 fn graph_json() -> Result<String, String> {
     let conn = open_db()?;
-    let _ = init_min_schema(&conn);
 
     let mut run_cmd: HashMap<i64, String> = HashMap::new();
     let mut cmd_count: HashMap<String, i64> = HashMap::new();
@@ -1397,7 +1393,6 @@ fn runs_page(raw: &str) -> String {
         Ok(c) => c,
         Err(e) => return page("Runs", &format!("<p>{}</p>", esc(&e))),
     };
-    let _ = init_min_schema(&conn);
 
     let mut body = String::from("<a class=\"back\" href=\"/graph\">← graph</a>\n");
     body.push_str(&format!(
@@ -1689,27 +1684,6 @@ fn session_debug_summary(transcript: &str, notes: &str) -> String {
     )
 }
 
-fn init_min_schema(conn: &Connection) -> Result<(), String> {
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS command_runs (id INTEGER PRIMARY KEY, command TEXT NOT NULL,
-            argv_json TEXT NOT NULL, cwd TEXT, exit_code INTEGER, stdout TEXT NOT NULL DEFAULT '',
-            stderr TEXT NOT NULL DEFAULT '', notes TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL);
-         CREATE TABLE IF NOT EXISTS sessions (id INTEGER PRIMARY KEY, shell TEXT, cwd TEXT,
-            transcript_path TEXT NOT NULL DEFAULT '', transcript TEXT NOT NULL DEFAULT '',
-            notes TEXT NOT NULL DEFAULT '', started_at TEXT NOT NULL DEFAULT '',
-            ended_at TEXT NOT NULL DEFAULT '', byte_count INTEGER NOT NULL DEFAULT 0,
-            status TEXT NOT NULL DEFAULT 'finished');
-         CREATE TABLE IF NOT EXISTS bookmarks (id INTEGER PRIMARY KEY, label TEXT NOT NULL,
-            cwd TEXT, created_at TEXT NOT NULL, command_run_id INTEGER, session_id INTEGER);",
-    )
-    .map_err(|e| format!("init schema: {e}"))?;
-    let _ = conn.execute(
-        "ALTER TABLE sessions ADD COLUMN status TEXT NOT NULL DEFAULT 'finished'",
-        [],
-    );
-    Ok(())
-}
-
 /// Import every session `.log` that has no row yet (interrupted recordings).
 struct RecoveryReport {
     recovered: usize,
@@ -1725,7 +1699,6 @@ fn recover_orphans() -> Result<RecoveryReport, String> {
         });
     }
     let conn = open_db()?;
-    init_min_schema(&conn)?;
 
     let mut entries: Vec<PathBuf> = fs::read_dir(&sessions_dir)
         .map_err(|e| format!("read sessions dir: {e}"))?
@@ -1822,7 +1795,7 @@ fn open_db() -> Result<Connection, String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("create data dir: {e}"))?;
     }
-    Connection::open(&path).map_err(|e| format!("open db {}: {e}", path.display()))
+    memorywhale_cli::storage::open_path(&path)
 }
 
 fn database_path() -> Result<PathBuf, String> {

--- a/crates/mw-cli/src/bin/mw-view.rs
+++ b/crates/mw-cli/src/bin/mw-view.rs
@@ -111,7 +111,6 @@ fn print_help() {
 
 fn list_all() -> Result<(), String> {
     let conn = open_db()?;
-    init_min_schema(&conn)?;
 
     println!("Sessions (open with `mw-view session <id>`):");
     let mut s = conn
@@ -497,30 +496,8 @@ fn open_in_browser(path: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn init_min_schema(conn: &Connection) -> Result<(), String> {
-    // Ensure the tables exist so `list` works on a fresh DB without erroring.
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS command_runs (id INTEGER PRIMARY KEY, command TEXT NOT NULL,
-            argv_json TEXT NOT NULL, cwd TEXT, exit_code INTEGER, stdout TEXT NOT NULL DEFAULT '',
-            stderr TEXT NOT NULL DEFAULT '', notes TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL);
-         CREATE TABLE IF NOT EXISTS sessions (id INTEGER PRIMARY KEY, shell TEXT, cwd TEXT,
-            transcript_path TEXT NOT NULL DEFAULT '', transcript TEXT NOT NULL DEFAULT '',
-            notes TEXT NOT NULL DEFAULT '', started_at TEXT NOT NULL DEFAULT '',
-            ended_at TEXT NOT NULL DEFAULT '', byte_count INTEGER NOT NULL DEFAULT 0,
-            status TEXT NOT NULL DEFAULT 'finished');",
-    )
-    .map_err(|e| format!("init schema: {e}"))?;
-    let _ = conn.execute(
-        "ALTER TABLE sessions ADD COLUMN status TEXT NOT NULL DEFAULT 'finished'",
-        [],
-    );
-    Ok(())
-}
-
 fn open_db() -> Result<Connection, String> {
-    let path = database_path()?;
-    let conn = Connection::open(&path).map_err(|e| format!("open db {}: {e}", path.display()))?;
-    Ok(conn)
+    memorywhale_cli::storage::open_path(&database_path()?)
 }
 
 fn views_dir() -> Result<PathBuf, String> {

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -729,10 +729,7 @@ fn open_session_db() -> Result<Connection, String> {
     if let Some(parent) = db_path.parent() {
         fs::create_dir_all(parent).map_err(|err| format!("failed to create data dir: {err}"))?;
     }
-    let conn = Connection::open(db_path).map_err(|err| format!("failed to open db: {err}"))?;
-    init_schema(&conn)?;
-    // Provenance (v1) + scope columns (v2) exist before any read or write.
-    memorywhale_cli::migrate(&conn)?;
+    let conn = memorywhale_cli::storage::open_path(&db_path)?;
     Ok(conn)
 }
 
@@ -1287,9 +1284,7 @@ fn show_session(args: &[String]) -> Result<(), String> {
         None => return Err("usage: mw show <id>".to_string()),
     };
 
-    let conn =
-        Connection::open(database_path()?).map_err(|err| format!("failed to open db: {err}"))?;
-    init_schema(&conn)?;
+    let conn = memorywhale_cli::storage::open()?;
 
     let row = conn.query_row(
         "SELECT started_at, cwd, notes, transcript FROM sessions WHERE id = ?1",
@@ -2971,69 +2966,6 @@ fn doctor() -> Result<(), String> {
         );
     }
 
-    Ok(())
-}
-
-fn init_schema(conn: &Connection) -> Result<(), String> {
-    conn.execute_batch(
-        "
-        PRAGMA journal_mode = WAL;
-
-        CREATE TABLE IF NOT EXISTS sessions (
-            id INTEGER PRIMARY KEY,
-            shell TEXT,
-            cwd TEXT,
-            transcript_path TEXT NOT NULL,
-            transcript TEXT NOT NULL DEFAULT '',
-            notes TEXT NOT NULL DEFAULT '',
-            started_at TEXT NOT NULL,
-            ended_at TEXT NOT NULL,
-            byte_count INTEGER NOT NULL DEFAULT 0,
-            status TEXT NOT NULL DEFAULT 'finished'
-        );
-
-        CREATE INDEX IF NOT EXISTS idx_sessions_started_at ON sessions(started_at);
-
-        CREATE TABLE IF NOT EXISTS command_runs (
-            id INTEGER PRIMARY KEY,
-            command TEXT NOT NULL,
-            argv_json TEXT NOT NULL,
-            cwd TEXT,
-            exit_code INTEGER,
-            stdout TEXT NOT NULL DEFAULT '',
-            stderr TEXT NOT NULL DEFAULT '',
-            notes TEXT NOT NULL DEFAULT '',
-            created_at TEXT NOT NULL
-        );
-
-        CREATE TABLE IF NOT EXISTS command_arguments (
-            id INTEGER PRIMARY KEY,
-            command_run_id INTEGER NOT NULL,
-            position INTEGER NOT NULL,
-            value TEXT NOT NULL,
-            FOREIGN KEY(command_run_id) REFERENCES command_runs(id) ON DELETE CASCADE
-        );
-
-        CREATE TABLE IF NOT EXISTS bookmarks (
-            id INTEGER PRIMARY KEY,
-            label TEXT NOT NULL,
-            cwd TEXT,
-            created_at TEXT NOT NULL,
-            command_run_id INTEGER,
-            session_id INTEGER
-        );
-
-        CREATE INDEX IF NOT EXISTS idx_command_runs_command ON command_runs(command);
-        CREATE INDEX IF NOT EXISTS idx_command_runs_exit_code ON command_runs(exit_code);
-        CREATE INDEX IF NOT EXISTS idx_command_arguments_value ON command_arguments(value);
-        CREATE INDEX IF NOT EXISTS idx_bookmarks_created_at ON bookmarks(created_at);
-        ",
-    )
-    .map_err(|err| format!("failed to initialize schema: {err}"))?;
-    let _ = conn.execute(
-        "ALTER TABLE sessions ADD COLUMN status TEXT NOT NULL DEFAULT 'finished'",
-        [],
-    );
     Ok(())
 }
 

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -1,6 +1,7 @@
 //! Shared helpers for the MemoryWhale CLI binaries.
 
 pub mod tui;
+pub mod storage;
 
 use chrono::Utc;
 use regex::Regex;
@@ -1029,8 +1030,7 @@ pub fn remember_as(
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("failed to create data dir: {e}"))?;
     }
-    let conn = Connection::open(&path).map_err(|e| format!("failed to open db: {e}"))?;
-    migrate(&conn)?;
+    let conn = storage::open_path(&path)?;
     let approved = if author_kind == "agent" && review_agent_memories() {
         0
     } else {

--- a/crates/mw-cli/src/storage.rs
+++ b/crates/mw-cli/src/storage.rs
@@ -1,0 +1,181 @@
+//! Canonical SQLite connection and schema ownership for every CLI surface.
+
+use rusqlite::Connection;
+use std::path::Path;
+
+/// Open MemoryWhale's default database and bring it to the current schema.
+pub fn open() -> Result<Connection, String> {
+    open_path(&crate::database_path()?)
+}
+
+/// Open a database at an explicit path and bring it to the current schema.
+pub fn open_path(path: &Path) -> Result<Connection, String> {
+    let conn =
+        Connection::open(path).map_err(|e| format!("failed to open {}: {e}", path.display()))?;
+    initialize(&conn)?;
+    Ok(conn)
+}
+
+/// Apply the connection policy and canonical base schema, then run migrations.
+///
+/// Keeping the complete latest shape here lets every binary safely open either
+/// a fresh database or one created by an older MemoryWhale release.
+pub fn initialize(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "
+        PRAGMA journal_mode = WAL;
+        PRAGMA foreign_keys = ON;
+        PRAGMA busy_timeout = 3000;
+
+        CREATE TABLE IF NOT EXISTS sessions (
+            id INTEGER PRIMARY KEY,
+            shell TEXT,
+            cwd TEXT,
+            transcript_path TEXT NOT NULL DEFAULT '',
+            transcript TEXT NOT NULL DEFAULT '',
+            notes TEXT NOT NULL DEFAULT '',
+            started_at TEXT NOT NULL DEFAULT '',
+            ended_at TEXT NOT NULL DEFAULT '',
+            byte_count INTEGER NOT NULL DEFAULT 0,
+            status TEXT NOT NULL DEFAULT 'finished',
+            project TEXT,
+            machine TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS command_runs (
+            id INTEGER PRIMARY KEY,
+            command TEXT NOT NULL,
+            argv_json TEXT NOT NULL,
+            cwd TEXT,
+            exit_code INTEGER,
+            stdout TEXT NOT NULL DEFAULT '',
+            stderr TEXT NOT NULL DEFAULT '',
+            notes TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            capture_kind TEXT NOT NULL DEFAULT 'full',
+            error_fingerprint TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS command_arguments (
+            id INTEGER PRIMARY KEY,
+            command_run_id INTEGER NOT NULL,
+            position INTEGER NOT NULL,
+            value TEXT NOT NULL,
+            FOREIGN KEY(command_run_id) REFERENCES command_runs(id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS bookmarks (
+            id INTEGER PRIMARY KEY,
+            label TEXT NOT NULL,
+            cwd TEXT,
+            created_at TEXT NOT NULL,
+            command_run_id INTEGER,
+            session_id INTEGER,
+            author_kind TEXT NOT NULL DEFAULT 'human',
+            author_name TEXT,
+            source_session_id INTEGER,
+            approved INTEGER NOT NULL DEFAULT 1
+        );
+
+        CREATE TABLE IF NOT EXISTS screenshots (
+            id INTEGER PRIMARY KEY,
+            command_run_id INTEGER,
+            file_path TEXT NOT NULL,
+            cwd TEXT,
+            notes TEXT NOT NULL DEFAULT '',
+            captured_at TEXT NOT NULL,
+            FOREIGN KEY(command_run_id) REFERENCES command_runs(id) ON DELETE SET NULL
+        );
+
+        ",
+    )
+    .map_err(|e| format!("failed to initialize database: {e}"))?;
+    crate::migrate(conn)?;
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_started_at ON sessions(started_at);
+         CREATE INDEX IF NOT EXISTS idx_command_runs_command ON command_runs(command);
+         CREATE INDEX IF NOT EXISTS idx_command_runs_exit_code ON command_runs(exit_code);
+         CREATE INDEX IF NOT EXISTS idx_command_runs_fingerprint ON command_runs(error_fingerprint);
+         CREATE INDEX IF NOT EXISTS idx_command_arguments_value ON command_arguments(value);
+         CREATE INDEX IF NOT EXISTS idx_bookmarks_created_at ON bookmarks(created_at);
+         CREATE INDEX IF NOT EXISTS idx_screenshots_command_run_id ON screenshots(command_run_id);
+         CREATE INDEX IF NOT EXISTS idx_screenshots_captured_at ON screenshots(captured_at);",
+    )
+    .map_err(|e| format!("failed to initialize database indexes: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_database_has_the_canonical_schema_and_connection_policy() {
+        let conn = Connection::open_in_memory().unwrap();
+        initialize(&conn).unwrap();
+
+        for table in [
+            "sessions",
+            "command_runs",
+            "command_arguments",
+            "bookmarks",
+            "screenshots",
+            "mempalace_sync",
+        ] {
+            let exists: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+                    [table],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(exists, 1, "missing canonical table {table}");
+        }
+        assert_eq!(
+            conn.query_row("PRAGMA foreign_keys", [], |r| r.get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            conn.query_row("PRAGMA busy_timeout", [], |r| r.get::<_, i64>(0))
+                .unwrap(),
+            3000
+        );
+        assert_eq!(
+            conn.query_row("PRAGMA user_version", [], |r| r.get::<_, i64>(0))
+                .unwrap(),
+            crate::LATEST_SCHEMA_VERSION
+        );
+    }
+
+    #[test]
+    fn legacy_partial_database_converges_without_losing_rows() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE command_runs (
+                id INTEGER PRIMARY KEY, command TEXT NOT NULL, argv_json TEXT NOT NULL,
+                cwd TEXT, exit_code INTEGER, stdout TEXT NOT NULL DEFAULT '',
+                stderr TEXT NOT NULL DEFAULT '', notes TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL
+             );
+             INSERT INTO command_runs (command, argv_json, created_at)
+             VALUES ('cargo', '[\"cargo\",\"test\"]', '2026-07-01T00:00:00Z');",
+        )
+        .unwrap();
+
+        initialize(&conn).unwrap();
+        let command: String = conn
+            .query_row("SELECT command FROM command_runs WHERE id = 1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(command, "cargo");
+        let capture_kind: String = conn
+            .query_row(
+                "SELECT capture_kind FROM command_runs WHERE id = 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(capture_kind, "full");
+    }
+}


### PR DESCRIPTION
Closes #74.

Moves SQLite connection policy and the canonical CLI schema behind one shared storage boundary.

## What changed

- Added `memorywhale_cli::storage` with:
  - default and explicit-path connection helpers;
  - WAL, foreign-key, and busy-timeout policy;
  - the complete current CLI schema and indexes;
  - migration execution for legacy databases.
- Routed `mw`, `mw-run`, `mw-remember`, `mw-screenshot`, `mw-recover`, `mw-view`, `mw-serve`, `mw-mcp`, and remembered-note writes through the shared opener.
- Removed production table definitions and connection pragmas from individual binaries.
- Updated MCP tests to seed through the canonical schema.
- Added tests for fresh databases and partially initialized legacy databases, including row preservation.
- Documented the storage boundary in the CLI crate README.

## Why

Independent `CREATE TABLE` blocks had already drifted in columns and connection settings. A database could therefore be initialized differently depending on which binary ran first. The shared boundary gives every entry point the same schema, migrations, indexes, WAL behavior, foreign-key enforcement, and lock timeout.

## Verification

- `cargo test -p memorywhale-cli`
- `git diff --check`
- confirmed no production CLI binary contains schema DDL or connection pragmas
