### PR TITLE
docs(contributing): update commands for Cargo workspace

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,12 @@ Closes #
 
 ## Verification
 <!-- How you know it works. Paste output/screenshots where useful. -->
-- [ ] `npm run build` passes
-- [ ] `cargo fmt` + `cargo check` pass (in `src-tauri/`)
+- [ ] `npm test` passes when frontend code changes
+- [ ] `npm run build` passes when frontend code changes
+- [ ] `cargo fmt --all -- --check` passes when Rust code changes
+- [ ] `cargo clippy -p memorywhale-core -p memorywhale-cli --all-targets -- -D warnings` passes when Rust code changes
+- [ ] `cargo test -p memorywhale-core -p memorywhale-cli` passes when Rust code changes
+- [ ] `cargo build --workspace` passes for workspace changes
 - [ ] Tested locally against my own MemoryWhale data
 
 ## Contribution rules checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,20 +43,17 @@ Run frontend checks:
 ```bash
 npm run build
 ```
-
-Run Rust checks:
+Run Rust formatting checks:
 
 ```bash
-cd src-tauri
-cargo fmt
-cargo check
+cargo fmt --all -- --check
+
 ```
 
 Try the terminal memory helper:
 
 ```bash
-cd src-tauri
-cargo run --bin mw-remember -- --help
+cargo run -p memorywhale-cli --bin mw-remember -- --help
 ```
 
 ## Contribution Rules
@@ -83,7 +80,11 @@ cargo run --bin mw-remember -- --help
 
 - The change preserves or improves local-first behavior.
 - Command/log memory remains searchable.
+- `npm test` passes when frontend code changes.
 - `npm run build` passes when frontend code changes.
-- `cargo fmt` and `cargo check` pass when Rust code changes.
+- `cargo fmt --all -- --check` passes when Rust code changes.
+- `cargo clippy -p memorywhale-core -p memorywhale-cli --all-targets -- -D warnings` passes when Rust code changes.
+- `cargo test -p memorywhale-core -p memorywhale-cli` passes when Rust code changes.
+- `cargo build --workspace` passes for workspace changes.
 - Documentation is updated for user-facing behavior.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,13 +41,17 @@ npm run tauri:dev
 Run frontend checks:
 
 ```bash
+npm test
 npm run build
 ```
-Run Rust formatting checks:
+
+Run Rust checks:
 
 ```bash
 cargo fmt --all -- --check
-
+cargo clippy -p memorywhale-core -p memorywhale-cli --all-targets -- -D warnings
+cargo test -p memorywhale-core -p memorywhale-cli
+cargo build --workspace
 ```
 
 Try the terminal memory helper:
@@ -87,4 +91,3 @@ cargo run -p memorywhale-cli --bin mw-remember -- --help
 - `cargo test -p memorywhale-core -p memorywhale-cli` passes when Rust code changes.
 - `cargo build --workspace` passes for workspace changes.
 - Documentation is updated for user-facing behavior.
-


### PR DESCRIPTION
## Summary

- Updated Cargo commands to work from the repository root.
- Updated the mw-remember command to target the memorywhale-cli package.
- Updated Rust checks and the PR checklist to match the current workspace.

Closes #124