### PR TITLE
feat(cli): TTL / auto-expiring memories (mw remember ttl:7d)

### DIFF
--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -268,7 +268,7 @@ fn print_help() {
          mw list [--project X] [--machine Y] [--since 7d]  list recorded sessions\n\
          mw show <id>             print the full faithful transcript of a session\n\
          mw mark <text>           bookmark the current debugging moment\n\
-         mw remember <text> [--force]  save a lesson/conclusion (warns on a near-duplicate; --force saves anyway), e.g. \"the fix was passing --features vendored-ssl\"\n\
+         mw remember <text> [ttl:7d] [--force]  save a lesson/conclusion (ttl: auto-expires it; warns on a near-duplicate, --force saves anyway), e.g. \"the fix was passing --features vendored-ssl\"\n\
          mw memory stale <id>     retire an outdated lesson without deleting its evidence\n\
          mw memory supersede <old-id> <new-id>  replace an old lesson with a newer one\n\
          mw rm [session|command] <id>  delete a saved item and its transcript\n\
@@ -890,15 +890,25 @@ fn memory_lifecycle_cmd(args: &[String]) -> Result<(), String> {
 
 fn remember_cmd(args: &[String]) -> Result<(), String> {
     let force = args.iter().any(|a| a == "--force");
+    let ttl_spec = args.iter().find_map(|a| a.strip_prefix("ttl:"));
     let text = args
         .iter()
-        .filter(|a| a.as_str() != "--force")
+        .filter(|a| a.as_str() != "--force" && !a.starts_with("ttl:"))
         .map(String::as_str)
         .collect::<Vec<_>>()
         .join(" ");
     if text.trim().is_empty() {
-        return Err("usage: mw remember <text> [--force]".to_string());
+        return Err("usage: mw remember <text> [ttl:7d] [--force]".to_string());
     }
+    // Validate the TTL before saving so a bad duration never leaves a note behind.
+    let expires_at = match ttl_spec {
+        Some(spec) => {
+            let d = memorywhale_cli::parse_since(spec)
+                .map_err(|_| format!("invalid ttl:{spec}; use e.g. 7d, 24h, 2w"))?;
+            Some((Utc::now() + d).to_rfc3339())
+        }
+        None => None,
+    };
     let cwd = env::current_dir()
         .ok()
         .and_then(|path| path.to_str().map(ToOwned::to_owned));
@@ -924,8 +934,21 @@ fn remember_cmd(args: &[String]) -> Result<(), String> {
     }
 
     let id = memorywhale_cli::remember(&text, cwd.as_deref())?;
+    if let Some(exp) = &expires_at {
+        if let Ok(conn) = open_session_db() {
+            let _ = memorywhale_cli::set_note_expiry(&conn, id, Some(exp));
+        }
+    }
     // Echo back what was actually stored (redacted), not the raw input.
-    println!("mw: remembered #{id}: {}", memorywhale_cli::redact(&text));
+    let suffix = expires_at
+        .as_deref()
+        .map(|e| format!(" (expires {})", &e[..10.min(e.len())]))
+        .unwrap_or_default();
+    println!(
+        "mw: remembered #{id}: {}{}",
+        memorywhale_cli::redact(&text),
+        suffix
+    );
     Ok(())
 }
 

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -112,7 +112,7 @@ const BOOKMARKS_BASE: &str = "CREATE TABLE IF NOT EXISTS bookmarks (
      CREATE INDEX IF NOT EXISTS idx_bookmarks_created_at ON bookmarks(created_at);";
 
 /// Schema version `migrate` brings a database up to.
-pub const LATEST_SCHEMA_VERSION: i64 = 6;
+pub const LATEST_SCHEMA_VERSION: i64 = 7;
 
 /// Apply numbered schema migrations to a MemoryWhale database. Idempotent and
 /// cheap (a `user_version` check), so callers run it before touching bookmarks.
@@ -206,7 +206,41 @@ pub fn migrate(conn: &Connection) -> Result<(), String> {
         )
         .map_err(|e| format!("failed to migrate memory lifecycle: {e}"))?;
     }
+    if version < 7 {
+        // Optional TTL: a note with a past `expires_at` is swept to status
+        // 'expired' on open, so it drops out of retrieval while its row (the
+        // original evidence) is preserved. NULL = never expires.
+        add_column_if_missing(conn, "bookmarks", "expires_at", "TEXT")?;
+        conn.execute_batch("PRAGMA user_version = 7;")
+            .map_err(|e| format!("failed to migrate memory ttl: {e}"))?;
+    }
     Ok(())
+}
+
+/// Set (or clear, with `None`) a note's expiry. `expires_at` is RFC3339.
+pub fn set_note_expiry(conn: &Connection, id: i64, expires_at: Option<&str>) -> Result<(), String> {
+    let changed = conn
+        .execute(
+            "UPDATE bookmarks SET expires_at = ?2 WHERE id = ?1",
+            params![id, expires_at],
+        )
+        .map_err(|e| format!("failed to set expiry: {e}"))?;
+    if changed == 0 {
+        return Err(format!("no memory #{id}"));
+    }
+    Ok(())
+}
+
+/// Sweep notes whose TTL has passed to status 'expired' (best-effort, additive).
+/// Returns how many were expired. Called on DB open so retrieval — which filters
+/// `status = 'active'` — stops surfacing them without deleting the evidence.
+pub fn expire_due_notes(conn: &Connection, now_rfc3339: &str) -> usize {
+    conn.execute(
+        "UPDATE bookmarks SET status = 'expired'
+         WHERE status = 'active' AND expires_at IS NOT NULL AND expires_at <= ?1",
+        params![now_rfc3339],
+    )
+    .unwrap_or(0)
 }
 
 /// Create the local `mempalace_sync` mapping table if absent. Additive and safe
@@ -1589,6 +1623,34 @@ mod tests {
             tags: tags.iter().map(|s| s.to_string()).collect(),
             embedding: None,
         }
+    }
+
+    #[test]
+    fn expire_due_notes_sweeps_only_past_ttls() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+        conn.execute_batch(
+            "INSERT INTO bookmarks (id, label, created_at, approved, status, expires_at) VALUES
+               (1, 'past',     '2026-01-01T00:00:00Z', 1, 'active', '2026-01-02T00:00:00Z'),
+               (2, 'future',   '2026-01-01T00:00:00Z', 1, 'active', '2999-01-01T00:00:00Z'),
+               (3, 'noexpiry', '2026-01-01T00:00:00Z', 1, 'active', NULL);",
+        )
+        .unwrap();
+        let expired = expire_due_notes(&conn, "2026-06-01T00:00:00Z");
+        assert_eq!(expired, 1, "only the past-TTL note should expire");
+        let status = |id: i64| -> String {
+            conn.query_row(
+                "SELECT status FROM bookmarks WHERE id=?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(status(1), "expired"); // TTL passed
+        assert_eq!(status(2), "active"); // TTL in the future
+        assert_eq!(status(3), "active"); // no TTL
+                                         // Idempotent: a second sweep changes nothing.
+        assert_eq!(expire_due_notes(&conn, "2026-06-01T00:00:00Z"), 0);
     }
 
     #[test]

--- a/crates/mw-cli/src/storage.rs
+++ b/crates/mw-cli/src/storage.rs
@@ -101,7 +101,12 @@ pub fn initialize(conn: &Connection) -> Result<(), String> {
          CREATE INDEX IF NOT EXISTS idx_screenshots_command_run_id ON screenshots(command_run_id);
          CREATE INDEX IF NOT EXISTS idx_screenshots_captured_at ON screenshots(captured_at);",
     )
-    .map_err(|e| format!("failed to initialize database indexes: {e}"))
+    .map_err(|e| format!("failed to initialize database indexes: {e}"))?;
+
+    // Sweep TTL-expired notes on every open so retrieval stops surfacing them
+    // (their rows are preserved). Best-effort — never fails an open.
+    crate::expire_due_notes(conn, &chrono::Utc::now().to_rfc3339());
+    Ok(())
 }
 
 #[cfg(test)]

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -19,6 +19,7 @@ mw tui                                # interactive terminal browser (type to se
 mw git-fix                            # diagnose the last failed git command: what, why, the fix
 mw mark "before the risky flash"      # bookmark the current debugging moment
 mw remember "the fix was passing --features vendored-ssl"  # save a lesson/conclusion (warns on a near-duplicate; add --force to save anyway)
+mw remember "staging creds rotate friday" ttl:7d   # auto-expires after 7d (m/h/d/w) — drops from retrieval, evidence preserved
 mw replay 12                          # rerun a saved command run
 mw demo                               # seed a small demo dataset to explore
 mw rm 5                               # delete a session (+ its transcript); mw rm command <id> for a run


### PR DESCRIPTION
## What this changes

Adds an optional time-to-live to saved lessons:

```
mw remember "staging creds rotate friday" ttl:7d
mw: remembered #1: staging creds rotate friday (expires 2026-08-15)
```

Once the TTL passes, the note is swept out of retrieval automatically — its row (the evidence) is preserved, it just stops surfacing.

Closes #103. (VISION **Forget** lifecycle stage / roadmap phase 4.)

## Why this slice

`mw memory stale <id>` already does *explicit* forget (drop from retrieval, keep evidence). The genuinely-missing piece was *automatic* expiry — so this focuses there and reuses the existing `status` machinery rather than duplicating it.

## What's in it

- **Migration 7** — additive `expires_at` column on `bookmarks` (NULL = never expires). Bumps `LATEST_SCHEMA_VERSION` to 7.
- **`mw remember <text> ttl:<dur>`** — `dur` is `7d`/`24h`/`2w`/`30m` (reuses `parse_since`). Validated **before** the note is written, so a bad duration never leaves a row.
- **`expire_due_notes`** — sweeps past-TTL notes to `status='expired'` on every DB open (in `storage::open_path`). Retrieval already filters `status='active'`, so they drop with no core-loader change. Best-effort: never fails an open.
- Help text + `docs/CLI.md`.

## Verification (ran against a scratch data dir)

- `ttl:7d` note shows `(expires …)` and stays searchable
- a past-TTL note is swept to `expired` on the next open and disappears from search (its row remains in the DB)
- `ttl:banana` errors before saving (no row created)
- [x] `cargo test` — 48 pass, 0 fail (new `expire_due_notes` test: expires only past TTLs, idempotent)
- [x] `cargo fmt --check` clean

## Scope / follow-ups

CLI `mw remember`. Natural follow-ups: pin controls (never-expire override on decay), a `ttl` option on the MCP `remember` tool.

## Contribution rules checklist
- [x] Preserves original evidence — expiry flips a status flag; the row is never deleted
- [x] No implicit cloud sync
- [x] Additive migration only (new nullable column); older DBs unaffected
- [x] Works fully offline