### PR TITLE
feat(cli): add --version and -V flags

### DIFF
--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -39,6 +39,10 @@ fn main() {
 fn run() -> Result<(), String> {
     let raw_args: Vec<String> = env::args().skip(1).collect();
     match raw_args.first().map(String::as_str) {
+        Some("--version") | Some("-V") => {
+            println!("mw {}", env!("CARGO_PKG_VERSION"));
+            return Ok(());
+        }
         Some("show") => return show_session(&raw_args[1..]),
         Some("list") => return list_sessions(&raw_args[1..]),
         Some("mark") => return mark_bookmark(&raw_args[1..]),
@@ -269,6 +273,7 @@ fn print_help() {
     println!(
         "mw [--notes <text>]      record a whole shell session until you exit\n\
          mw --live [--notes <text>]  autosave the session to SQLite while it is still running\n\
+         mw --version | -V          print the current MemoryWhale version\n\
          mw list [--project X] [--machine Y] [--since 7d]  list recorded sessions\n\
          mw show <id>             print the full faithful transcript of a session\n\
          mw mark <text>           bookmark the current debugging moment\n\

--- a/crates/mw-cli/tests/version.rs
+++ b/crates/mw-cli/tests/version.rs
@@ -1,0 +1,40 @@
+use std::process::Command;
+
+fn assert_version_flag(flag: &str, sandbox_name: &str) {
+    let data_dir =
+        std::env::temp_dir().join(format!("mw-version-{sandbox_name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&data_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_mw"))
+        .arg(flag)
+        .env("MEMORYWHALE_DATA_DIR", &data_dir)
+        .output()
+        .expect("run mw version command");
+
+    assert!(output.status.success(), "{flag} failed: {output:?}");
+    let stdout = std::str::from_utf8(&output.stdout).expect("version output is UTF-8");
+    assert_eq!(
+        stdout.trim_end(),
+        format!("mw {}", env!("CARGO_PKG_VERSION"))
+    );
+    assert_eq!(
+        stdout.lines().count(),
+        1,
+        "unexpected version output: {stdout:?}"
+    );
+    assert!(output.stderr.is_empty(), "unexpected stderr: {output:?}");
+    assert!(
+        !data_dir.exists(),
+        "{flag} created the MemoryWhale data directory"
+    );
+}
+
+#[test]
+fn long_version_flag_prints_version_without_initializing_database() {
+    assert_version_flag("--version", "long");
+}
+
+#[test]
+fn short_version_flag_prints_version_without_initializing_database() {
+    assert_version_flag("-V", "short");
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -10,6 +10,7 @@ you're working from a source checkout instead, prefix any command with
 ```bash
 mw --notes "Jetson build debugging"   # record a whole shell session until exit
 mw --live --notes "project:demo"      # autosave to SQLite every few seconds
+mw --version                           # print the installed MemoryWhale version
 mw list                               # list recorded sessions
 mw show 1                             # print the full transcript of a session
 mw search "linker error"              # search commands, output, notes, transcripts


### PR DESCRIPTION
## What this changes

Adds `mw --version` and `mw -V`, printing the CLI crate version before any session or database initialization.

Closes #123

## Why it matters

The bug-report template asks users for `mw --version`, but the command currently fails. A stable version command makes support evidence reproducible without touching the local memory store.

## What's in it

- early dispatch for both version flags using `CARGO_PKG_VERSION`
- help and CLI reference updates
- process-level regressions for exact output, successful exit, empty stderr, and zero data-directory creation

## Verification

- [ ] `npm run build` — frontend not touched
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p memorywhale-core -p memorywhale-cli`
- [x] strict Clippy for both non-desktop crates and all targets
- [x] full `memorywhale-core` + `memorywhale-cli` suites
- [x] release build for every CLI binary
- [x] release smoke: both flags print `mw 0.7.0`; sandbox data directory remains absent
- [ ] Tested against personal MemoryWhale data — intentionally not needed; tests use isolated nonexistent data directories

## Contribution rules checklist

- [x] Capture/evidence paths are unchanged
- [x] No implicit cloud sync
- [x] No database schema or data changes
- [x] Works fully offline, with no account or server