### PR TITLE
feat(cli): tag and time filters for mw search

### DIFF
--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -284,7 +284,7 @@ fn print_help() {
          mw import <bundle|sqlite> merge another machine's exported memory into this one\n\
          mw push <ssh-host>       send this machine's memory to a teammate (scp + remote mw import)\n\
          mw pull <ssh-host> [path] copy another machine's memory here and merge it (scp + import)\n\
-         mw search <text> [--explain] [--project X] [--machine Y] [--since 7d]  rank commands, sessions, and notes by relevance (--explain shows why)\n\
+         mw search <text> [--explain] [tag:X] [source:command|session|note|document|conversation] [after:YYYY-MM-DD] [before:YYYY-MM-DD] [limit:N] [--project X] [--machine Y] [--since 7d]  rank commands, sessions, and notes by relevance (--explain shows why)\n\
          mw explain <id> [query]  show the per-signal score breakdown for one memory (ids come from `mw search`)\n\
          mw tui                   interactive terminal browser: type to search, arrow keys to move, Enter to reveal the command\n\
          mw sync-mempalace [--wing NAME] [--limit N] [--dry-run]  sync local memories into a running MemPalace server, idempotent by memory id (needs mempalace_command in config)\n\
@@ -2114,18 +2114,24 @@ fn note_meta(conn: &Connection, id: i64) -> Option<(String, String)> {
 fn search_memory(args: &[String]) -> Result<(), String> {
     let (scope, args) = Scope::take(args)?;
     let explain = args.iter().any(|a| a == "--explain");
-    let terms: Vec<&String> = args.iter().filter(|a| a.as_str() != "--explain").collect();
-    if terms.is_empty() {
+    let terms: Vec<&str> = args
+        .iter()
+        .map(|s| s.as_str())
+        .filter(|a| *a != "--explain")
+        .collect();
+    // Pull inline `tag:`/`source:`/`before:`/`after:`/`limit:` filters out of the
+    // terms; whatever's left is the free-text query.
+    let (filters, query) = memorywhale_cli::parse_search_filters(&terms)?;
+    let has_filter = !filters.tags.is_empty()
+        || !filters.sources.is_empty()
+        || filters.before.is_some()
+        || filters.after.is_some();
+    if query.is_empty() && !has_filter {
         return Err(
-            "usage: mw search <text> [--explain] [--project X] [--machine Y] [--since 7d]"
+            "usage: mw search <text> [--explain] [tag:X] [source:command|session|note|document|conversation] [after:YYYY-MM-DD] [before:YYYY-MM-DD] [limit:N] [--project X] [--machine Y] [--since 7d]"
                 .to_string(),
         );
     }
-    let query = terms
-        .iter()
-        .map(|s| s.as_str())
-        .collect::<Vec<_>>()
-        .join(" ");
 
     // External semantic engine (MemPalace), if the user opted in via config. It
     // ranks server-side over its own corpus, so the local scope filters don't
@@ -2162,13 +2168,16 @@ fn search_memory(args: &[String]) -> Result<(), String> {
         scope.machine.as_deref(),
         scope.cutoff(now),
     );
+    // Inline tag:/source:/before:/after: filters narrow the set before ranking.
+    let mems = memorywhale_cli::filter_memories(mems, &filters);
     let engine = memorywhale_core::engine::BuiltinEngine::new(mems);
     let mut q = memorywhale_core::Query::new(&query, now);
     let tags = scope.task_tags();
     if !tags.is_empty() {
         q = q.with_task(tags);
     }
-    let hits = engine.retrieve(&q, 20);
+    // limit:N caps the ranked results; default matches the previous behaviour.
+    let hits = engine.retrieve(&q, filters.limit.unwrap_or(20));
 
     println!("# matches for {query:?}  (ranked)\n");
     if hits.is_empty() {

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -1006,6 +1006,98 @@ pub fn scope_memories(
     mems
 }
 
+/// Inline `key:value` filters for `mw search` (e.g. `tag:infra after:2026-01-01`).
+#[derive(Debug, Default, PartialEq)]
+pub struct SearchFilters {
+    /// All must be present on a memory (AND), matched case-insensitively.
+    pub tags: Vec<String>,
+    /// Any may match (OR): command|session|note|document|conversation.
+    pub sources: Vec<String>,
+    /// created_at on or after this day (start of day, UTC).
+    pub after: Option<chrono::DateTime<Utc>>,
+    /// created_at on or before this day (end of day, UTC).
+    pub before: Option<chrono::DateTime<Utc>>,
+    /// Cap on the number of ranked results.
+    pub limit: Option<usize>,
+}
+
+/// The source names accepted by `source:` — the same strings `Source::tag()` emits.
+pub const SEARCH_SOURCES: [&str; 5] = ["command", "session", "note", "document", "conversation"];
+
+fn parse_filter_day(kind: &str, val: &str) -> Result<chrono::DateTime<Utc>, String> {
+    let d = chrono::NaiveDate::parse_from_str(val, "%Y-%m-%d")
+        .map_err(|_| format!("invalid date in {kind}:{val} — use YYYY-MM-DD"))?;
+    // `after` is inclusive from the start of the day; `before` through its end.
+    let (h, m, s) = if kind == "before" {
+        (23, 59, 59)
+    } else {
+        (0, 0, 0)
+    };
+    Ok(d.and_hms_opt(h, m, s)
+        .expect("0/23:59:59 is always valid")
+        .and_utc())
+}
+
+/// Split search args into inline `key:value` filters and the remaining
+/// free-text query. Unknown `key:` prefixes are treated as query text.
+pub fn parse_search_filters(terms: &[&str]) -> Result<(SearchFilters, String), String> {
+    let mut f = SearchFilters::default();
+    let mut query: Vec<&str> = Vec::new();
+    for t in terms {
+        if let Some(v) = t.strip_prefix("tag:") {
+            if !v.is_empty() {
+                f.tags.push(v.to_lowercase());
+            }
+        } else if let Some(v) = t.strip_prefix("source:") {
+            let v = v.to_lowercase();
+            if !SEARCH_SOURCES.contains(&v.as_str()) {
+                return Err(format!(
+                    "unknown source:{v} — use one of {}",
+                    SEARCH_SOURCES.join("|")
+                ));
+            }
+            f.sources.push(v);
+        } else if let Some(v) = t.strip_prefix("after:") {
+            f.after = Some(parse_filter_day("after", v)?);
+        } else if let Some(v) = t.strip_prefix("before:") {
+            f.before = Some(parse_filter_day("before", v)?);
+        } else if let Some(v) = t.strip_prefix("limit:") {
+            f.limit = Some(
+                v.parse()
+                    .map_err(|_| format!("invalid limit:{v} — expected a number"))?,
+            );
+        } else {
+            query.push(t);
+        }
+    }
+    Ok((f, query.join(" ")))
+}
+
+/// Apply the value filters to the memory set. The `limit` is applied later to
+/// the ranked hits, not here.
+pub fn filter_memories(
+    mut mems: Vec<memorywhale_core::Memory>,
+    f: &SearchFilters,
+) -> Vec<memorywhale_core::Memory> {
+    use memorywhale_core::sqlite::decode_id;
+    if let Some(a) = f.after {
+        mems.retain(|m| m.created_at >= a);
+    }
+    if let Some(b) = f.before {
+        mems.retain(|m| m.created_at <= b);
+    }
+    if !f.tags.is_empty() {
+        mems.retain(|m| {
+            let have: Vec<String> = m.tags.iter().map(|t| t.to_lowercase()).collect();
+            f.tags.iter().all(|want| have.iter().any(|h| h == want))
+        });
+    }
+    if !f.sources.is_empty() {
+        mems.retain(|m| f.sources.iter().any(|s| s == decode_id(m.id).0.tag()));
+    }
+    mems
+}
+
 /// True when agent-written memories should start unapproved and be excluded from
 /// retrieval until approved in the dashboard. On by default. Set
 /// `MEMORYWHALE_REVIEW_AGENT_MEMORIES=0` or
@@ -1434,6 +1526,78 @@ mod tests {
         assert!(fix_surfaced(&[9, 2, 5], &[2], 5));
         assert!(!fix_surfaced(&[9, 5, 7, 8, 6, 2], &[2], 5)); // fix at rank 6, k=5
         assert!(!fix_surfaced(&[9, 5, 7], &[2], 5)); // fix not retrieved at all
+    }
+
+    fn mem(id: i64, tags: &[&str], created: &str) -> memorywhale_core::Memory {
+        let when = chrono::DateTime::parse_from_rfc3339(created)
+            .unwrap()
+            .with_timezone(&Utc);
+        memorywhale_core::Memory {
+            id,
+            text: "x".into(),
+            created_at: when,
+            last_used: when,
+            mentions: 1,
+            importance: 0.5,
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            embedding: None,
+        }
+    }
+
+    #[test]
+    fn parse_search_filters_splits_filters_from_query() {
+        let (f, q) =
+            parse_search_filters(&["docker", "after:2026-01-01", "tag:Infra", "source:command"])
+                .unwrap();
+        assert_eq!(q, "docker");
+        assert_eq!(f.tags, vec!["infra"]); // lowercased
+        assert_eq!(f.sources, vec!["command"]);
+        assert!(f.after.is_some());
+        // Unknown prefixes stay as query text; a bare word too.
+        let (f2, q2) = parse_search_filters(&["ratio:1", "hello"]).unwrap();
+        assert!(f2.tags.is_empty());
+        assert_eq!(q2, "ratio:1 hello");
+    }
+
+    #[test]
+    fn parse_search_filters_rejects_bad_values() {
+        assert!(parse_search_filters(&["before:nope"]).is_err());
+        assert!(parse_search_filters(&["source:banana"]).is_err());
+        assert!(parse_search_filters(&["limit:x"]).is_err());
+    }
+
+    #[test]
+    fn filter_memories_applies_tag_source_and_dates() {
+        // ids: 1_000_000_001 -> Command, 3_000_000_001 -> Note.
+        let mems = vec![
+            mem(1_000_000_001, &["command", "infra"], "2026-02-01T00:00:00Z"),
+            mem(3_000_000_001, &["note"], "2026-06-01T00:00:00Z"),
+        ];
+
+        // tag: keeps only the infra-tagged command.
+        let f = SearchFilters {
+            tags: vec!["infra".into()],
+            ..Default::default()
+        };
+        let out = filter_memories(mems.clone(), &f);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, 1_000_000_001);
+
+        // source:note keeps only the note.
+        let f = SearchFilters {
+            sources: vec!["note".into()],
+            ..Default::default()
+        };
+        assert_eq!(filter_memories(mems.clone(), &f)[0].id, 3_000_000_001);
+
+        // after:2026-03-01 drops the February command.
+        let f = SearchFilters {
+            after: parse_search_filters(&["after:2026-03-01"]).unwrap().0.after,
+            ..Default::default()
+        };
+        let out = filter_memories(mems.clone(), &f);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, 3_000_000_001);
     }
 
     /// End-to-end scoring over the REAL retrieval path (load_memories +

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -13,6 +13,7 @@ mw --live --notes "project:demo"      # autosave to SQLite every few seconds
 mw list                               # list recorded sessions
 mw show 1                             # print the full transcript of a session
 mw search "linker error"              # search commands, output, notes, transcripts
+mw search docker after:2026-01-01 tag:infra   # filter results: tag:X, source:command|session|note|document|conversation, before:/after:YYYY-MM-DD, limit:N
 mw explain 1000000001                 # why this memory ranks: per-signal breakdown (ids come from `mw search`)
 mw tui                                # interactive terminal browser (type to search, Enter to act, F1 help, Esc quit)
 mw git-fix                            # diagnose the last failed git command: what, why, the fix


### PR DESCRIPTION
## What this changes

Adds inline `key:value` filters to `mw search`: **`tag:`**, **`source:`**, **`before:`**, **`after:`**, **`limit:`**.

```
mw search docker after:2026-01-01 tag:infra
mw search source:note limit:5
```

Closes #105.

## Why it matters

The `Memory` struct already carried `tags` (used for scoring) and timestamps, but nothing let you *filter* search by them. These give precise, dimension-scoped retrieval — the "which 12" precision the project is judged on — with no schema change.

## What's in it

- **`parse_search_filters` / `filter_memories`** in the CLI lib (pure, unit-tested):
  - `tag:X` — repeatable, **AND**, case-insensitive
  - `source:X` — repeatable, **OR**, over `command|session|note|document|conversation`
  - `before:YYYY-MM-DD` / `after:YYYY-MM-DD` — inclusive of the named day
  - `limit:N` — caps ranked results
  - unknown `key:` prefixes fall through as query text; bad date/source/limit values error clearly
- Wired into `search_memory`: filters narrow the set **before** ranking; `limit` caps retrieval; a filter with no free text is allowed (lists the filtered set).
- Help text + `docs/CLI.md` updated.

## Verification (ran against seeded demo data)

- `source:command` / `source:note` correctly include/exclude by source
- `tag:error` matches the tagged command
- `build limit:1` returns 1 (vs 2 unlimited); `tag:command after:2026-01-01` returns 1
- `before:nope` → `invalid date … use YYYY-MM-DD`, exit 1
- `after:2027-01-01` → `(none)`
- [x] `cargo test` — 46 pass, 0 fail (3 new filter tests)
- [x] `cargo fmt` clean

## Contribution rules checklist
- [x] Preserves original evidence (read-only filtering; no capture change)
- [x] No implicit cloud sync
- [x] No DB/schema changes (filters over already-loaded memories)
- [x] Works fully offline