### PR TITLE
integrations: add Cline, Continue, and Gemini CLI recipes

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -30,7 +30,10 @@ file differs. Per-client setup (config + a "when to use it" rule):
 - **OpenClaw** → [`openclaw/`](openclaw/README.md)
 - **Goose** (Block) → [`goose/`](goose/README.md)
 - **Claude Desktop** → [`claude-desktop/`](claude-desktop/README.md)
-- **Any other MCP client** (Zed, Cline, Continue, …) — add a stdio server whose
+- **Cline** (VS Code) → [`cline/`](cline/README.md)
+- **Continue** (VS Code / JetBrains) → [`continue/`](continue/README.md)
+- **Gemini CLI** (Google) → [`gemini-cli/`](gemini-cli/README.md)
+- **Any other MCP client** (Zed, …) — add a stdio server whose
   command is `mw-mcp` (no arguments). It honours `MEMORYWHALE_DATA_DIR` like the
   rest of the CLI.
 

--- a/integrations/cline/README.md
+++ b/integrations/cline/README.md
@@ -1,0 +1,53 @@
+# Cline integration
+
+[Cline](https://github.com/cline/cline) (the autonomous coding agent for VS Code)
+supports MCP servers, so it gets MemoryWhale's four tools: `recent_errors`,
+`search_memory`, `get_context`, `remember`.
+
+## Connect the MCP server
+
+In VS Code, click the **Cline** icon → open the menu (top-right of the Cline
+panel) → **MCP Servers** → **Configure MCP Servers**. That opens Cline's
+`cline_mcp_settings.json`. Add the `memorywhale` entry from
+[`mcp_settings.json`](mcp_settings.json):
+
+```json
+{
+  "mcpServers": {
+    "memorywhale": {
+      "command": "mw-mcp"
+    }
+  }
+}
+```
+
+If the file already has an `mcpServers` object, add `memorywhale` alongside your
+other servers rather than replacing it.
+
+The file lives under VS Code's global storage (path may vary by OS/version):
+
+```
+~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json   # macOS
+~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json                       # Linux
+%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json                        # Windows
+```
+
+Prefer editing through the Cline UI (above) — it points at the right file.
+`mw-mcp` must be on `PATH` (the standard MemoryWhale install); otherwise use its
+absolute path as `command`. For a non-default database add
+`"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`.
+
+## Tell it when to reach for the memory
+
+The MCP server gives Cline the *tools*; a rule teaches it *when*. Add to a
+`.clinerules` file (or Cline's custom instructions):
+
+> When a build/test/deploy fails, before proposing a fix, use `search_memory`
+> or `recent_errors` (MemoryWhale MCP) to check whether this failure has a known
+> cause or a saved lesson. Once you've figured out why something failed or how a
+> fix worked, use `remember` to save that conclusion.
+
+## Without the MCP server
+
+The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+`mw remember "…"`.

--- a/integrations/cline/mcp_settings.json
+++ b/integrations/cline/mcp_settings.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "memorywhale": {
+      "command": "mw-mcp"
+    }
+  }
+}

--- a/integrations/continue/README.md
+++ b/integrations/continue/README.md
@@ -1,0 +1,47 @@
+# Continue integration
+
+[Continue](https://github.com/continuedev/continue) (the open-source AI code
+assistant for VS Code and JetBrains) connects to MCP servers, so it gets
+MemoryWhale's four tools: `recent_errors`, `search_memory`, `get_context`,
+`remember`.
+
+## Connect the MCP server
+
+Continue reads MCP servers from YAML. Add the `mcpServers` block from
+[`config.yaml`](config.yaml) to your global config at `~/.continue/config.yaml`:
+
+```yaml
+mcpServers:
+  - name: memorywhale
+    command: mw-mcp
+    args: []
+```
+
+`mcpServers` entries are **list items** — the leading `-` matters, and mixing
+tabs with spaces silently breaks YAML parsing. If you already have an
+`mcpServers:` list, add `memorywhale` as another item rather than replacing it.
+
+Alternatively, drop a standalone server file into `.continue/mcpServers/` inside
+a project.
+
+`mw-mcp` must be on `PATH` (the standard MemoryWhale install); otherwise use its
+absolute path as `command`. For a non-default database add an `env` map:
+`env: { MEMORYWHALE_DATA_DIR: "/path/to/dir" }`.
+
+Continue does not always pick up MCP edits live — run **Reload Window** (VS Code)
+or reload the extension so it re-reads the config.
+
+## Tell it when to reach for the memory
+
+The MCP server gives Continue the *tools*; a rule (Continue's rules / system
+message) teaches it *when*:
+
+> When a build/test/deploy fails, before proposing a fix, use `search_memory`
+> or `recent_errors` (MemoryWhale MCP) to check whether this failure has a known
+> cause or a saved lesson. Once you've figured out why something failed or how a
+> fix worked, use `remember` to save that conclusion.
+
+## Without the MCP server
+
+The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+`mw remember "…"`.

--- a/integrations/continue/config.yaml
+++ b/integrations/continue/config.yaml
@@ -1,0 +1,11 @@
+# Add this mcpServers block to ~/.continue/config.yaml to give Continue access
+# to MemoryWhale's memory via MCP (tools: recent_errors, search_memory,
+# get_context, remember). mcpServers entries are LIST items — the leading dash
+# matters, and don't mix tabs with spaces.
+#
+# `mw-mcp` must be on PATH (the standard MemoryWhale install). For a non-default
+# database, add an `env` map with MEMORYWHALE_DATA_DIR.
+mcpServers:
+  - name: memorywhale
+    command: mw-mcp
+    args: []

--- a/integrations/gemini-cli/README.md
+++ b/integrations/gemini-cli/README.md
@@ -1,0 +1,47 @@
+# Gemini CLI integration
+
+Google's [Gemini CLI](https://github.com/google-gemini/gemini-cli) is a terminal
+AI agent that connects to MCP servers — so it gets MemoryWhale's four tools:
+`recent_errors`, `search_memory`, `get_context`, `remember`. It's a
+terminal/dev-loop agent, the same world MemoryWhale's memory is about.
+
+## Connect the MCP server
+
+Add the `memorywhale` entry from [`settings.json`](settings.json) to your Gemini
+CLI settings:
+
+- **Every project:** `~/.gemini/settings.json`
+- **This project only:** `.gemini/settings.json` in the project root
+
+```json
+{
+  "mcpServers": {
+    "memorywhale": {
+      "command": "mw-mcp"
+    }
+  }
+}
+```
+
+If the file already has an `mcpServers` object, add `memorywhale` alongside your
+other servers rather than replacing it. `mw-mcp` must be on `PATH` (the standard
+MemoryWhale install); otherwise use its absolute path as `command`. For a
+non-default database add `"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`.
+
+Verify inside Gemini CLI with the `/mcp` command — `memorywhale` should list its
+four tools.
+
+## Tell it when to reach for the memory
+
+The MCP server gives Gemini CLI the *tools*; a `GEMINI.md` instruction (in your
+project or `~/.gemini/`) teaches it *when*:
+
+> When a build/test/deploy fails, before proposing a fix, use `search_memory`
+> or `recent_errors` (MemoryWhale MCP) to check whether this failure has a known
+> cause or a saved lesson. Once you've figured out why something failed or how a
+> fix worked, use `remember` to save that conclusion.
+
+## Without the MCP server
+
+The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+`mw remember "…"`.

--- a/integrations/gemini-cli/settings.json
+++ b/integrations/gemini-cli/settings.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "memorywhale": {
+      "command": "mw-mcp"
+    }
+  }
+}


### PR DESCRIPTION
## What this changes

Adds three more MCP-client integration recipes and lists them in `integrations/README.md`.

Closes #97, closes #98, closes #99.

## Why it matters

Each connects to MCP servers, so `mw-mcp` plugs in with **no new code** — the same four tools every other client gets (`recent_errors`, `search_memory`, `get_context`, `remember`). Cline and Continue cover the two biggest VS Code coding-agent audiences; Gemini CLI is a terminal/dev-loop agent, a strong thematic fit for terminal memory.

## What's in it

- `integrations/cline/` — README + `mcp_settings.json` (`mcpServers` block for `cline_mcp_settings.json`, editable via Cline's MCP Servers UI).
- `integrations/continue/` — README + `config.yaml` (`mcpServers` **list** block for `~/.continue/config.yaml`; notes the reload requirement and YAML list/indent gotcha).
- `integrations/gemini-cli/` — README + `settings.json` (`mcpServers` for `~/.gemini/settings.json`; verify via `/mcp`).
- Three lines added to `integrations/README.md`.

## Verification

Config formats checked against each tool's current docs:
- **Cline** — `mcpServers { command, args, env }` in `cline_mcp_settings.json` under VS Code global storage.
- **Continue** — `mcpServers` YAML list in `~/.continue/config.yaml` (list items, reload required).
- **Gemini CLI** — `mcpServers` in `~/.gemini/settings.json` (global) or `.gemini/settings.json` (project).

Recipe-level verification (config shape + the standard MCP handshake `mw-mcp` already answers). Full live runs inside each app were not performed.