### PR TITLE
feat(cli): add 'mw explain <id>' command

### DIFF
--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -59,6 +59,7 @@ fn run() -> Result<(), String> {
         Some("agent") => return agent_cmd(&raw_args[1..]),
         Some("ask") => return ask_cmd(&raw_args[1..]),
         Some("search") => return search_memory(&raw_args[1..]),
+        Some("explain") => return explain_cmd(&raw_args[1..]),
         Some("tui") => return memorywhale_cli::tui::run(),
         Some("sync-mempalace") => return sync_mempalace(&raw_args[1..]),
         Some("git-fix") => return git_fix_cmd(&raw_args[1..]),
@@ -284,6 +285,7 @@ fn print_help() {
          mw push <ssh-host>       send this machine's memory to a teammate (scp + remote mw import)\n\
          mw pull <ssh-host> [path] copy another machine's memory here and merge it (scp + import)\n\
          mw search <text> [--explain] [--project X] [--machine Y] [--since 7d]  rank commands, sessions, and notes by relevance (--explain shows why)\n\
+         mw explain <id> [query]  show the per-signal score breakdown for one memory (ids come from `mw search`)\n\
          mw tui                   interactive terminal browser: type to search, arrow keys to move, Enter to reveal the command\n\
          mw sync-mempalace [--wing NAME] [--limit N] [--dry-run]  sync local memories into a running MemPalace server, idempotent by memory id (needs mempalace_command in config)\n\
          mw git-fix [id]          diagnose the last failed git command (or one by id): what happened, the fix, seen before?\n\
@@ -2196,9 +2198,10 @@ fn search_memory(args: &[String]) -> Result<(), String> {
             _ => String::new(),
         };
         println!(
-            "{:>3}%  [{}] {}{}{}",
+            "{:>3}%  [{}] #{} {}{}{}",
             sm.percent(),
             source.tag(),
+            sm.memory.id,
             snippet,
             action,
             prov
@@ -2931,6 +2934,57 @@ fn ask_cmd(args: &[String]) -> Result<(), String> {
 
 /// Print a compact, token-budgeted digest of recent memory for an AI agent to
 /// read: recent failed commands (with short error tails) and recent sessions.
+/// `mw explain <id> [query text]` — the per-signal score breakdown for one
+/// memory. The differentiator: not just *that* a memory ranks, but *why*
+/// (recency, importance, reinforcement, and — when query text is supplied —
+/// similarity / keyword overlap). Ids are the namespaced ids shown by
+/// `mw search`.
+fn explain_cmd(args: &[String]) -> Result<(), String> {
+    let (scope, args) = Scope::take(args)?;
+    let Some((id_arg, rest)) = args.split_first() else {
+        return Err("usage: mw explain <id> [query text]".to_string());
+    };
+    let id: i64 = id_arg.parse().map_err(|_| {
+        format!(
+            "invalid id {id_arg:?}: expected a numeric memory id (see the ids from `mw search`)"
+        )
+    })?;
+    let query_text = rest
+        .iter()
+        .map(|s| s.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    // Same loader + engine the Recall panel and `mw search` use, so the
+    // breakdown matches what ranking actually did. "now" is fixed here so
+    // scoring stays deterministic.
+    let conn = open_session_db()?;
+    let now = Utc::now();
+    let mems = memorywhale_core::sqlite::load_memories(&conn);
+    let mems = memorywhale_cli::scope_memories(
+        &conn,
+        mems,
+        scope.project.as_deref(),
+        scope.machine.as_deref(),
+        scope.cutoff(now),
+    );
+    let engine = memorywhale_core::engine::BuiltinEngine::new(mems);
+    let mut q = memorywhale_core::Query::new(&query_text, now);
+    let tags = scope.task_tags();
+    if !tags.is_empty() {
+        q = q.with_task(tags);
+    }
+    match engine.explain(id, &q) {
+        Some(sm) => {
+            print!("{}", sm.explain());
+            Ok(())
+        }
+        None => Err(format!(
+            "no memory with id {id} (list ids with `mw search`)"
+        )),
+    }
+}
+
 fn context_cmd(args: &[String]) -> Result<(), String> {
     let mut project: Option<String> = None;
     let mut last_error = false;

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -13,6 +13,7 @@ mw --live --notes "project:demo"      # autosave to SQLite every few seconds
 mw list                               # list recorded sessions
 mw show 1                             # print the full transcript of a session
 mw search "linker error"              # search commands, output, notes, transcripts
+mw explain 1000000001                 # why this memory ranks: per-signal breakdown (ids come from `mw search`)
 mw tui                                # interactive terminal browser (type to search, Enter to act, F1 help, Esc quit)
 mw git-fix                            # diagnose the last failed git command: what, why, the fix
 mw mark "before the risky flash"      # bookmark the current debugging moment


### PR DESCRIPTION
## What this changes

Adds a standalone `mw explain <id>` command that prints the per-signal score breakdown for one memory — VISION roadmap phase 2's "memory explain <id>".

Closes #91.

## Why it matters

The core breakdown (`ScoredMemory::explain` / `engine.explain`) already existed but was only reachable as a flag on search (`mw search … --explain`). Explainability is a stated differentiator; this exposes it directly for any memory by id.

## What's in it

- **New dispatch arm + `explain_cmd`** in `mw.rs`: parses `<id>`, accepts optional trailing query text (engages the similarity/keyword signal), and prints the breakdown via the same engine path `mw search` uses. Clear errors — not panics — for missing / non-numeric / unknown id.
- **`mw search` now prints each result's canonical `#id`.** Explain needs the namespaced id; search previously only showed the decoded `mw replay N` hint, so the id was undiscoverable. One-field change closes that gap.
- Listed in `mw --help`; documented in `docs/CLI.md`.

## Verification (ran locally against seeded demo data)

```
$ mw search linker
 37%  [command] #1000000001 cargo … — `mw replay 1`
$ mw explain 1000000001
memory explain 1000000001
  score 37%  =
     similarity    w0.40 × 0.00 = +0.000   0% term overlap (lexical)
     recency       w0.20 × 1.00 = +0.200   last used today
     …
$ mw explain 999      # unknown  -> "no memory with id 999 …"  exit 1
$ mw explain          # missing  -> usage                        exit 1
$ mw explain abc      # bad id   -> clear error                  exit 1
```

- [x] `cargo test` — 43 pass, 0 fail (unknown-id path covered by existing core test `engine::explain(9999) is_none`)
- [x] `cargo fmt` clean

## Contribution rules checklist
- [x] Preserves original evidence (read-only view; no capture change)
- [x] No implicit cloud sync
- [x] No DB/schema changes
- [x] Works fully offline