### PR TITLE
fix(core): don't substitute Utc::now() for malformed timestamps

### DIFF
--- a/crates/memorywhale-core/src/sqlite.rs
+++ b/crates/memorywhale-core/src/sqlite.rs
@@ -61,9 +61,17 @@ pub fn decode_id(id: i64) -> (Source, i64) {
 }
 
 fn parse_ts(ts: &str) -> DateTime<Utc> {
-    DateTime::parse_from_rfc3339(ts)
-        .map(|d| d.with_timezone(&Utc))
-        .unwrap_or_else(|_| Utc::now())
+    match DateTime::parse_from_rfc3339(ts) {
+        Ok(d) => d.with_timezone(&Utc),
+        Err(e) => {
+            // A malformed timestamp must not masquerade as `now()`: that would
+            // give a corrupted row an unearned recency boost (recency halves by
+            // age, so "now" ranks highest) and silently hide the corruption.
+            // Fall back to the Unix epoch so the row sorts as oldest, and warn.
+            eprintln!("memorywhale: unparseable timestamp {ts:?} ({e}); treating as epoch");
+            DateTime::from_timestamp(0, 0).unwrap_or_default()
+        }
+    }
 }
 
 /// Load everything MemoryWhale remembers as scorable memories, tolerant of any
@@ -311,6 +319,22 @@ mod tests {
         )
         .unwrap();
         conn
+    }
+
+    #[test]
+    fn parse_ts_valid_roundtrips_and_malformed_falls_back_to_epoch() {
+        // Valid RFC3339 parses to the same instant.
+        assert_eq!(
+            parse_ts("2026-06-20T12:00:00+00:00"),
+            DateTime::parse_from_rfc3339("2026-06-20T12:00:00+00:00")
+                .unwrap()
+                .with_timezone(&Utc),
+        );
+        // Malformed must NOT become `now()` — it becomes the epoch, so a
+        // corrupted row sorts as oldest instead of newest.
+        let epoch = DateTime::from_timestamp(0, 0).unwrap();
+        assert_eq!(parse_ts("not-a-timestamp"), epoch);
+        assert_eq!(parse_ts(""), epoch);
     }
 
     #[test]


### PR DESCRIPTION
## What this changes

`parse_ts()` in `crates/memorywhale-core/src/sqlite.rs` no longer falls back to `Utc::now()` when an RFC3339 timestamp fails to parse. It falls back to the **Unix epoch** and warns to stderr instead.

## Why it matters

The old fallback made a corrupted/malformed timestamp look brand-new. Since `parse_ts` feeds `last_used`, and recency scoring halves with age (`0.5^(age/half_life)`), a bad row got the **maximum** recency boost — corrupting ranking and silently hiding the corruption. Epoch is the safe direction: the row sorts as *oldest* (recency ≈ 0) and the warning surfaces the bad data instead of masking it.

Closes #101.

## What's in it

- `parse_ts` returns the epoch (via `DateTime::from_timestamp(0, 0)`) and `eprintln!`s a warning on parse failure.
- Regression test `parse_ts_valid_roundtrips_and_malformed_falls_back_to_epoch` — valid input round-trips; `"not-a-timestamp"` and `""` become the epoch (not `now()`).

## Verification

- [x] `cargo test -p memorywhale-core` passes (new test + existing suite)
- [x] `cargo fmt` clean

## Contribution rules checklist
- [x] Preserves original evidence — the raw row is untouched; only the in-memory parse fallback changes, and it now surfaces (warns) rather than hides corruption
- [x] No implicit cloud sync
- [x] No DB/schema changes
- [x] Works fully offline