### PR TITLE
fix(installer): verify release checksum before installing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,13 @@ jobs:
           tar tzf "$asset" | grep -qx "$root/README.md"
           tar tzf "$asset" | grep -qx "$root/LICENSE"
 
+      - name: Checksum tarball
+        shell: bash
+        run: |
+          asset="${{ steps.package.outputs.asset }}"
+          shasum -a 256 "$asset" > "$asset.sha256"
+          cat "$asset.sha256"
+
       - name: Build .deb
         if: matrix.deb
         run: |
@@ -104,6 +111,7 @@ jobs:
           generate_release_notes: true
           files: |
             ${{ steps.package.outputs.asset }}
+            ${{ steps.package.outputs.asset }}.sha256
             *.deb
 
   # Update Formula/memorywhale.rb on main to point at the new tag, so

--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,34 @@ trap 'rm -rf "$tmp"' EXIT
 
 echo "==> Downloading $asset ($tag)…"
 curl -fSL "$url" -o "$tmp/$asset"
+
+# Verify the download against the release's published SHA256 checksum. Releases
+# from v0.7.0 on ship "<asset>.sha256"; older releases have none, so we skip
+# (with a warning) rather than fail. A checksum mismatch is always fatal.
+echo "==> Verifying checksum…"
+if curl -fsSL "$url.sha256" -o "$tmp/$asset.sha256" 2>/dev/null; then
+  expected="$(cut -d' ' -f1 "$tmp/$asset.sha256")"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$tmp/$asset" | cut -d' ' -f1)"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$tmp/$asset" | cut -d' ' -f1)"
+  else
+    actual=""
+    echo "   WARNING: no sha256 tool (sha256sum/shasum) found; cannot verify." >&2
+  fi
+  if [ -n "$actual" ]; then
+    if [ "$actual" != "$expected" ]; then
+      echo "   CHECKSUM MISMATCH — refusing to install." >&2
+      echo "   expected: $expected" >&2
+      echo "   actual:   $actual" >&2
+      exit 1
+    fi
+    echo "   OK ($expected)"
+  fi
+else
+  echo "   NOTE: no published checksum for $tag; skipping verification." >&2
+fi
+
 tar xzf "$tmp/$asset" -C "$tmp"
 
 mkdir -p "$BIN_DIR"


### PR DESCRIPTION
## What this changes

The one-line installer now verifies the downloaded release tarball against a published SHA256 checksum before installing.

Closes #102.

## Why it matters

`install.sh` (run as `curl … | sh`) downloaded a prebuilt binary tarball and installed it with **zero** integrity/authenticity check. A corrupted download went undetected, and there was no way to verify the artifact. This is standard supply-chain hardening for a `curl | sh` installer.

## What's in it

- **`.github/workflows/release.yml`** — a new *Checksum tarball* step runs `shasum -a 256` and publishes `<asset>.sha256` alongside each release tarball (reuses the tooling already used for the Homebrew formula).
- **`install.sh`** — after download, fetches `<asset>.sha256`, computes the local digest (`sha256sum` or `shasum -a 256`), and **aborts on mismatch**.

## Backward-compatible by design

- **Older releases** (no `.sha256` published): the fetch fails → warn and skip, so the installer still works. New releases from v0.7.0 on will carry checksums.
- **Hosts without a sha256 tool**: warn and skip rather than break.
- **Mismatch is always fatal** (`exit 1`).

## Verification

- [x] `sh -n install.sh` — syntax OK
- [x] Functional test of the verify logic: matching digest proceeds; tampered file is detected as a mismatch (would `exit 1`)
- [x] `.sha256` format matches what the workflow produces (`shasum -a 256 <file>`, `cut -d' ' -f1` extracts the digest)

## Contribution rules checklist
- [x] No implicit cloud sync
- [x] No DB/schema changes
- [x] Works fully offline (verification only runs during network install; skips gracefully)
- [x] Explains why it matters (supply-chain integrity)