### PR TITLE
chore: prepare v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to MemoryWhale are documented here. This project follows
+[Semantic Versioning](https://semver.org/).
+
+## [0.7.0]
+
+Product version `0.7.0`; `memorywhale-core` `0.3.0`.
+
+### Added
+
+- **`mw explain <id>`** — per-signal score breakdown for a single memory
+  (similarity, recency, importance, reinforcement, task). `mw search` now prints
+  each result's `#id` so it's discoverable. (#91)
+- **Search filters** on `mw search`: `tag:`, `source:`, `before:`/`after:`
+  (YYYY-MM-DD), and `limit:` — e.g. `mw search docker after:2026-01-01 tag:infra`. (#105)
+- **Duplicate detection** on `mw remember` — a near-identical lesson is refused
+  with a clear message; `--force` keeps both. Read-only (never merges/deletes). (#106)
+- **TTL / auto-expiring memories** — `mw remember <text> ttl:7d` (m/h/d/w). Past
+  their TTL, notes are swept out of retrieval on open; the row (evidence) is
+  preserved. (#103)
+- **Memory links** — `mw link <a> <b> [rel:<type>]`, `mw unlink`, and
+  `mw links <id>` to build and inspect a typed graph between memories. (#104)
+- **MCP client integrations** under `integrations/`: OpenClaw, CrowClaw, Goose,
+  Claude Desktop, Cline, Continue, and Gemini CLI — each `mw-mcp` plugs in with
+  no new code.
+- GitHub issue and pull-request templates encoding the project's contribution
+  rules.
+
+### Fixed
+
+- **`parse_ts` no longer masquerades corrupt timestamps as "now."** A malformed
+  RFC3339 timestamp now falls back to the Unix epoch (and warns) instead of
+  `Utc::now()`, so a corrupted row sorts as oldest rather than getting an
+  unearned recency boost. (#101)
+
+### Security
+
+- **The installer verifies release integrity.** Releases now publish a
+  `<asset>.sha256`, and `install.sh` checks the downloaded tarball against it,
+  aborting on a mismatch. Older releases without a checksum are skipped with a
+  warning. (#102)
+
+### Notes
+
+- Schema migrations to `user_version = 8` are additive (a nullable `expires_at`
+  column and a new `memory_links` table); existing databases upgrade in place.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ Product version `0.7.0`; `memorywhale-core` `0.3.0`.
 - **Memory links** — `mw link <a> <b> [rel:<type>]`, `mw unlink`, and
   `mw links <id>` to build and inspect a typed graph between memories. (#104)
 - **MCP client integrations** under `integrations/`: OpenClaw, CrowClaw, Goose,
-  Claude Desktop, Cline, Continue, and Gemini CLI — each `mw-mcp` plugs in with
-  no new code.
+  Claude Desktop, Cline, Continue, Gemini CLI, and Zed — each `mw-mcp` plugs in
+  with no new code.
 - GitHub issue and pull-request templates encoding the project's contribution
   rules.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale-cli"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale-core"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/memorywhale-core/Cargo.toml
+++ b/crates/memorywhale-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale-core"
-version = "0.2.5"
+version = "0.3.0"
 edition = "2021"
 description = "Explainable retrieval for MemoryWhale: a MemoryEngine interface, a built-in scorer that ranks memories with per-signal reasons, and an optional MemPalace backend over MCP."
 license = "MIT"

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale-cli"
-version = "0.6.2"
+version = "0.7.0"
 description = "MemoryWhale CLI — local-first terminal memory. Record commands, sessions, and output into local SQLite; browse them in a built-in web dashboard. Nothing is uploaded."
 authors = ["Isabel Wu <wuisabel@usc.edu>"]
 license = "MIT"
@@ -21,7 +21,7 @@ dirs = "5"
 # MCP server, with a builtin fallback when that server is unreachable.
 # `version` (alongside `path`) is required so `cargo publish` can resolve the
 # dependency from crates.io — publish memorywhale-core first, then this crate.
-memorywhale-core = { path = "../memorywhale-core", version = "0.2.5", features = ["mempalace"] }
+memorywhale-core = { path = "../memorywhale-core", version = "0.3.0", features = ["mempalace"] }
 regex = "1"
 # Pure-Rust interactive terminal UI (`mw tui`) — no system libraries, so it
 # keeps the bare-machine / Jetson build story intact. Bundles crossterm.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorywhale",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorywhale",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorywhale",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale"
-version = "0.6.2"
+version = "0.7.0"
 description = "A Rust/Tauri visual second brain for local knowledge graphs"
 authors = ["MemoryWhale"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MemoryWhale",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "identifier": "com.memorywhale.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## What this changes

Bumps versions and adds an accurate changelog for **v0.7.0**.

- Product version **0.6.2 → 0.7.0**: `crates/mw-cli/Cargo.toml`, `package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`.
- `memorywhale-core` **0.2.5 → 0.3.0** (it changed — the `parse_ts` fix): the crate version, the mw-cli dependency pin, and `Cargo.lock`.
- New **`CHANGELOG.md`** with a v0.7.0 entry covering everything merged since v0.6.2.

## Why fresh (supersedes #89)

#89 was opened 2026-07-24, before any of the v0.7.0 work landed, so its changelog was inaccurate and it conflicts heavily with `main`. This is a clean, minimal prep whose changelog reflects what actually shipped.

## v0.7.0 highlights (in the changelog)

- **Added:** `mw explain`, search filters (`tag:`/`source:`/`before:`/`after:`/`limit:`), duplicate detection on `remember`, TTL (`ttl:7d`), memory links (`link`/`unlink`/`links`), 7 MCP integrations, issue/PR templates.
- **Fixed:** `parse_ts` epoch fallback (#101).
- **Security:** installer checksum verification (#102).

## Verification

- [x] `scripts/check-release-version.sh v0.7.0` → "release version 0.7.0 is consistent"
- [x] `cargo check -p memorywhale-cli -p memorywhale-core` (Cargo.lock synced to 0.7.0 / 0.3.0)

## Follow-up

After this merges, tag `v0.7.0` to trigger the release workflow (which now also publishes `.sha256` checksums).