### PR TITLE
docs(zed): add MCP integration guide

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -26,6 +26,7 @@ file differs. Per-client setup (config + a "when to use it" rule):
 - **Cursor** → [`cursor/`](cursor/README.md)
 - **VS Code / GitHub Copilot** (agent mode) → [`vscode/`](vscode/README.md)
 - **Windsurf** → [`windsurf/`](windsurf/README.md)
+- **Zed** → [`zed/`](zed/README.md)
 - **Codex CLI** → [`codex/`](codex/README.md)
 - **OpenClaw** → [`openclaw/`](openclaw/README.md)
 - **CrowClaw** → [`crowclaw/`](crowclaw/README.md)
@@ -34,7 +35,7 @@ file differs. Per-client setup (config + a "when to use it" rule):
 - **Cline** (VS Code) → [`cline/`](cline/README.md)
 - **Continue** (VS Code / JetBrains) → [`continue/`](continue/README.md)
 - **Gemini CLI** (Google) → [`gemini-cli/`](gemini-cli/README.md)
-- **Any other MCP client** (Zed, …) — add a stdio server whose
+- **Any other MCP client** — add a stdio server whose
   command is `mw-mcp` (no arguments). It honours `MEMORYWHALE_DATA_DIR` like the
   rest of the CLI.
 

--- a/integrations/zed/README.md
+++ b/integrations/zed/README.md
@@ -1,0 +1,41 @@
+# Zed integration
+
+Zed supports custom MCP servers, so its Agent Panel can use MemoryWhale's four
+tools: `recent_errors`, `search_memory`, `get_context`, and `remember`.
+
+## Connect the MCP server
+
+Open **Settings → AI → MCP Servers** and choose **Add Server → Add Local
+Server**, or run `agent: open settings` and open the JSON settings file. Merge
+the [`settings.json`](settings.json) example into your existing settings:
+
+```json
+{
+  "context_servers": {
+    "memorywhale": {
+      "command": "mw-mcp",
+      "args": [],
+      "env": {}
+    }
+  }
+}
+```
+
+`mw-mcp` must be on `PATH` (standard MemoryWhale install); otherwise use its
+absolute path. For a non-default database, add
+`"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`.
+
+After saving, open the Agent Panel settings and confirm that `memorywhale` has
+a green running indicator. Zed's canonical custom-server documentation is
+[Model Context Protocol](https://zed.dev/docs/ai/mcp).
+
+## Tell the agent when to reach for memory
+
+Add this to your project or user rules:
+
+> When a build, test, or deploy fails, use `search_memory` or `recent_errors`
+> before proposing a fix. After finding the cause or a working fix, use
+> `remember` to save the conclusion.
+
+Without the MCP server, the CLI remains available: `mw context --last-error`,
+`mw search "…"`, and `mw remember "…"`.

--- a/integrations/zed/settings.json
+++ b/integrations/zed/settings.json
@@ -1,0 +1,9 @@
+{
+  "context_servers": {
+    "memorywhale": {
+      "command": "mw-mcp",
+      "args": [],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
Adds `integrations/zed/` (Zed `context_servers` config for `mw-mcp` + README) and lists Zed in `integrations/README.md`.

**Authored by @adity982** — this is their work from #94, rebased onto current `main` to resolve the integrations-list conflict (the list gained several entries after #94 was opened). The commit author is preserved. Supersedes #94, which was stuck as a Draft with a stale merge base.

Closes #90.

Config verified against [Zed's official MCP docs](https://zed.dev/docs/ai/mcp): `context_servers` with `command` as a string plus sibling `args`/`env`, no `source` field needed.