### PR TITLE
chore: prepare v0.7.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
-# Tag a version to cut a release:  git tag v0.2.1 && git push --tags
+# Push a matching version tag to publish. Manual runs only build dry-run
+# artifacts; they never publish a GitHub release, crates, or Homebrew updates.
 on:
   push:
     tags: ["v*"]
@@ -23,6 +24,14 @@ jobs:
           else
             scripts/check-release-version.sh
           fi
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Verify core package and CLI dependency graph
+        run: |
+          cargo package -p memorywhale-core
+          # The CLI's registry package can only resolve the new core version
+          # after publish-crate uploads it. Compile the local pair here; the
+          # publish job packages and verifies the CLI after core indexing.
+          cargo check -p memorywhale-cli --all-targets
 
   binaries:
     name: ${{ matrix.target }}
@@ -64,14 +73,15 @@ jobs:
         id: package
         shell: bash
         run: |
-          ver="${GITHUB_REF_NAME#v}"
+          ver="$(awk -F'"' '/^version = / { print $2; exit }' crates/mw-cli/Cargo.toml)"
           name="memorywhale-${ver}-${{ matrix.target }}"
           staging="$name"
           mkdir -p "$staging/bin"
           for b in mw mw-remember mw-serve mw-view mw-recover mw-run mw-screenshot mw-mcp; do
             cp "target/${{ matrix.target }}/release/$b" "$staging/bin/"
           done
-          cp README.md LICENSE "$staging/"
+          cp README.md CHANGELOG.md LICENSE "$staging/"
+          cp docs/SECURITY.md "$staging/SECURITY.md"
           cp -r linux/completions linux/man "$staging/" 2>/dev/null || true
           tar czf "$name.tar.gz" "$staging"
           echo "asset=$name.tar.gz" >> "$GITHUB_OUTPUT"
@@ -80,13 +90,15 @@ jobs:
         shell: bash
         run: |
           asset="${{ steps.package.outputs.asset }}"
-          ver="${GITHUB_REF_NAME#v}"
+          ver="$(awk -F'"' '/^version = / { print $2; exit }' crates/mw-cli/Cargo.toml)"
           root="memorywhale-${ver}-${{ matrix.target }}"
           test "$(tar tzf "$asset" | head -1)" = "$root/"
           for b in mw mw-remember mw-serve mw-view mw-recover mw-run mw-screenshot mw-mcp; do
             tar tzf "$asset" | grep -qx "$root/bin/$b"
           done
           tar tzf "$asset" | grep -qx "$root/README.md"
+          tar tzf "$asset" | grep -qx "$root/CHANGELOG.md"
+          tar tzf "$asset" | grep -qx "$root/SECURITY.md"
           tar tzf "$asset" | grep -qx "$root/LICENSE"
 
       - name: Build .deb
@@ -96,6 +108,7 @@ jobs:
           cargo deb -p memorywhale-cli --target ${{ matrix.target }} --no-build --output "memorywhale_${{ matrix.target }}.deb"
 
       - name: Upload to release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           # Auto-generate "What's Changed" notes from commits since the last
@@ -105,6 +118,16 @@ jobs:
           files: |
             ${{ steps.package.outputs.asset }}
             *.deb
+
+      - name: Upload dry-run artifacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: memorywhale-${{ matrix.target }}
+          path: |
+            ${{ steps.package.outputs.asset }}
+            *.deb
+          if-no-files-found: error
 
   # Update Formula/memorywhale.rb on main to point at the new tag, so
   # `brew install` never lags a release. Last manual release chore, automated.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,14 +92,15 @@ jobs:
           asset="${{ steps.package.outputs.asset }}"
           ver="$(awk -F'"' '/^version = / { print $2; exit }' crates/mw-cli/Cargo.toml)"
           root="memorywhale-${ver}-${{ matrix.target }}"
-          test "$(tar tzf "$asset" | head -1)" = "$root/"
+          tar tzf "$asset" > archive-contents.txt
+          test "$(head -1 archive-contents.txt)" = "$root/"
           for b in mw mw-remember mw-serve mw-view mw-recover mw-run mw-screenshot mw-mcp; do
-            tar tzf "$asset" | grep -qx "$root/bin/$b"
+            grep -Fxq "$root/bin/$b" archive-contents.txt
           done
-          tar tzf "$asset" | grep -qx "$root/README.md"
-          tar tzf "$asset" | grep -qx "$root/CHANGELOG.md"
-          tar tzf "$asset" | grep -qx "$root/SECURITY.md"
-          tar tzf "$asset" | grep -qx "$root/LICENSE"
+          grep -Fxq "$root/README.md" archive-contents.txt
+          grep -Fxq "$root/CHANGELOG.md" archive-contents.txt
+          grep -Fxq "$root/SECURITY.md" archive-contents.txt
+          grep -Fxq "$root/LICENSE" archive-contents.txt
 
       - name: Build .deb
         if: matrix.deb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## 0.7.0 (unreleased)
+
+### Security and privacy
+
+- Bind the dashboard to `127.0.0.1` by default and require authenticated,
+  explicit LAN mode for non-loopback access.
+- Move dashboard authentication out of URL query strings and into a sign-in
+  form backed by an HTTP-only cookie.
+- Add bounded output capture, retention controls, sensitive-source auditing,
+  repository-scoped deletion, restrictive local file permissions, and a
+  documented local threat model.
+
+### Memory lifecycle
+
+- Hold automatically authored conclusions for review by default.
+- Add active, stale, and superseded states while preserving original evidence.
+- Keep stale and superseded memories out of normal retrieval.
+
+### Reliability and maintainability
+
+- Centralize SQLite connection policy, schema creation, migrations, and writes.
+- Split large dashboard and frontend modules by capability.
+- Add formatting, linting, dependency auditing, frontend tests, clean-install
+  validation, release version checks, and package smoke tests.
+- Synchronize command and MCP documentation with the runtime surface.
+
+### Upgrade notes
+
+- Databases are migrated in place when first opened. Back up
+  `memorywhale.sqlite3` before upgrading if it contains important history.
+- LAN dashboard users must now opt in explicitly and configure authentication.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale-cli"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale-core"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/memorywhale-core/Cargo.toml
+++ b/crates/memorywhale-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale-core"
-version = "0.2.5"
+version = "0.3.0"
 edition = "2021"
 description = "Explainable retrieval for MemoryWhale: a MemoryEngine interface, a built-in scorer that ranks memories with per-signal reasons, and an optional MemPalace backend over MCP."
 license = "MIT"

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale-cli"
-version = "0.6.2"
+version = "0.7.0"
 description = "MemoryWhale CLI — local-first terminal memory. Record commands, sessions, and output into local SQLite; browse them in a built-in web dashboard. Nothing is uploaded."
 authors = ["Isabel Wu <wuisabel@usc.edu>"]
 license = "MIT"
@@ -21,7 +21,7 @@ dirs = "5"
 # MCP server, with a builtin fallback when that server is unreachable.
 # `version` (alongside `path`) is required so `cargo publish` can resolve the
 # dependency from crates.io — publish memorywhale-core first, then this crate.
-memorywhale-core = { path = "../memorywhale-core", version = "0.2.5", features = ["mempalace"] }
+memorywhale-core = { path = "../memorywhale-core", version = "0.3.0", features = ["mempalace"] }
 regex = "1"
 # Pure-Rust interactive terminal UI (`mw tui`) — no system libraries, so it
 # keeps the bare-machine / Jetson build story intact. Bundles crossterm.

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -47,6 +47,7 @@ fn run() -> Result<(), String> {
         Some("rm") => return rm_memory(&raw_args[1..]),
         Some("prune") => return prune_cmd(&raw_args[1..]),
         Some("audit") => return audit_cmd(),
+        Some("forget-repo") => return forget_repository_cmd(&raw_args[1..]),
         Some("share") => return share_cmd(&raw_args[1..]),
         Some("discard") => return discard_cmd(),
         Some("replay") => return replay_command(&raw_args[1..]),
@@ -274,6 +275,7 @@ fn print_help() {
          mw prune [--min-bytes N] [--dry-run]  delete empty auto-recorded sessions (noise cleanup)\n\
          mw prune --older-than <7d|24h|2w> [--dry-run]  delete sessions and command runs older than a window\n\
          mw audit                 report capture policy, retained volume, and high-volume sources\n\
+         mw forget-repo [path] [--dry-run|--yes]  preview or delete everything captured for one repository\n\
          mw status                print the effective capture mode for this directory and why\n\
          mw share [session|command] <id> [-o file]  write a self-contained HTML page to send to someone\n\
          mw discard               inside a recording: throw the current session away — nothing saved\n\
@@ -578,6 +580,93 @@ fn audit_cmd() -> Result<(), String> {
 
     println!("\nCleanup: `mw rm <id>` deletes one session and transcript; use");
     println!("`mw prune --older-than 30d --dry-run` to preview retention cleanup.");
+    Ok(())
+}
+
+/// Preview or delete every memory whose working directory is inside one
+/// repository. Actual deletion requires `--yes`; the default is a dry run.
+fn forget_repository_cmd(args: &[String]) -> Result<(), String> {
+    let mut path: Option<PathBuf> = None;
+    let mut confirmed = false;
+    for arg in args {
+        match arg.as_str() {
+            "--yes" => confirmed = true,
+            "--dry-run" => {}
+            value if value.starts_with('-') => {
+                return Err(format!(
+                    "unknown option {value:?}; usage: mw forget-repo [path] [--dry-run|--yes]"
+                ))
+            }
+            value if path.is_none() => path = Some(PathBuf::from(value)),
+            value => {
+                return Err(format!(
+                    "unexpected path {value:?}; usage: mw forget-repo [path] [--dry-run|--yes]"
+                ))
+            }
+        }
+    }
+
+    let requested = match path {
+        Some(path) if path.is_absolute() => path,
+        Some(path) => env::current_dir()
+            .map_err(|e| format!("failed to resolve current directory: {e}"))?
+            .join(path),
+        None => {
+            env::current_dir().map_err(|e| format!("failed to resolve current directory: {e}"))?
+        }
+    };
+    let root = fs::canonicalize(&requested)
+        .map_err(|e| format!("failed to resolve repository {}: {e}", requested.display()))?;
+    if !root.is_dir() {
+        return Err(format!(
+            "repository path is not a directory: {}",
+            root.display()
+        ));
+    }
+
+    let mut conn = open_session_db()?;
+    let plan = memorywhale_cli::storage::plan_repository_deletion(&conn, &root)?;
+    println!("MemoryWhale repository deletion preview");
+    println!("  repository: {}", plan.root.display());
+    println!("  sessions: {}", plan.sessions);
+    println!("  command runs: {}", plan.command_runs);
+    println!("  bookmarks: {}", plan.bookmarks);
+    println!("  screenshots: {}", plan.screenshots);
+    println!("  managed capture files: {}", plan.managed_files.len());
+
+    if plan.total_rows() == 0 {
+        println!("mw: no captured memory matched this repository.");
+        return Ok(());
+    }
+    if !confirmed {
+        println!(
+            "mw: dry run only; rerun with `mw forget-repo {} --yes` to delete these records.",
+            plan.root.display()
+        );
+        return Ok(());
+    }
+
+    memorywhale_cli::storage::execute_repository_deletion(&mut conn, &plan)?;
+    let mut file_failures = 0usize;
+    for path in &plan.managed_files {
+        match fs::remove_file(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                eprintln!("mw: warning: could not remove {}: {error}", path.display());
+                file_failures += 1;
+            }
+        }
+    }
+    println!(
+        "mw: deleted {} database row(s) and {} managed capture file(s) for {}.",
+        plan.total_rows(),
+        plan.managed_files.len().saturating_sub(file_failures),
+        plan.root.display()
+    );
+    if file_failures > 0 {
+        eprintln!("mw: warning: {file_failures} managed capture file(s) could not be removed.");
+    }
     Ok(())
 }
 

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -1782,6 +1782,30 @@ mod tests {
         dir
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn local_data_permissions_are_restricted() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = fresh_data_dir("permissions");
+        let file = dir.join("memorywhale.sqlite3");
+        std::fs::write(&file, b"fixture").unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o777)).unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o666)).unwrap();
+
+        restrict_path_permissions(&dir, true).unwrap();
+        restrict_path_permissions(&file, false).unwrap();
+
+        let dir_mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        let file_mode = std::fs::metadata(&file).unwrap().permissions().mode() & 0o777;
+        assert_eq!(dir_mode, 0o700);
+        assert_eq!(file_mode, 0o600);
+
+        std::env::remove_var("MEMORYWHALE_DATA_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn remember_writes_and_redacts() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());

--- a/crates/mw-cli/src/storage.rs
+++ b/crates/mw-cli/src/storage.rs
@@ -1,7 +1,8 @@
 //! Canonical SQLite connection and schema ownership for every CLI surface.
 
-use rusqlite::Connection;
-use std::path::Path;
+use rusqlite::{params, Connection};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 
 /// Open MemoryWhale's default database and bring it to the current schema.
 pub fn open() -> Result<Connection, String> {
@@ -104,6 +105,222 @@ pub fn initialize(conn: &Connection) -> Result<(), String> {
     .map_err(|e| format!("failed to initialize database indexes: {e}"))
 }
 
+/// Rows and managed capture files associated with one repository tree.
+#[derive(Debug)]
+pub struct RepositoryDeletionPlan {
+    pub root: PathBuf,
+    pub sessions: usize,
+    pub command_runs: usize,
+    pub bookmarks: usize,
+    pub screenshots: usize,
+    pub managed_files: Vec<PathBuf>,
+    session_ids: HashSet<i64>,
+    command_run_ids: HashSet<i64>,
+    bookmark_ids: HashSet<i64>,
+    screenshot_ids: HashSet<i64>,
+    sync_ids: HashSet<i64>,
+}
+
+impl RepositoryDeletionPlan {
+    pub fn total_rows(&self) -> usize {
+        self.sessions + self.command_runs + self.bookmarks + self.screenshots
+    }
+}
+
+fn cwd_is_within(cwd: Option<&str>, root: &Path) -> bool {
+    cwd.filter(|cwd| !cwd.is_empty())
+        .map(Path::new)
+        .is_some_and(|cwd| {
+            let resolved = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+            resolved == root || resolved.starts_with(root)
+        })
+}
+
+/// Preview every local-memory row associated with `root`.
+///
+/// Linked bookmarks and screenshots are included even when their own `cwd` is
+/// empty. Only transcript and screenshot paths inside MemoryWhale's data
+/// directory are returned as managed files, so a tampered database cannot turn
+/// repository cleanup into arbitrary file deletion.
+pub fn plan_repository_deletion(
+    conn: &Connection,
+    root: &Path,
+) -> Result<RepositoryDeletionPlan, String> {
+    let mut session_ids = HashSet::new();
+    let mut command_run_ids = HashSet::new();
+    let mut bookmark_ids = HashSet::new();
+    let mut screenshot_ids = HashSet::new();
+    let mut managed_files = Vec::new();
+    let data_dir = crate::data_dir()?;
+
+    let mut session_stmt = conn
+        .prepare("SELECT id, cwd, transcript_path FROM sessions")
+        .map_err(|e| format!("failed to inspect sessions: {e}"))?;
+    let sessions = session_stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })
+        .map_err(|e| format!("failed to inspect sessions: {e}"))?;
+    for row in sessions {
+        let (id, cwd, transcript_path) = row.map_err(|e| format!("failed to read session: {e}"))?;
+        if cwd_is_within(cwd.as_deref(), root) {
+            session_ids.insert(id);
+            if let Some(path) = transcript_path
+                .filter(|path| !path.is_empty())
+                .map(PathBuf::from)
+                .filter(|path| path.starts_with(&data_dir))
+            {
+                managed_files.push(path);
+            }
+        }
+    }
+
+    let mut command_stmt = conn
+        .prepare("SELECT id, cwd FROM command_runs")
+        .map_err(|e| format!("failed to inspect command runs: {e}"))?;
+    let commands = command_stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, Option<String>>(1)?))
+        })
+        .map_err(|e| format!("failed to inspect command runs: {e}"))?;
+    for row in commands {
+        let (id, cwd) = row.map_err(|e| format!("failed to read command run: {e}"))?;
+        if cwd_is_within(cwd.as_deref(), root) {
+            command_run_ids.insert(id);
+        }
+    }
+
+    let mut bookmark_stmt = conn
+        .prepare("SELECT id, cwd, command_run_id, session_id FROM bookmarks")
+        .map_err(|e| format!("failed to inspect bookmarks: {e}"))?;
+    let bookmarks = bookmark_stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+                row.get::<_, Option<i64>>(3)?,
+            ))
+        })
+        .map_err(|e| format!("failed to inspect bookmarks: {e}"))?;
+    for row in bookmarks {
+        let (id, cwd, command_run_id, session_id) =
+            row.map_err(|e| format!("failed to read bookmark: {e}"))?;
+        if cwd_is_within(cwd.as_deref(), root)
+            || command_run_id.is_some_and(|id| command_run_ids.contains(&id))
+            || session_id.is_some_and(|id| session_ids.contains(&id))
+        {
+            bookmark_ids.insert(id);
+        }
+    }
+
+    let mut screenshot_stmt = conn
+        .prepare("SELECT id, cwd, command_run_id, file_path FROM screenshots")
+        .map_err(|e| format!("failed to inspect screenshots: {e}"))?;
+    let screenshots = screenshot_stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })
+        .map_err(|e| format!("failed to inspect screenshots: {e}"))?;
+    for row in screenshots {
+        let (id, cwd, command_run_id, file_path) =
+            row.map_err(|e| format!("failed to read screenshot: {e}"))?;
+        if cwd_is_within(cwd.as_deref(), root)
+            || command_run_id.is_some_and(|id| command_run_ids.contains(&id))
+        {
+            screenshot_ids.insert(id);
+            let path = PathBuf::from(file_path);
+            if path.starts_with(&data_dir) {
+                managed_files.push(path);
+            }
+        }
+    }
+
+    let mut sync_ids = HashSet::new();
+    let mut sync_stmt = conn
+        .prepare("SELECT mw_id FROM mempalace_sync")
+        .map_err(|e| format!("failed to inspect sync mappings: {e}"))?;
+    let mappings = sync_stmt
+        .query_map([], |row| row.get::<_, i64>(0))
+        .map_err(|e| format!("failed to inspect sync mappings: {e}"))?;
+    for mapping in mappings {
+        let mw_id = mapping.map_err(|e| format!("failed to read sync mapping: {e}"))?;
+        let (source, id) = memorywhale_core::sqlite::decode_id(mw_id);
+        let selected = match source {
+            memorywhale_core::sqlite::Source::Command => command_run_ids.contains(&id),
+            memorywhale_core::sqlite::Source::Note => bookmark_ids.contains(&id),
+            memorywhale_core::sqlite::Source::Session => session_ids.contains(&id),
+            _ => false,
+        };
+        if selected {
+            sync_ids.insert(mw_id);
+        }
+    }
+
+    managed_files.sort();
+    managed_files.dedup();
+    Ok(RepositoryDeletionPlan {
+        root: root.to_path_buf(),
+        sessions: session_ids.len(),
+        command_runs: command_run_ids.len(),
+        bookmarks: bookmark_ids.len(),
+        screenshots: screenshot_ids.len(),
+        managed_files,
+        session_ids,
+        command_run_ids,
+        bookmark_ids,
+        screenshot_ids,
+        sync_ids,
+    })
+}
+
+/// Delete a previously reviewed repository plan in one database transaction.
+pub fn execute_repository_deletion(
+    conn: &mut Connection,
+    plan: &RepositoryDeletionPlan,
+) -> Result<(), String> {
+    let transaction = conn
+        .transaction()
+        .map_err(|e| format!("failed to start repository deletion: {e}"))?;
+    for id in &plan.sync_ids {
+        transaction
+            .execute("DELETE FROM mempalace_sync WHERE mw_id = ?1", params![id])
+            .map_err(|e| format!("failed to delete sync mapping: {e}"))?;
+    }
+    for id in &plan.screenshot_ids {
+        transaction
+            .execute("DELETE FROM screenshots WHERE id = ?1", params![id])
+            .map_err(|e| format!("failed to delete screenshot: {e}"))?;
+    }
+    for id in &plan.bookmark_ids {
+        transaction
+            .execute("DELETE FROM bookmarks WHERE id = ?1", params![id])
+            .map_err(|e| format!("failed to delete bookmark: {e}"))?;
+    }
+    for id in &plan.command_run_ids {
+        transaction
+            .execute("DELETE FROM command_runs WHERE id = ?1", params![id])
+            .map_err(|e| format!("failed to delete command run: {e}"))?;
+    }
+    for id in &plan.session_ids {
+        transaction
+            .execute("DELETE FROM sessions WHERE id = ?1", params![id])
+            .map_err(|e| format!("failed to delete session: {e}"))?;
+    }
+    transaction
+        .commit()
+        .map_err(|e| format!("failed to commit repository deletion: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,5 +394,241 @@ mod tests {
             )
             .unwrap();
         assert_eq!(capture_kind, "full");
+    }
+
+    #[test]
+    fn v0_6_2_database_upgrades_without_data_loss() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE sessions (
+                id INTEGER PRIMARY KEY,
+                shell TEXT,
+                cwd TEXT,
+                transcript_path TEXT NOT NULL DEFAULT '',
+                transcript TEXT NOT NULL DEFAULT '',
+                notes TEXT NOT NULL DEFAULT '',
+                started_at TEXT NOT NULL DEFAULT '',
+                ended_at TEXT NOT NULL DEFAULT '',
+                byte_count INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'finished',
+                project TEXT,
+                machine TEXT
+            );
+            CREATE TABLE command_runs (
+                id INTEGER PRIMARY KEY,
+                command TEXT NOT NULL,
+                argv_json TEXT NOT NULL,
+                cwd TEXT,
+                exit_code INTEGER,
+                stdout TEXT NOT NULL DEFAULT '',
+                stderr TEXT NOT NULL DEFAULT '',
+                notes TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL,
+                capture_kind TEXT NOT NULL DEFAULT 'full',
+                error_fingerprint TEXT
+            );
+            CREATE TABLE command_arguments (
+                id INTEGER PRIMARY KEY,
+                command_run_id INTEGER NOT NULL,
+                position INTEGER NOT NULL,
+                value TEXT NOT NULL,
+                FOREIGN KEY(command_run_id) REFERENCES command_runs(id) ON DELETE CASCADE
+            );
+            CREATE TABLE bookmarks (
+                id INTEGER PRIMARY KEY,
+                label TEXT NOT NULL,
+                cwd TEXT,
+                created_at TEXT NOT NULL,
+                command_run_id INTEGER,
+                session_id INTEGER,
+                author_kind TEXT NOT NULL DEFAULT 'human',
+                author_name TEXT,
+                source_session_id INTEGER,
+                approved INTEGER NOT NULL DEFAULT 1
+            );
+            CREATE TABLE screenshots (
+                id INTEGER PRIMARY KEY,
+                command_run_id INTEGER,
+                file_path TEXT NOT NULL,
+                cwd TEXT,
+                notes TEXT NOT NULL DEFAULT '',
+                captured_at TEXT NOT NULL,
+                FOREIGN KEY(command_run_id) REFERENCES command_runs(id) ON DELETE SET NULL
+            );
+            CREATE TABLE mempalace_sync (
+                mw_id INTEGER PRIMARY KEY,
+                wing TEXT NOT NULL,
+                drawer_id TEXT NOT NULL,
+                content_hash TEXT NOT NULL,
+                synced_at TEXT NOT NULL
+            );
+
+            INSERT INTO sessions
+                (id, shell, cwd, transcript_path, transcript, notes, started_at,
+                 ended_at, byte_count, status, project, machine)
+            VALUES
+                (11, 'zsh', '/work/project', '/tmp/session.log',
+                 'cargo test failed, then passed', 'project:upgrade-test',
+                 '2026-07-20T10:00:00Z', '2026-07-20T10:05:00Z', 30,
+                 'finished', 'upgrade-test', 'laptop');
+            INSERT INTO command_runs
+                (id, command, argv_json, cwd, exit_code, stdout, stderr, notes,
+                 created_at, capture_kind, error_fingerprint)
+            VALUES
+                (12, 'cargo', '[\"cargo\",\"test\"]', '/work/project', 1, '',
+                 'linker failed', 'before upgrade',
+                 '2026-07-20T10:01:00Z', 'full', 'linker-fingerprint');
+            INSERT INTO command_arguments
+                (id, command_run_id, position, value)
+            VALUES (13, 12, 0, 'test');
+            INSERT INTO bookmarks
+                (id, label, cwd, created_at, command_run_id, session_id,
+                 author_kind, author_name, source_session_id, approved)
+            VALUES
+                (14, 'install the linker before building', '/work/project',
+                 '2026-07-20T10:02:00Z', 12, 11, 'human', NULL, NULL, 1);
+            INSERT INTO screenshots
+                (id, command_run_id, file_path, cwd, notes, captured_at)
+            VALUES
+                (15, 12, '/tmp/failure.png', '/work/project', 'failure state',
+                 '2026-07-20T10:03:00Z');
+            INSERT INTO mempalace_sync
+                (mw_id, wing, drawer_id, content_hash, synced_at)
+            VALUES
+                (16, 'terminal', 'drawer-16', 'abc123',
+                 '2026-07-20T10:04:00Z');
+            PRAGMA user_version = 5;
+            ",
+        )
+        .unwrap();
+
+        initialize(&conn).unwrap();
+
+        assert_eq!(
+            conn.query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            crate::LATEST_SCHEMA_VERSION
+        );
+        let lifecycle: (String, Option<i64>) = conn
+            .query_row(
+                "SELECT status, superseded_by_id FROM bookmarks WHERE id = 14",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(lifecycle, ("active".to_string(), None));
+
+        for (table, expected) in [
+            ("sessions", 1_i64),
+            ("command_runs", 1),
+            ("command_arguments", 1),
+            ("bookmarks", 1),
+            ("screenshots", 1),
+            ("mempalace_sync", 1),
+        ] {
+            let count: i64 = conn
+                .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                    row.get(0)
+                })
+                .unwrap();
+            assert_eq!(count, expected, "{table} rows changed during upgrade");
+        }
+
+        let memories = memorywhale_core::sqlite::load_memories(&conn);
+        assert!(
+            memories
+                .iter()
+                .any(|memory| memory.text.contains("install the linker")),
+            "the released bookmark remains retrievable after migration"
+        );
+        assert!(
+            memories
+                .iter()
+                .any(|memory| memory.text.contains("linker failed")),
+            "the released command failure remains retrievable after migration"
+        );
+
+        initialize(&conn).unwrap();
+        let bookmark_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM bookmarks", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(bookmark_count, 1, "reopening the upgraded DB is idempotent");
+    }
+
+    #[test]
+    fn repository_deletion_is_scoped_and_removes_linked_rows() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        initialize(&conn).unwrap();
+        let managed_transcript = crate::data_dir().unwrap().join("sessions/repo.log");
+        conn.execute_batch(&format!(
+            "
+            INSERT INTO sessions
+                (id, cwd, transcript_path, transcript, started_at, ended_at)
+            VALUES
+                (1, '/work/repo', '{}', 'secret session', '2026-07-20T10:00:00Z',
+                 '2026-07-20T10:01:00Z'),
+                (2, '/work/repo-other', '/tmp/keep.log', 'keep session',
+                 '2026-07-20T10:00:00Z', '2026-07-20T10:01:00Z');
+            INSERT INTO command_runs
+                (id, command, argv_json, cwd, created_at)
+            VALUES
+                (3, 'cargo', '[\"cargo\"]', '/work/repo/crate',
+                 '2026-07-20T10:00:00Z'),
+                (4, 'git', '[\"git\"]', '/work/repo-other',
+                 '2026-07-20T10:00:00Z');
+            INSERT INTO command_arguments
+                (command_run_id, position, value)
+            VALUES (3, 0, 'test'), (4, 0, 'status');
+            INSERT INTO bookmarks
+                (id, label, cwd, created_at, command_run_id, session_id)
+            VALUES
+                (5, 'linked secret', NULL, '2026-07-20T10:00:00Z', 3, 1),
+                (6, 'keep note', '/work/repo-other', '2026-07-20T10:00:00Z', 4, 2);
+            INSERT INTO screenshots
+                (id, command_run_id, file_path, cwd, captured_at)
+            VALUES
+                (7, 3, '/tmp/outside-data-dir.png', NULL, '2026-07-20T10:00:00Z'),
+                (8, 4, '/tmp/keep.png', '/work/repo-other', '2026-07-20T10:00:00Z');
+            INSERT INTO mempalace_sync
+                (mw_id, wing, drawer_id, content_hash, synced_at)
+            VALUES
+                (1000000003, 'terminal', 'run-3', 'a', '2026-07-20T10:00:00Z'),
+                (3000000005, 'terminal', 'note-5', 'b', '2026-07-20T10:00:00Z'),
+                (4000000001, 'terminal', 'session-1', 'c', '2026-07-20T10:00:00Z'),
+                (1000000004, 'terminal', 'run-4', 'd', '2026-07-20T10:00:00Z');
+            ",
+            managed_transcript.display()
+        ))
+        .unwrap();
+
+        let plan = plan_repository_deletion(&conn, Path::new("/work/repo")).unwrap();
+        assert_eq!(plan.sessions, 1);
+        assert_eq!(plan.command_runs, 1);
+        assert_eq!(plan.bookmarks, 1);
+        assert_eq!(plan.screenshots, 1);
+        assert_eq!(plan.total_rows(), 4);
+        assert_eq!(plan.managed_files, vec![managed_transcript]);
+        execute_repository_deletion(&mut conn, &plan).unwrap();
+
+        for table in [
+            "sessions",
+            "command_runs",
+            "command_arguments",
+            "bookmarks",
+            "screenshots",
+            "mempalace_sync",
+        ] {
+            let count: i64 = conn
+                .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                    row.get(0)
+                })
+                .unwrap();
+            assert_eq!(count, 1, "unrelated {table} row should remain");
+        }
+        let cwd: String = conn
+            .query_row("SELECT cwd FROM sessions", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(cwd, "/work/repo-other", "prefix collisions must not match");
     }
 }

--- a/crates/mw-cli/tests/privacy.rs
+++ b/crates/mw-cli/tests/privacy.rs
@@ -65,3 +65,69 @@ fn command_capture_stdout_stderr_is_redacted_in_db() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn repository_cleanup_previews_then_deletes_only_the_selected_tree() {
+    let dir = std::env::temp_dir().join(format!("mw-forget-repo-{}", std::process::id()));
+    let repo = dir.join("repo");
+    let other = dir.join("repo-other");
+    let data = dir.join("data");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::create_dir_all(&other).unwrap();
+    std::fs::create_dir_all(&data).unwrap();
+
+    for (cwd, command) in [(&repo, "cargo"), (&other, "git")] {
+        let out = Command::new(env!("CARGO_BIN_EXE_mw-remember"))
+            .env("MEMORYWHALE_DATA_DIR", &data)
+            .args([
+                "--cwd",
+                cwd.to_str().unwrap(),
+                "--exit-code",
+                "0",
+                "--",
+                command,
+            ])
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "mw-remember failed: {out:?}");
+    }
+
+    let preview = Command::new(env!("CARGO_BIN_EXE_mw"))
+        .env("MEMORYWHALE_DATA_DIR", &data)
+        .args(["forget-repo", repo.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(preview.status.success(), "preview failed: {preview:?}");
+    assert!(
+        String::from_utf8_lossy(&preview.stdout).contains("dry run only"),
+        "unexpected preview output: stdout={} stderr={}",
+        String::from_utf8_lossy(&preview.stdout),
+        String::from_utf8_lossy(&preview.stderr)
+    );
+    let conn = Connection::open(data.join("memorywhale.sqlite3")).unwrap();
+    let before: i64 = conn
+        .query_row("SELECT COUNT(*) FROM command_runs", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(before, 2, "preview must not delete data");
+    drop(conn);
+
+    let deletion = Command::new(env!("CARGO_BIN_EXE_mw"))
+        .env("MEMORYWHALE_DATA_DIR", &data)
+        .args(["forget-repo", repo.to_str().unwrap(), "--yes"])
+        .output()
+        .unwrap();
+    assert!(deletion.status.success(), "deletion failed: {deletion:?}");
+
+    let conn = Connection::open(data.join("memorywhale.sqlite3")).unwrap();
+    let remaining: Vec<String> = conn
+        .prepare("SELECT cwd FROM command_runs")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(remaining, vec![other.to_string_lossy().into_owned()]);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -21,6 +21,7 @@ mw replay 12                          # rerun a saved command run
 mw demo                               # seed a small demo dataset to explore
 mw rm 5                               # delete a session (+ its transcript); mw rm command <id> for a run
 mw prune [--min-bytes N] [--dry-run]  # delete empty auto-recorded sessions (noise cleanup)
+mw forget-repo [path] [--dry-run|--yes] # preview/delete everything captured under one repository
 mw memory stale <id>                  # retire an outdated lesson, preserving its row
 mw memory supersede <old> <new>       # replace an old lesson with a newer one
 mw audit                              # inspect capture policy and retained volume

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -29,6 +29,9 @@ need the same protection as shell history or an unencrypted developer backup.
   highest-volume session sources.
 - Use `mw rm` for individual deletion and `mw prune --older-than <window>` for
   retention cleanup. Preview bulk cleanup with `--dry-run`.
+- Use `mw forget-repo [path]` to preview everything associated with one
+  repository tree, then repeat with `--yes` to remove its sessions, commands,
+  bookmarks, screenshots, sync mappings, and managed capture files.
 
 For a sensitive repository, prefer preventing capture over relying on
 redaction or later deletion.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorywhale",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorywhale",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorywhale",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -5,6 +5,12 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root"
 
 cli_version="$(awk -F'"' '/^version = / { print $2; exit }' crates/mw-cli/Cargo.toml)"
+core_version="$(awk -F'"' '/^version = / { print $2; exit }' crates/memorywhale-core/Cargo.toml)"
+cli_core_version="$(
+  sed -n 's/.*memorywhale-core = {[^}]*version = "\([^"]*\)".*/\1/p' \
+    crates/mw-cli/Cargo.toml
+)"
+desktop_version="$(awk -F'"' '/^version = / { print $2; exit }' src-tauri/Cargo.toml)"
 package_version="$(node -p "require('./package.json').version")"
 lock_version="$(node -p "require('./package-lock.json').version")"
 tauri_version="$(node -p "require('./src-tauri/tauri.conf.json').version")"
@@ -12,6 +18,7 @@ tauri_version="$(node -p "require('./src-tauri/tauri.conf.json').version")"
 failed=0
 for entry in \
   "crates/mw-cli/Cargo.toml:$cli_version" \
+  "src-tauri/Cargo.toml:$desktop_version" \
   "package.json:$package_version" \
   "package-lock.json:$lock_version" \
   "src-tauri/tauri.conf.json:$tauri_version"
@@ -23,6 +30,12 @@ do
     failed=1
   fi
 done
+
+if [[ -z "$core_version" || "$cli_core_version" != "$core_version" ]]; then
+  echo "core version mismatch: crates/memorywhale-core/Cargo.toml is $core_version; \
+crates/mw-cli/Cargo.toml requires ${cli_core_version:-<missing>}" >&2
+  failed=1
+fi
 
 if [[ $# -gt 0 ]]; then
   expected="${1#v}"
@@ -36,4 +49,4 @@ if [[ "$failed" -ne 0 ]]; then
   exit 1
 fi
 
-echo "release version $cli_version is consistent"
+echo "release version $cli_version is consistent (memorywhale-core $core_version)"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale"
-version = "0.6.2"
+version = "0.7.0"
 description = "A Rust/Tauri visual second brain for local knowledge graphs"
 authors = ["MemoryWhale"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MemoryWhale",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "identifier": "com.memorywhale.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- bump the desktop and CLI product version to `0.7.0` and `memorywhale-core` to `0.3.0`
- enforce product-version consistency and the CLI/core dependency relationship
- make manual release runs upload dry-run artifacts without publishing releases, crates, or Homebrew changes
- package the core crate during preflight and preserve core-first registry publishing
- add a populated v0.6.2 database upgrade regression test and Unix permission coverage
- add guarded repository-scoped deletion with preview-by-default behavior and an explicit `--yes` confirmation
- include curated changelog, security guidance, and release-package documentation

## Why

The changes since v0.6.2 include security defaults, database migrations, lifecycle behavior, and new release gates. Preparing them as v0.7.0 avoids reusing published crate versions, validates the released database upgrade path, and makes it possible to exercise release packaging without accidentally publishing.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p memorywhale-core -p memorywhale-cli --all-targets -- -D warnings`
- `cargo test -p memorywhale-core -p memorywhale-cli`
- `npm test`
- `npm run build`
- `cargo build --workspace`
- `cargo package -p memorywhale-core --allow-dirty`
- `cargo check -p memorywhale-cli --all-targets`
- `scripts/check-release-version.sh v0.7.0`
- `scripts/check-doc-references.sh`

This PR does not create or push a release tag.
