### PR TITLE
feat(cli): link memories into a graph (mw link/unlink/links)

### DIFF
--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -60,6 +60,9 @@ fn run() -> Result<(), String> {
         Some("ask") => return ask_cmd(&raw_args[1..]),
         Some("search") => return search_memory(&raw_args[1..]),
         Some("explain") => return explain_cmd(&raw_args[1..]),
+        Some("link") => return link_cmd(&raw_args[1..]),
+        Some("unlink") => return unlink_cmd(&raw_args[1..]),
+        Some("links") => return links_cmd(&raw_args[1..]),
         Some("tui") => return memorywhale_cli::tui::run(),
         Some("sync-mempalace") => return sync_mempalace(&raw_args[1..]),
         Some("git-fix") => return git_fix_cmd(&raw_args[1..]),
@@ -286,6 +289,9 @@ fn print_help() {
          mw pull <ssh-host> [path] copy another machine's memory here and merge it (scp + import)\n\
          mw search <text> [--explain] [tag:X] [source:command|session|note|document|conversation] [after:YYYY-MM-DD] [before:YYYY-MM-DD] [limit:N] [--project X] [--machine Y] [--since 7d]  rank commands, sessions, and notes by relevance (--explain shows why)\n\
          mw explain <id> [query]  show the per-signal score breakdown for one memory (ids come from `mw search`)\n\
+         mw link <a> <b> [rel:<type>]  link two memories (default relation \"related\"); ids come from `mw search`\n\
+         mw unlink <a> <b> [rel:<type>]  remove the link between two memories\n\
+         mw links <id>            show a memory's linked neighbors (both directions)\n\
          mw tui                   interactive terminal browser: type to search, arrow keys to move, Enter to reveal the command\n\
          mw sync-mempalace [--wing NAME] [--limit N] [--dry-run]  sync local memories into a running MemPalace server, idempotent by memory id (needs mempalace_command in config)\n\
          mw git-fix [id]          diagnose the last failed git command (or one by id): what happened, the fix, seen before?\n\
@@ -3042,6 +3048,100 @@ fn explain_cmd(args: &[String]) -> Result<(), String> {
             "no memory with id {id} (list ids with `mw search`)"
         )),
     }
+}
+
+/// Load every memory keyed by its namespaced id — used to validate link targets
+/// and to render neighbor text.
+fn memory_map(
+    conn: &rusqlite::Connection,
+) -> std::collections::HashMap<i64, memorywhale_core::Memory> {
+    memorywhale_core::sqlite::load_memories(conn)
+        .into_iter()
+        .map(|m| (m.id, m))
+        .collect()
+}
+
+fn parse_link_id(arg: &str) -> Result<i64, String> {
+    arg.parse().map_err(|_| {
+        format!("invalid id {arg:?}: expected a numeric memory id (see the ids from `mw search`)")
+    })
+}
+
+/// `mw link <a> <b> [rel:<type>]` — create a typed edge between two memories.
+fn link_cmd(args: &[String]) -> Result<(), String> {
+    let rel = args
+        .iter()
+        .find_map(|a| a.strip_prefix("rel:"))
+        .filter(|r| !r.is_empty())
+        .unwrap_or("related");
+    let ids: Vec<&String> = args.iter().filter(|a| !a.starts_with("rel:")).collect();
+    let (a, b) = match ids.as_slice() {
+        [a, b] => (parse_link_id(a)?, parse_link_id(b)?),
+        _ => return Err("usage: mw link <a> <b> [rel:<type>]".to_string()),
+    };
+    let conn = open_session_db()?;
+    let known = memory_map(&conn);
+    for id in [a, b] {
+        if !known.contains_key(&id) {
+            return Err(format!(
+                "no memory with id {id} (list ids with `mw search`)"
+            ));
+        }
+    }
+    let added = memorywhale_cli::add_link(&conn, a, b, rel, &Utc::now().to_rfc3339())?;
+    if added {
+        println!("mw: linked #{a} -> #{b} [{rel}]");
+    } else {
+        println!("mw: #{a} -> #{b} [{rel}] already linked");
+    }
+    Ok(())
+}
+
+/// `mw unlink <a> <b> [rel:<type>]` — remove edge(s) between two memories.
+fn unlink_cmd(args: &[String]) -> Result<(), String> {
+    let rel = args.iter().find_map(|a| a.strip_prefix("rel:"));
+    let ids: Vec<&String> = args.iter().filter(|a| !a.starts_with("rel:")).collect();
+    let (a, b) = match ids.as_slice() {
+        [a, b] => (parse_link_id(a)?, parse_link_id(b)?),
+        _ => return Err("usage: mw unlink <a> <b> [rel:<type>]".to_string()),
+    };
+    let conn = open_session_db()?;
+    let removed = memorywhale_cli::remove_link(&conn, a, b, rel)?;
+    if removed == 0 {
+        return Err(format!("no link #{a} -> #{b} to remove"));
+    }
+    println!("mw: unlinked #{a} -> #{b} ({removed} edge(s))");
+    Ok(())
+}
+
+/// `mw links <id>` — show a memory's neighbors (both directions).
+fn links_cmd(args: &[String]) -> Result<(), String> {
+    let id = match args {
+        [id] => parse_link_id(id)?,
+        _ => return Err("usage: mw links <id>".to_string()),
+    };
+    let conn = open_session_db()?;
+    let map = memory_map(&conn);
+    if !map.contains_key(&id) {
+        return Err(format!(
+            "no memory with id {id} (list ids with `mw search`)"
+        ));
+    }
+    let links = memorywhale_cli::neighbors(&conn, id)?;
+    if links.is_empty() {
+        println!("mw: no links for #{id}");
+        return Ok(());
+    }
+    println!("# links for #{id}\n");
+    for l in links {
+        let arrow = if l.outgoing { "->" } else { "<-" };
+        let text = map
+            .get(&l.other_id)
+            .map(|m| m.text.chars().take(70).collect::<String>())
+            .unwrap_or_else(|| "(memory no longer present)".to_string());
+        println!("  {arrow} #{} [{}] {}", l.other_id, l.relation, text);
+    }
+    Ok(())
 }
 
 fn context_cmd(args: &[String]) -> Result<(), String> {

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -112,7 +112,7 @@ const BOOKMARKS_BASE: &str = "CREATE TABLE IF NOT EXISTS bookmarks (
      CREATE INDEX IF NOT EXISTS idx_bookmarks_created_at ON bookmarks(created_at);";
 
 /// Schema version `migrate` brings a database up to.
-pub const LATEST_SCHEMA_VERSION: i64 = 7;
+pub const LATEST_SCHEMA_VERSION: i64 = 8;
 
 /// Apply numbered schema migrations to a MemoryWhale database. Idempotent and
 /// cheap (a `user_version` check), so callers run it before touching bookmarks.
@@ -214,7 +214,113 @@ pub fn migrate(conn: &Connection) -> Result<(), String> {
         conn.execute_batch("PRAGMA user_version = 7;")
             .map_err(|e| format!("failed to migrate memory ttl: {e}"))?;
     }
+    if version < 8 {
+        // Typed edges between memories (namespaced ids), so recall can traverse
+        // relationships instead of scoring isolated items. Directed; neighbor
+        // lookups walk both directions.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS memory_links (
+                 from_id    INTEGER NOT NULL,
+                 to_id      INTEGER NOT NULL,
+                 relation   TEXT NOT NULL DEFAULT 'related',
+                 created_at TEXT,
+                 PRIMARY KEY (from_id, to_id, relation)
+             );
+             CREATE INDEX IF NOT EXISTS idx_memory_links_to ON memory_links(to_id);
+             PRAGMA user_version = 8;",
+        )
+        .map_err(|e| format!("failed to migrate memory links: {e}"))?;
+    }
     Ok(())
+}
+
+/// A neighbor of a memory in the link graph: the other memory's id, the
+/// relation label, and which way the edge points (`out` = this→other).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Link {
+    pub other_id: i64,
+    pub relation: String,
+    pub outgoing: bool,
+}
+
+/// Create a typed directed edge `from_id -> to_id`. Idempotent (same triple is a
+/// no-op). Returns whether a new edge was added.
+pub fn add_link(
+    conn: &Connection,
+    from_id: i64,
+    to_id: i64,
+    relation: &str,
+    now_rfc3339: &str,
+) -> Result<bool, String> {
+    if from_id == to_id {
+        return Err("a memory can't be linked to itself".to_string());
+    }
+    let changed = conn
+        .execute(
+            "INSERT OR IGNORE INTO memory_links (from_id, to_id, relation, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![from_id, to_id, relation, now_rfc3339],
+        )
+        .map_err(|e| format!("failed to link memories: {e}"))?;
+    Ok(changed > 0)
+}
+
+/// Remove edges between two memories in the given direction. When `relation` is
+/// `None`, all relations for that direction are removed. Returns the count.
+pub fn remove_link(
+    conn: &Connection,
+    from_id: i64,
+    to_id: i64,
+    relation: Option<&str>,
+) -> Result<usize, String> {
+    let n = match relation {
+        Some(rel) => conn.execute(
+            "DELETE FROM memory_links WHERE from_id = ?1 AND to_id = ?2 AND relation = ?3",
+            params![from_id, to_id, rel],
+        ),
+        None => conn.execute(
+            "DELETE FROM memory_links WHERE from_id = ?1 AND to_id = ?2",
+            params![from_id, to_id],
+        ),
+    }
+    .map_err(|e| format!("failed to unlink memories: {e}"))?;
+    Ok(n)
+}
+
+/// All neighbors of `id` — outgoing (`id -> other`) and incoming (`other -> id`).
+pub fn neighbors(conn: &Connection, id: i64) -> Result<Vec<Link>, String> {
+    let mut out = Vec::new();
+    let mut stmt = conn
+        .prepare("SELECT to_id, relation FROM memory_links WHERE from_id = ?1")
+        .map_err(|e| format!("failed to read links: {e}"))?;
+    let rows = stmt
+        .query_map(params![id], |r| {
+            Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+        })
+        .map_err(|e| format!("failed to read links: {e}"))?;
+    for (other_id, relation) in rows.flatten() {
+        out.push(Link {
+            other_id,
+            relation,
+            outgoing: true,
+        });
+    }
+    let mut stmt = conn
+        .prepare("SELECT from_id, relation FROM memory_links WHERE to_id = ?1")
+        .map_err(|e| format!("failed to read links: {e}"))?;
+    let rows = stmt
+        .query_map(params![id], |r| {
+            Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+        })
+        .map_err(|e| format!("failed to read links: {e}"))?;
+    for (other_id, relation) in rows.flatten() {
+        out.push(Link {
+            other_id,
+            relation,
+            outgoing: false,
+        });
+    }
+    Ok(out)
 }
 
 /// Set (or clear, with `None`) a note's expiry. `expires_at` is RFC3339.
@@ -1623,6 +1729,34 @@ mod tests {
             tags: tags.iter().map(|s| s.to_string()).collect(),
             embedding: None,
         }
+    }
+
+    #[test]
+    fn links_are_idempotent_directional_and_removable() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+        let now = "2026-06-01T00:00:00Z";
+
+        // First add creates the edge; a duplicate is a no-op.
+        assert!(add_link(&conn, 10, 20, "fixed-by", now).unwrap());
+        assert!(!add_link(&conn, 10, 20, "fixed-by", now).unwrap());
+        // Self-links are rejected.
+        assert!(add_link(&conn, 10, 10, "related", now).is_err());
+
+        // Neighbors: 10 sees it outgoing, 20 sees it incoming.
+        let from_10 = neighbors(&conn, 10).unwrap();
+        assert_eq!(from_10.len(), 1);
+        assert!(
+            from_10[0].outgoing && from_10[0].other_id == 20 && from_10[0].relation == "fixed-by"
+        );
+        let from_20 = neighbors(&conn, 20).unwrap();
+        assert_eq!(from_20.len(), 1);
+        assert!(!from_20[0].outgoing && from_20[0].other_id == 10);
+
+        // Remove is directional and counts what it deleted.
+        assert_eq!(remove_link(&conn, 10, 20, None).unwrap(), 1);
+        assert!(neighbors(&conn, 10).unwrap().is_empty());
+        assert_eq!(remove_link(&conn, 10, 20, None).unwrap(), 0);
     }
 
     #[test]

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -15,6 +15,8 @@ mw show 1                             # print the full transcript of a session
 mw search "linker error"              # search commands, output, notes, transcripts
 mw search docker after:2026-01-01 tag:infra   # filter results: tag:X, source:command|session|note|document|conversation, before:/after:YYYY-MM-DD, limit:N
 mw explain 1000000001                 # why this memory ranks: per-signal breakdown (ids come from `mw search`)
+mw link 1000000001 3000000001 rel:fixed-by   # link two memories (typed edge; ids from `mw search`)
+mw links 1000000001                   # show a memory's linked neighbors (both directions); mw unlink <a> <b> removes
 mw tui                                # interactive terminal browser (type to search, Enter to act, F1 help, Esc quit)
 mw git-fix                            # diagnose the last failed git command: what, why, the fix
 mw mark "before the risky flash"      # bookmark the current debugging moment


### PR DESCRIPTION
## What this changes

Adds the ability to link memories with typed edges, and inspect a memory's neighbors:

```
mw link 1000000001 3000000001 rel:fixed-by   # a command ↔ the note that fixed it
mw links 1000000001
# links for #1000000001
  -> #3000000001 [fixed-by] Tauri build failed here; install missing Linux packages.
mw unlink 1000000001 3000000001
```

Closes #104. (VISION **Link** lifecycle stage / roadmap phase 3.)

## What's in it

- **Migration 8** — `memory_links(from_id, to_id, relation, created_at)`, directed, indexed both directions. Bumps `LATEST_SCHEMA_VERSION` to 8.
- **`add_link` / `remove_link` / `neighbors`** in the cli lib (pure, unit-tested): idempotent inserts (`INSERT OR IGNORE`), self-link rejected, directional removal with a count, neighbor walk in both directions.
- **`mw link <a> <b> [rel:<type>]`** (default relation `related`), **`mw unlink <a> <b> [rel:<type>]`**, **`mw links <id>`**. Ids are the namespaced ids from `mw search`; both are validated against existing memories. `links` renders each neighbor's text and edge direction.
- help text + `docs/CLI.md`.

## Verification (ran against seeded demo data)

- link a command → a note (`rel:fixed-by`); duplicate link is idempotent ("already linked")
- `mw links` shows the edge as **outgoing** from one side and **incoming** (`<-`) from the other
- self-link and unknown-id are rejected with clear errors (exit 1)
- `mw unlink` removes it; `mw links` then shows none
- [x] `cargo test` — 49 pass, 0 fail (new link test: idempotent / directional / removable / self-link guard)
- [x] `cargo fmt --check` clean

## Scope / follow-ups

This lands the **link data model + CLI**. The two natural next steps (called out in #104):
- **graph-aware retrieval** — recall expanding along edges ("retrieval as traversal")
- the **desktop graph view**

## Contribution rules checklist
- [x] Preserves original evidence — links are a separate additive table; no memory rows touched
- [x] No implicit cloud sync
- [x] Additive migration only (new table); older DBs unaffected
- [x] Works fully offline