### PR TITLE
integrations: add OpenClaw MCP setup recipe

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -27,6 +27,7 @@ file differs. Per-client setup (config + a "when to use it" rule):
 - **VS Code / GitHub Copilot** (agent mode) → [`vscode/`](vscode/README.md)
 - **Windsurf** → [`windsurf/`](windsurf/README.md)
 - **Codex CLI** → [`codex/`](codex/README.md)
+- **OpenClaw** → [`openclaw/`](openclaw/README.md)
 - **Any other MCP client** (Zed, Cline, Continue, …) — add a stdio server whose
   command is `mw-mcp` (no arguments). It honours `MEMORYWHALE_DATA_DIR` like the
   rest of the CLI.

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,0 +1,52 @@
+# OpenClaw integration
+
+[OpenClaw](https://github.com/openclaw/openclaw) agents connect to MCP servers,
+so they get MemoryWhale's four tools: `recent_errors`, `search_memory`,
+`get_context`, `remember`.
+
+## Connect the MCP server
+
+`mw-mcp` is a Model Context Protocol server over stdio. Register it with the CLI:
+
+```bash
+openclaw mcp add memorywhale --command mw-mcp
+openclaw mcp doctor memorywhale --probe
+```
+
+The probe matters — saving a definition proves nothing about reachability.
+
+Or write it straight into config. Merge the block from
+[`openclaw.mcp.json5`](openclaw.mcp.json5) into `~/.openclaw/openclaw.json`
+(OpenClaw accepts JSON5):
+
+```json5
+{
+  mcp: {
+    servers: {
+      memorywhale: { command: "mw-mcp", enabled: true },
+    },
+  },
+}
+```
+
+`mw-mcp` must be on `PATH` (the standard MemoryWhale install); otherwise use its
+absolute path as `command`. For a non-default database add
+`env: { MEMORYWHALE_DATA_DIR: "/path/to/dir" }`. A running Gateway may need a
+restart or runtime reload before it picks up a config-file change.
+
+## Tell it when to reach for the memory
+
+The MCP server gives OpenClaw the *tools*; a workspace instruction teaches it
+*when* to reach for them. OpenClaw agents read an `AGENTS.md` from their
+workspace (default `~/.openclaw/workspace/AGENTS.md`). Add:
+
+> When a build/test/deploy fails, before proposing a fix, use `search_memory`
+> or `recent_errors` (MemoryWhale MCP) to check whether this failure has a known
+> cause or a saved lesson. Once you've figured out why something failed or how a
+> fix worked, use `remember` to save that conclusion.
+
+## Without the MCP server
+
+The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+`mw remember "…"`. And with no integration at all, `mw ask` packages the last
+failure onto your clipboard for any chat.

--- a/integrations/openclaw/openclaw.mcp.json5
+++ b/integrations/openclaw/openclaw.mcp.json5
@@ -1,0 +1,19 @@
+// Merge this block into your OpenClaw config (`~/.openclaw/openclaw.json`, JSON5
+// is accepted) to give OpenClaw agents access to MemoryWhale's memory via MCP
+// (tools: recent_errors, search_memory, get_context, remember).
+//
+// `mw-mcp` must be on PATH (the standard MemoryWhale install); otherwise use its
+// absolute path as `command`. For a non-default database, add:
+//   env: { MEMORYWHALE_DATA_DIR: "/path/to/dir" }
+//
+// Equivalent one-liner:  openclaw mcp add memorywhale --command mw-mcp
+{
+  mcp: {
+    servers: {
+      memorywhale: {
+        command: "mw-mcp",
+        enabled: true,
+      },
+    },
+  },
+}


### PR DESCRIPTION
## What

Adds `integrations/openclaw/` — a setup recipe for the [OpenClaw](https://github.com/openclaw/openclaw) agent, and lists it in `integrations/README.md`.

## Why

OpenClaw connects to MCP servers, so `mw-mcp` plugs in with **no new code** — OpenClaw agents get the same four tools every other client gets: `recent_errors`, `search_memory`, `get_context`, `remember`. It's the one MCP-speaking agent missing from the integrations list.

## What's in it

- `integrations/openclaw/README.md` — connect the MCP server (CLI `openclaw mcp add` or a `mcp.servers` config block), plus the "when to use it" instruction for the workspace `AGENTS.md`. Mirrors the Codex recipe.
- `integrations/openclaw/openclaw.mcp.json5` — the `mcp.servers` block to merge into `~/.openclaw/openclaw.json`.
- One line added to `integrations/README.md`.

## Verified against OpenClaw

The `openclaw mcp add memorywhale --command mw-mcp` command, the `mcp.servers` config shape, and the workspace `AGENTS.md` instruction hook were all checked against a local OpenClaw build and its `docs/tools/mcp.md`.