### PR TITLE
integrations: add Goose and Claude Desktop MCP recipes

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -28,6 +28,8 @@ file differs. Per-client setup (config + a "when to use it" rule):
 - **Windsurf** → [`windsurf/`](windsurf/README.md)
 - **Codex CLI** → [`codex/`](codex/README.md)
 - **OpenClaw** → [`openclaw/`](openclaw/README.md)
+- **Goose** (Block) → [`goose/`](goose/README.md)
+- **Claude Desktop** → [`claude-desktop/`](claude-desktop/README.md)
 - **Any other MCP client** (Zed, Cline, Continue, …) — add a stdio server whose
   command is `mw-mcp` (no arguments). It honours `MEMORYWHALE_DATA_DIR` like the
   rest of the CLI.

--- a/integrations/claude-desktop/README.md
+++ b/integrations/claude-desktop/README.md
@@ -1,0 +1,42 @@
+# Claude Desktop integration
+
+[Claude Desktop](https://claude.ai/download) is Anthropic's desktop app and the
+reference MCP host. Point it at MemoryWhale's MCP server and it gets the four
+tools: `recent_errors`, `search_memory`, `get_context`, `remember`.
+
+(This is the desktop app. For the Claude Code CLI, see
+[`../claude-code/`](../claude-code/).)
+
+## Connect the MCP server
+
+Edit Claude Desktop's config file:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the `memorywhale` entry from
+[`claude_desktop_config.json`](claude_desktop_config.json):
+
+```json
+{
+  "mcpServers": {
+    "memorywhale": {
+      "command": "mw-mcp"
+    }
+  }
+}
+```
+
+If the file already has an `mcpServers` object, add `memorywhale` alongside your
+other servers rather than replacing it. Then **fully restart Claude Desktop**
+(quit and reopen) — it reads MCP config only at launch.
+
+`mw-mcp` must be on `PATH` (the standard MemoryWhale install); otherwise use its
+absolute path as `command`. For a non-default database add
+`"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`. After restart, the tools
+appear under the 🔌/tools menu in the composer.
+
+## Without the MCP server
+
+The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+`mw remember "…"`.

--- a/integrations/claude-desktop/claude_desktop_config.json
+++ b/integrations/claude-desktop/claude_desktop_config.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "memorywhale": {
+      "command": "mw-mcp"
+    }
+  }
+}

--- a/integrations/goose/README.md
+++ b/integrations/goose/README.md
@@ -1,0 +1,61 @@
+# Goose integration
+
+[Goose](https://github.com/block/goose) is Block's on-machine AI agent (CLI +
+desktop). It calls MCP servers "extensions", so it gets MemoryWhale's four
+tools: `recent_errors`, `search_memory`, `get_context`, `remember`. Goose is a
+terminal/dev-loop agent — the same world MemoryWhale's memory is about.
+
+## Connect the MCP server (recommended: the wizard)
+
+```bash
+goose configure
+```
+
+Choose **Add Extension → Command-line Extension**, then:
+
+| Prompt | Value |
+| --- | --- |
+| Name | `memorywhale` |
+| Command | `mw-mcp` |
+| Timeout | `300` (default) |
+
+The wizard writes the entry for you (no hand-editing). In the desktop app the
+same lives under **Settings → Extensions → Add**.
+
+## Or edit the config directly
+
+Add this under `extensions:` in `~/.config/goose/config.yaml`
+([`config.yaml`](config.yaml)):
+
+```yaml
+extensions:
+  memorywhale:
+    type: stdio
+    name: memorywhale
+    cmd: mw-mcp
+    args: []
+    enabled: true
+    timeout: 300
+    env_keys: []
+    envs: {}
+    description: "MemoryWhale persistent local memory"
+```
+
+`mw-mcp` must be on `PATH` (the standard MemoryWhale install); otherwise use its
+absolute path as `cmd`. For a non-default database, add
+`MEMORYWHALE_DATA_DIR` to `envs` (e.g. `envs: { MEMORYWHALE_DATA_DIR: "/path/to/dir" }`).
+
+## Tell it when to reach for the memory
+
+The extension gives Goose the *tools*; a hint in your `.goosehints` (or the
+session's system prompt) teaches it *when*:
+
+> When a build/test/deploy fails, before proposing a fix, use `search_memory`
+> or `recent_errors` (MemoryWhale MCP) to check whether this failure has a known
+> cause or a saved lesson. Once you've figured out why something failed or how a
+> fix worked, use `remember` to save that conclusion.
+
+## Without the MCP server
+
+The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+`mw remember "…"`.

--- a/integrations/goose/config.yaml
+++ b/integrations/goose/config.yaml
@@ -1,0 +1,18 @@
+# Add this under `extensions:` in ~/.config/goose/config.yaml to give Goose
+# access to MemoryWhale's memory via MCP (tools: recent_errors, search_memory,
+# get_context, remember). Or use the wizard: `goose configure` -> Add Extension
+# -> Command-line Extension.
+#
+# `mw-mcp` must be on PATH (the standard MemoryWhale install). For a non-default
+# database, add MEMORYWHALE_DATA_DIR under `envs`.
+extensions:
+  memorywhale:
+    type: stdio
+    name: memorywhale
+    cmd: mw-mcp
+    args: []
+    enabled: true
+    timeout: 300
+    env_keys: []
+    envs: {}
+    description: "MemoryWhale persistent local memory"


### PR DESCRIPTION
## What

Adds two more MCP-client integration recipes, and lists them in `integrations/README.md`:

- **Goose** (Block's on-machine AI agent) — `integrations/goose/`
- **Claude Desktop** (Anthropic's reference MCP host) — `integrations/claude-desktop/`

## Why

Both connect to MCP servers, so `mw-mcp` plugs in with **no new code** — the same four tools every other client gets: `recent_errors`, `search_memory`, `get_context`, `remember`. Goose is a terminal/dev-loop agent, a strong thematic fit for terminal memory; Claude Desktop rounds out the Claude family alongside the existing `claude-code/` (CLI) recipe.

## What's in it

- `integrations/goose/` — README (register via `goose configure` → Command-line Extension, or edit `config.yaml`) + a `config.yaml` snippet (`type: stdio`, `cmd: mw-mcp`).
- `integrations/claude-desktop/` — README (add to `claude_desktop_config.json`, restart the app) + the `mcpServers` config block.
- Two lines added to `integrations/README.md`.

## Verification

Config formats checked against each tool's docs:
- Goose `config.yaml` `extensions.<name>` stdio shape (`type`/`cmd`/`args`/`enabled`/`timeout`/`envs`), and the `goose configure` wizard flow.
- Claude Desktop `claude_desktop_config.json` `mcpServers` shape (the standard Anthropic format, same as the existing `cursor/` recipe).

Recipe-level verification (config shape + the standard MCP handshake `mw-mcp` already answers). A full live end-to-end run inside each app was not performed.