### PR TITLE
feat(cli): duplicate detection on 'mw remember'

### DIFF
--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -268,7 +268,7 @@ fn print_help() {
          mw list [--project X] [--machine Y] [--since 7d]  list recorded sessions\n\
          mw show <id>             print the full faithful transcript of a session\n\
          mw mark <text>           bookmark the current debugging moment\n\
-         mw remember <text>       save a lesson/conclusion, e.g. \"the fix was passing --features vendored-ssl\"\n\
+         mw remember <text> [--force]  save a lesson/conclusion (warns on a near-duplicate; --force saves anyway), e.g. \"the fix was passing --features vendored-ssl\"\n\
          mw memory stale <id>     retire an outdated lesson without deleting its evidence\n\
          mw memory supersede <old-id> <new-id>  replace an old lesson with a newer one\n\
          mw rm [session|command] <id>  delete a saved item and its transcript\n\
@@ -889,13 +889,40 @@ fn memory_lifecycle_cmd(args: &[String]) -> Result<(), String> {
 }
 
 fn remember_cmd(args: &[String]) -> Result<(), String> {
-    if args.is_empty() {
-        return Err("usage: mw remember <text>".to_string());
+    let force = args.iter().any(|a| a == "--force");
+    let text = args
+        .iter()
+        .filter(|a| a.as_str() != "--force")
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(" ");
+    if text.trim().is_empty() {
+        return Err("usage: mw remember <text> [--force]".to_string());
     }
-    let text = args.join(" ");
     let cwd = env::current_dir()
         .ok()
         .and_then(|path| path.to_str().map(ToOwned::to_owned));
+
+    // Store-time duplicate check: don't silently pile up the same lesson twice.
+    // Read-only — never merges or deletes; `--force` keeps both. If the db can't
+    // be opened here, skip the check and let `remember` surface the real error.
+    if !force {
+        if let Ok(conn) = open_session_db() {
+            let mems = memorywhale_core::sqlite::load_memories(&conn);
+            if let Some((sim, existing)) = memorywhale_cli::nearest_similar(&mems, &text) {
+                if sim >= memorywhale_cli::DEDUP_SIMILARITY {
+                    let snippet: String = existing.text.chars().take(100).collect();
+                    return Err(format!(
+                        "a similar memory already exists (#{} · {:.0}% overlap):\n  \"{}\"\nnot saved (near-duplicate). Re-run with `mw remember --force` to save it anyway.",
+                        existing.id,
+                        sim * 100.0,
+                        memorywhale_cli::redact(&snippet),
+                    ));
+                }
+            }
+        }
+    }
+
     let id = memorywhale_cli::remember(&text, cwd.as_deref())?;
     // Echo back what was actually stored (redacted), not the raw input.
     println!("mw: remembered #{id}: {}", memorywhale_cli::redact(&text));

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -1006,6 +1006,53 @@ pub fn scope_memories(
     mems
 }
 
+/// Word set (lowercased, alphanumeric tokens) for textual-overlap comparison.
+fn word_set(s: &str) -> std::collections::HashSet<String> {
+    s.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Jaccard overlap of two word sets: |A∩B| / |A∪B|, in `[0,1]`.
+fn jaccard(a: &std::collections::HashSet<String>, b: &std::collections::HashSet<String>) -> f32 {
+    let union = a.union(b).count();
+    if union == 0 {
+        return 0.0;
+    }
+    a.intersection(b).count() as f32 / union as f32
+}
+
+/// The existing memory with the highest textual overlap to `text`, and that
+/// overlap score in `[0,1]`. Used for store-time duplicate detection.
+///
+/// Deliberately uses Jaccard word-overlap, not the engine's BM25 "similarity":
+/// BM25 scores an exact duplicate near zero on a small corpus (shared terms
+/// carry no discriminative weight), which is the opposite of what dedup needs.
+/// Returns `None` when there is nothing overlapping to compare against.
+pub fn nearest_similar(
+    mems: &[memorywhale_core::Memory],
+    text: &str,
+) -> Option<(f32, memorywhale_core::Memory)> {
+    let want = word_set(text);
+    if want.is_empty() {
+        return None;
+    }
+    mems.iter()
+        .map(|m| (jaccard(&want, &word_set(&m.text)), m))
+        .filter(|(sim, _)| *sim > 0.0)
+        .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(sim, m)| (sim, m.clone()))
+}
+
+/// Overlap at or above which `mw remember` treats a new lesson as a probable
+/// duplicate and asks the user to confirm with `--force`. 1.0 = identical word
+/// set; ~0.5 = a loose paraphrase. Set to catch near-identical saves while
+/// leaving genuine paraphrases through.
+// ponytail: single threshold constant — make it configurable only if users ask.
+pub const DEDUP_SIMILARITY: f32 = 0.7;
+
 /// Inline `key:value` filters for `mw search` (e.g. `tag:infra after:2026-01-01`).
 #[derive(Debug, Default, PartialEq)]
 pub struct SearchFilters {
@@ -1542,6 +1589,40 @@ mod tests {
             tags: tags.iter().map(|s| s.to_string()).collect(),
             embedding: None,
         }
+    }
+
+    #[test]
+    fn nearest_similar_flags_duplicates_not_unrelated() {
+        let mems = vec![
+            mem(3_000_000_001, &["note"], "2026-06-01T00:00:00Z"),
+            mem(3_000_000_002, &["note"], "2026-06-02T00:00:00Z"),
+        ];
+        let mut mems = mems;
+        mems[0].text = "the fix was passing --features vendored-ssl".into();
+        mems[1].text = "linker error: missing -lstdc++ on the jetson".into();
+
+        // Exact text → overlap 1.0, matched to the right memory.
+        let (sim, hit) =
+            nearest_similar(&mems, "the fix was passing --features vendored-ssl").unwrap();
+        assert!(
+            (sim - 1.0).abs() < 1e-6,
+            "exact match should be 1.0, got {sim}"
+        );
+        assert_eq!(hit.id, 3_000_000_001);
+        assert!(sim >= DEDUP_SIMILARITY);
+
+        // Partial overlap (a couple shared words) → below the dedup threshold.
+        let (sim2, _) = nearest_similar(&mems, "the fix for the jetson").unwrap();
+        assert!(
+            sim2 > 0.0 && sim2 < DEDUP_SIMILARITY,
+            "partial overlap should be between 0 and the threshold, got {sim2}"
+        );
+
+        // No shared words → None (nothing to dedup against, so the save proceeds).
+        assert!(nearest_similar(&mems, "completely unrelated kubernetes ingress").is_none());
+        // Empty corpus / empty text → None.
+        assert!(nearest_similar(&[], "anything").is_none());
+        assert!(nearest_similar(&mems, "   ").is_none());
     }
 
     #[test]

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -18,7 +18,7 @@ mw explain 1000000001                 # why this memory ranks: per-signal breakd
 mw tui                                # interactive terminal browser (type to search, Enter to act, F1 help, Esc quit)
 mw git-fix                            # diagnose the last failed git command: what, why, the fix
 mw mark "before the risky flash"      # bookmark the current debugging moment
-mw remember "the fix was passing --features vendored-ssl"  # save a lesson/conclusion
+mw remember "the fix was passing --features vendored-ssl"  # save a lesson/conclusion (warns on a near-duplicate; add --force to save anyway)
 mw replay 12                          # rerun a saved command run
 mw demo                               # seed a small demo dataset to explore
 mw rm 5                               # delete a session (+ its transcript); mw rm command <id> for a run


### PR DESCRIPTION
## What this changes

`mw remember` now checks for a near-identical existing memory before saving. On a match it refuses with a clear message; `--force` saves anyway (keep both). Read-only — it never merges or deletes.

```
$ mw remember "the fix was passing --features vendored-ssl"
mw: remembered #1: …
$ mw remember "the fix was passing --features vendored-ssl"
mw: a similar memory already exists (#3000000001 · 100% overlap):
  "the fix was passing --features vendored-ssl"
not saved (near-duplicate). Re-run with `mw remember --force` to save it anyway.
```

Closes #106. (VISION Filter/Consolidate stage, roadmap phase 5.)

## Why the approach

The obvious move — reuse the engine's `similarity` signal — is **wrong for dedup**: that signal is BM25 *relevance*, which scores an exact duplicate near **0%** on a small corpus because the shared terms carry no discriminative weight. I verified this (an exact-match search showed `similarity … 0%`). Dedup needs textual *overlap*, so `nearest_similar` uses **Jaccard word-overlap** instead — 1.0 for an identical word set, ~0.5 for a loose paraphrase.

## What's in it

- `nearest_similar` + `DEDUP_SIMILARITY` (0.7) in the CLI lib — pure, unit-tested.
- `remember_cmd`: parses `--force`, runs the check (read-only load), blocks near-duplicates with an actionable message. Skips gracefully if the db can't be opened.
- Help text + `docs/CLI.md` document `--force`.

## Verification (ran against a scratch data dir)

- exact duplicate → **blocked** (100% overlap), exit 1
- loose paraphrase (~50% overlap) → **saved** (below 0.7 threshold)
- unrelated lesson → **saved**
- `--force` on an exact duplicate → **saved** (keep both)
- [x] `cargo test` — 47 pass, 0 fail (new `nearest_similar` test: exact / partial / none)
- [x] `cargo fmt --check` clean

## Scope / follow-up

Covers the CLI `mw remember` surface (where `--force` is natural). Extending the same check to the **MCP `remember` tool** (used by agents) is a clean follow-up — noted, not silently skipped.

## Contribution rules checklist
- [x] Preserves original evidence — refuses to *add* a duplicate; never merges or deletes existing memories
- [x] No implicit cloud sync
- [x] No DB/schema changes (compares over already-loaded memories)
- [x] Works fully offline