### PR TITLE
chore: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Something MemoryWhale captured, stored, or recalled wrong
+title: ""
+labels: bug
+---
+
+## What happened
+<!-- What did MemoryWhale do vs. what you expected? -->
+
+## Steps to reproduce
+1.
+2.
+
+## The exact case (this is the useful part)
+<!-- MemoryWhale is about exact evidence — give us the same. -->
+- Command / action:
+- What got stored vs. what should have:
+- Relevant `mw` output or error:
+
+## Environment
+- OS + arch:
+- MemoryWhale version (`mw --version`):
+- Install method (crates.io / release / from source):
+- Data dir non-default? (`MEMORYWHALE_DATA_DIR`):
+
+## Notes
+<!-- Everything stays local — redact anything sensitive before pasting. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Make memory more durable, searchable, or useful
+title: ""
+labels: enhancement
+---
+
+## The problem
+<!-- What debugging context is getting lost, or what's hard to recover today? -->
+
+## Proposed change
+
+## Why it fits MemoryWhale
+<!-- Local-first, evidence-preserving, understandable. Which value does it serve? -->
+
+## Alternatives considered
+
+## Out of scope / non-goals

--- a/.github/ISSUE_TEMPLATE/integration_request.md
+++ b/.github/ISSUE_TEMPLATE/integration_request.md
@@ -1,0 +1,26 @@
+---
+name: Integration request
+about: Add an MCP client / editor to integrations/
+title: "Add a <tool> integration"
+labels: documentation, good first issue
+---
+
+## Summary
+<!-- Which tool, and confirm it speaks MCP (can run a local stdio server). -->
+`<tool>` supports MCP servers, so it can use MemoryWhale's four tools
+(`recent_errors`, `search_memory`, `get_context`, `remember`). Add
+`integrations/<tool>/`.
+
+## Why it's a good first issue
+Docs + config only, mirroring an existing folder (e.g. `integrations/codex/`).
+No Rust.
+
+## What to do
+1. Create `integrations/<tool>/` with a config snippet registering a stdio
+   server whose command is `mw-mcp`.
+2. **Verify the exact config format/location against the tool's current docs** —
+   don't assume; formats change between versions.
+3. Add a `README.md` mirroring an existing one: register the server, the
+   `mw-mcp`-on-PATH note, `MEMORYWHALE_DATA_DIR` for a non-default DB, and a
+   "when to use it" instruction for the tool's rules/system-prompt file.
+4. List the tool in `integrations/README.md`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## What this changes
+<!-- One or two sentences. What does this PR do? -->
+
+## Why it matters
+<!-- Connect back to the core problem: terminal history and debugging context
+disappear too easily. Which value does this serve? -->
+Closes #
+
+## What's in it
+<!-- Bullet the files/areas touched. -->
+-
+
+## Verification
+<!-- How you know it works. Paste output/screenshots where useful. -->
+- [ ] `npm run build` passes
+- [ ] `cargo fmt` + `cargo check` pass (in `src-tauri/`)
+- [ ] Tested locally against my own MemoryWhale data
+
+## Contribution rules checklist
+- [ ] Preserves original evidence (command, args, stdout, stderr, exit code, cwd, timestamp) where the change touches capture
+- [ ] No implicit cloud sync — any remote/sync behavior is explicit and documented
+- [ ] Database changes use clear SQLite tables/migrations, not opaque blobs
+- [ ] Still works fully offline, with no account or server


### PR DESCRIPTION
## What this changes

Adds GitHub issue templates and a PR template under `.github/`, so opening an issue or PR pre-fills with structure instead of a blank box.

## Why it matters

Every PR so far has been hand-structured (What/Why/Verification), and the five Contribution Rules live only in `CONTRIBUTING.md`. These templates make that structure automatic for every contributor — the rules get checked on each PR instead of relying on reviewer memory.

## What's in it

- `.github/pull_request_template.md` — What / Why / What's-in-it / Verification, plus a checklist mirroring the five Contribution Rules (evidence preservation, no implicit cloud sync, understandable SQLite/migrations, offline-first) and the standard `npm run build` / `cargo fmt` + `cargo check` gates.
- `.github/ISSUE_TEMPLATE/bug_report.md` — forces the "exact case" (command / what got stored vs. expected / `mw` output) + environment, fitting a project built on exact evidence.
- `.github/ISSUE_TEMPLATE/feature_request.md` — problem, proposal, why-it-fits-MemoryWhale, non-goals.
- `.github/ISSUE_TEMPLATE/integration_request.md` — the recurring "add an MCP client" pattern (mirrors #90), with a "verify the config format, don't guess" step baked in.

## Notes

- No `config.yml` contact link — Discussions is disabled on the repo, so it would be a dead link. Easy to add later if Discussions is turned on.
- Docs-only; no code paths touched.