### PR TITLE
test(storage): v0.6.2 database upgrades without data loss

### DIFF
--- a/crates/mw-cli/src/storage.rs
+++ b/crates/mw-cli/src/storage.rs
@@ -114,6 +114,166 @@ mod tests {
     use super::*;
 
     #[test]
+    fn v0_6_2_database_upgrades_without_data_loss() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE sessions (
+                id INTEGER PRIMARY KEY,
+                shell TEXT,
+                cwd TEXT,
+                transcript_path TEXT NOT NULL DEFAULT '',
+                transcript TEXT NOT NULL DEFAULT '',
+                notes TEXT NOT NULL DEFAULT '',
+                started_at TEXT NOT NULL DEFAULT '',
+                ended_at TEXT NOT NULL DEFAULT '',
+                byte_count INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'finished',
+                project TEXT,
+                machine TEXT
+            );
+            CREATE TABLE command_runs (
+                id INTEGER PRIMARY KEY,
+                command TEXT NOT NULL,
+                argv_json TEXT NOT NULL,
+                cwd TEXT,
+                exit_code INTEGER,
+                stdout TEXT NOT NULL DEFAULT '',
+                stderr TEXT NOT NULL DEFAULT '',
+                notes TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL,
+                capture_kind TEXT NOT NULL DEFAULT 'full',
+                error_fingerprint TEXT
+            );
+            CREATE TABLE command_arguments (
+                id INTEGER PRIMARY KEY,
+                command_run_id INTEGER NOT NULL,
+                position INTEGER NOT NULL,
+                value TEXT NOT NULL,
+                FOREIGN KEY(command_run_id) REFERENCES command_runs(id) ON DELETE CASCADE
+            );
+            CREATE TABLE bookmarks (
+                id INTEGER PRIMARY KEY,
+                label TEXT NOT NULL,
+                cwd TEXT,
+                created_at TEXT NOT NULL,
+                command_run_id INTEGER,
+                session_id INTEGER,
+                author_kind TEXT NOT NULL DEFAULT 'human',
+                author_name TEXT,
+                source_session_id INTEGER,
+                approved INTEGER NOT NULL DEFAULT 1
+            );
+            CREATE TABLE screenshots (
+                id INTEGER PRIMARY KEY,
+                command_run_id INTEGER,
+                file_path TEXT NOT NULL,
+                cwd TEXT,
+                notes TEXT NOT NULL DEFAULT '',
+                captured_at TEXT NOT NULL,
+                FOREIGN KEY(command_run_id) REFERENCES command_runs(id) ON DELETE SET NULL
+            );
+            CREATE TABLE mempalace_sync (
+                mw_id INTEGER PRIMARY KEY,
+                wing TEXT NOT NULL,
+                drawer_id TEXT NOT NULL,
+                content_hash TEXT NOT NULL,
+                synced_at TEXT NOT NULL
+            );
+
+            INSERT INTO sessions
+                (id, shell, cwd, transcript_path, transcript, notes, started_at,
+                 ended_at, byte_count, status, project, machine)
+            VALUES
+                (11, 'zsh', '/work/project', '/tmp/session.log',
+                 'cargo test failed, then passed', 'project:upgrade-test',
+                 '2026-07-20T10:00:00Z', '2026-07-20T10:05:00Z', 30,
+                 'finished', 'upgrade-test', 'laptop');
+            INSERT INTO command_runs
+                (id, command, argv_json, cwd, exit_code, stdout, stderr, notes,
+                 created_at, capture_kind, error_fingerprint)
+            VALUES
+                (12, 'cargo', '[\"cargo\",\"test\"]', '/work/project', 1, '',
+                 'linker failed', 'before upgrade',
+                 '2026-07-20T10:01:00Z', 'full', 'linker-fingerprint');
+            INSERT INTO command_arguments
+                (id, command_run_id, position, value)
+            VALUES (13, 12, 0, 'test');
+            INSERT INTO bookmarks
+                (id, label, cwd, created_at, command_run_id, session_id,
+                 author_kind, author_name, source_session_id, approved)
+            VALUES
+                (14, 'install the linker before building', '/work/project',
+                 '2026-07-20T10:02:00Z', 12, 11, 'human', NULL, NULL, 1);
+            INSERT INTO screenshots
+                (id, command_run_id, file_path, cwd, notes, captured_at)
+            VALUES
+                (15, 12, '/tmp/failure.png', '/work/project', 'failure state',
+                 '2026-07-20T10:03:00Z');
+            INSERT INTO mempalace_sync
+                (mw_id, wing, drawer_id, content_hash, synced_at)
+            VALUES
+                (16, 'terminal', 'drawer-16', 'abc123',
+                 '2026-07-20T10:04:00Z');
+            PRAGMA user_version = 5;
+            ",
+        )
+        .unwrap();
+
+        initialize(&conn).unwrap();
+
+        assert_eq!(
+            conn.query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            crate::LATEST_SCHEMA_VERSION
+        );
+        let lifecycle: (String, Option<i64>) = conn
+            .query_row(
+                "SELECT status, superseded_by_id FROM bookmarks WHERE id = 14",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(lifecycle, ("active".to_string(), None));
+
+        for (table, expected) in [
+            ("sessions", 1_i64),
+            ("command_runs", 1),
+            ("command_arguments", 1),
+            ("bookmarks", 1),
+            ("screenshots", 1),
+            ("mempalace_sync", 1),
+        ] {
+            let count: i64 = conn
+                .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                    row.get(0)
+                })
+                .unwrap();
+            assert_eq!(count, expected, "{table} rows changed during upgrade");
+        }
+
+        let memories = memorywhale_core::sqlite::load_memories(&conn);
+        assert!(
+            memories
+                .iter()
+                .any(|memory| memory.text.contains("install the linker")),
+            "the released bookmark remains retrievable after migration"
+        );
+        assert!(
+            memories
+                .iter()
+                .any(|memory| memory.text.contains("linker failed")),
+            "the released command failure remains retrievable after migration"
+        );
+
+        initialize(&conn).unwrap();
+        let bookmark_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM bookmarks", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(bookmark_count, 1, "reopening the upgraded DB is idempotent");
+    }
+
+    #[test]
     fn fresh_database_has_the_canonical_schema_and_connection_policy() {
         let conn = Connection::open_in_memory().unwrap();
         initialize(&conn).unwrap();


### PR DESCRIPTION
## What this changes

Adds a regression test that builds a **v0.6.2-shaped database** (schema version 5), runs `initialize()`, and asserts the upgrade is lossless:

- `user_version` reaches `LATEST_SCHEMA_VERSION`
- lifecycle columns backfill (`status='active'`, `superseded_by_id=NULL`)
- every table keeps its row count
- saved memories stay retrievable via `load_memories`
- re-opening the upgraded DB is idempotent

Because it pins to `LATEST_SCHEMA_VERSION`, it also now covers this release's new migrations — **v7 (`expires_at`)** and **v8 (`memory_links`)**.

## Why

**Salvaged from the stale #89.** That PR (opened before all the v0.7.0 work) bundled this genuinely-useful test with a now-inaccurate release bump. Rather than rebase 3 weeks of conflicts, this lifts just the test onto current `main`, where it passes as-is.

## Verification

- [x] `cargo test` — 50 pass, 0 fail (this test included)
- [x] `cargo fmt --check` clean