### PR TITLE
integrations: add CrowClaw MCP setup recipe

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -28,6 +28,7 @@ file differs. Per-client setup (config + a "when to use it" rule):
 - **Windsurf** → [`windsurf/`](windsurf/README.md)
 - **Codex CLI** → [`codex/`](codex/README.md)
 - **OpenClaw** → [`openclaw/`](openclaw/README.md)
+- **CrowClaw** → [`crowclaw/`](crowclaw/README.md)
 - **Goose** (Block) → [`goose/`](goose/README.md)
 - **Claude Desktop** → [`claude-desktop/`](claude-desktop/README.md)
 - **Cline** (VS Code) → [`cline/`](cline/README.md)

--- a/integrations/crowclaw/README.md
+++ b/integrations/crowclaw/README.md
@@ -1,0 +1,59 @@
+# CrowClaw integration
+
+[CrowClaw](https://github.com/subinium/CrowClaw) is a TypeScript agent runtime,
+and its agents connect to MCP servers — so it gets MemoryWhale's four tools:
+`recent_errors`, `search_memory`, `get_context`, `remember`.
+
+## Connect the MCP server
+
+CrowClaw supports custom (non-preset) MCP servers. Add MemoryWhale as one.
+
+**From the dashboard:** open the CrowClaw dashboard → **MCP** → **Add server**,
+and enter:
+
+| Field | Value |
+| --- | --- |
+| Name | `memorywhale` |
+| Command | `mw-mcp` |
+| Args | *(none)* |
+
+**Or via the REST API** the dashboard uses — post the block from
+[`server.json`](server.json) to `/api/mcp/servers`:
+
+```json
+{
+  "name": "memorywhale",
+  "command": "mw-mcp",
+  "args": [],
+  "custom": true
+}
+```
+
+Either way the definition is persisted under `~/.crowclaw/`. `mw-mcp` must be on
+`PATH` (the standard MemoryWhale install); otherwise use its absolute path as
+`command`. For a non-default database add
+`"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`.
+
+Verify the server answers and its tools were discovered:
+
+```
+GET /api/mcp/servers/memorywhale/tools
+```
+
+(or use the dashboard's per-server reconnect/tools view). You should see the
+four tools listed.
+
+## Tell it when to reach for the memory
+
+The MCP server gives CrowClaw the *tools*; a preset's `systemPromptAppend` (or
+your agent's system prompt) teaches it *when* to reach for them:
+
+> When a build/test/deploy fails, before proposing a fix, use `search_memory`
+> or `recent_errors` (MemoryWhale MCP) to check whether this failure has a known
+> cause or a saved lesson. Once you've figured out why something failed or how a
+> fix worked, use `remember` to save that conclusion.
+
+## Without the MCP server
+
+The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+`mw remember "…"`.

--- a/integrations/crowclaw/server.json
+++ b/integrations/crowclaw/server.json
@@ -1,0 +1,6 @@
+{
+  "name": "memorywhale",
+  "command": "mw-mcp",
+  "args": [],
+  "custom": true
+}


### PR DESCRIPTION
## What

Adds `integrations/crowclaw/` — a setup recipe for [CrowClaw](https://github.com/subinium/CrowClaw), a TypeScript agent runtime — and lists it in `integrations/README.md`.

## Why

CrowClaw agents connect to MCP servers, so `mw-mcp` plugs in with **no new code** — CrowClaw gets the same four tools every other client gets: `recent_errors`, `search_memory`, `get_context`, `remember`.

## What's in it

- `integrations/crowclaw/README.md` — register MemoryWhale as a custom MCP server (dashboard or `POST /api/mcp/servers`), verify via the per-server tools endpoint, plus the "when to use it" instruction for a preset's `systemPromptAppend`.
- `integrations/crowclaw/server.json` — the custom-server config block.
- One line added to `integrations/README.md`.

## Verification

Checked against CrowClaw source (v0.9.0):
- Custom (non-preset) MCP servers are supported — `McpServerConfig { name, command, args, env?, custom }`, persisted under `~/.crowclaw/`, added via the dashboard's `/api/mcp/servers` API.
- CrowClaw's stdio transport uses newline-delimited JSON-RPC with protocol `2024-11-05` — the exact framing/handshake `mw-mcp` already responds to (confirmed in the OpenClaw integration's live probe).

Verified at the protocol + config-shape level from source. A full end-to-end run through the CrowClaw runtime + dashboard (needs a model provider key) was not performed.