### PR TITLE
feat: install the Hermes memory integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/integration_request.md
+++ b/.github/ISSUE_TEMPLATE/integration_request.md
@@ -7,8 +7,9 @@ labels: documentation, good first issue
 
 ## Summary
 <!-- Which tool, and confirm it speaks MCP (can run a local stdio server). -->
-`<tool>` supports MCP servers, so it can use MemoryWhale's four tools
-(`recent_errors`, `search_memory`, `get_context`, `remember`). Add
+`<tool>` supports MCP servers, so it can use MemoryWhale's six tools
+(`recent_errors`, `search_memory`, `get_context`, `remember`,
+`similar_failures`, `stats`). Add
 `integrations/<tool>/`.
 
 ## Why it's a good first issue

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,6 +2188,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -3360,6 +3361,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4472,6 +4486,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/README.md
+++ b/README.md
@@ -170,9 +170,10 @@ mw ask                          # or: mw ask "why does this keep breaking"
 mw context --last-error         # smaller digest, same idea, no browser
 ```
 
-See [integrations/](integrations/README.md) for the MCP tools, a Claude Code
-hook that auto-records every command the agent runs, and a skill that knows
-when to read from (and write to) the memory.
+See [integrations/](integrations/README.md) for the MCP tools and setup guides,
+including [Hermes Agent](integrations/hermes/README.md), plus a Claude Code hook
+that auto-records every command the agent runs and a skill that knows when to
+read from (and write to) the memory.
 
 ## Web dashboard (solo or team)
 

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -29,6 +29,7 @@ ratatui = "0.29"
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 
 # Parent-death detection (prctl on Linux, getppid/pipe-EOF elsewhere).
 [target.'cfg(unix)'.dependencies]

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -75,6 +75,7 @@ fn run() -> Result<(), String> {
         Some("global") => return global_cmd(&raw_args[1..]),
         Some("status") => return global_status(),
         Some("hooks") => return hooks_cmd(&raw_args[1..]),
+        Some("integrate") => return integrate_cmd(&raw_args[1..]),
         Some("--help") | Some("-h") => {
             print_help();
             return Ok(());
@@ -308,11 +309,29 @@ fn print_help() {
          mw doctor                check the install: data dir, database, `script`, and hook status\n\
          mw global on|off|status  auto-record every new terminal by wiring a shell startup hook\n\
          mw hooks install|uninstall  always-on lightweight capture: command, cwd, exit code, duration (no output)\n\
+         mw integrate hermes       register mw-mcp in Hermes Agent's config\n\
          \n\
          Records every command + output, stored locally and never uploaded.\n\
          Raw transcript: <data_local>/MemoryWhale/sessions/\n\
          Metadata + cleaned transcript: <data_local>/MemoryWhale/memorywhale.sqlite3 (sessions table)"
     );
+}
+
+fn integrate_cmd(args: &[String]) -> Result<(), String> {
+    match args.first().map(String::as_str) {
+        Some("hermes") if args.len() == 1 => {
+            let config_path = memorywhale_cli::hermes::install()?;
+            println!(
+                "MemoryWhale added to Hermes Agent in {}",
+                config_path.display()
+            );
+            Ok(())
+        }
+        Some(other) => Err(format!(
+            "unsupported integration {other:?}; usage: mw integrate hermes"
+        )),
+        None => Err("usage: mw integrate hermes".to_string()),
+    }
 }
 
 /// Shown only on a genuine cold start: no hook wired and nothing recorded yet.

--- a/crates/mw-cli/src/hermes.rs
+++ b/crates/mw-cli/src/hermes.rs
@@ -1,0 +1,99 @@
+//! Hermes Agent configuration integration.
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+const SERVER: &str = "  memorywhale:\n    command: \"mw-mcp\"\n";
+
+/// Register MemoryWhale's MCP server in the current Hermes home.
+///
+/// Existing settings and comments are preserved. Both the original and
+/// resulting documents are validated before any write occurs.
+pub fn install() -> Result<PathBuf, String> {
+    let hermes_home = if let Some(path) = env::var_os("HERMES_HOME") {
+        PathBuf::from(path)
+    } else {
+        dirs::home_dir()
+            .ok_or_else(|| "could not resolve the home directory".to_string())?
+            .join(".hermes")
+    };
+    fs::create_dir_all(&hermes_home)
+        .map_err(|err| format!("failed to create {}: {err}", hermes_home.display()))?;
+    let config_path = hermes_home.join("config.yaml");
+    let existing = if config_path.exists() {
+        fs::read_to_string(&config_path)
+            .map_err(|err| format!("failed to read {}: {err}", config_path.display()))?
+    } else {
+        String::new()
+    };
+    validate(&existing)?;
+    let updated = add_server(&existing);
+    validate(&updated)?;
+    fs::write(&config_path, updated)
+        .map_err(|err| format!("failed to write {}: {err}", config_path.display()))?;
+    Ok(config_path)
+}
+
+fn validate(config: &str) -> Result<(), String> {
+    if config.trim().is_empty() {
+        return Ok(());
+    }
+    let value: serde_yaml::Value = serde_yaml::from_str(config)
+        .map_err(|err| format!("invalid Hermes config; file was not changed: {err}"))?;
+    let root = value
+        .as_mapping()
+        .ok_or_else(|| "invalid Hermes config; expected a top-level YAML mapping".to_string())?;
+    if let Some(servers) = root.get(serde_yaml::Value::String("mcp_servers".to_string())) {
+        if !servers.is_mapping() {
+            return Err(
+                "invalid Hermes config; mcp_servers must be a YAML mapping and file was not changed"
+                    .to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn add_server(config: &str) -> String {
+    if config.is_empty() {
+        return format!("mcp_servers:\n{SERVER}");
+    }
+
+    let lines: Vec<&str> = config.split_inclusive('\n').collect();
+    if let Some(start) = lines
+        .iter()
+        .position(|line| line.trim_end_matches(['\r', '\n']) == "mcp_servers:")
+    {
+        let end = lines
+            .iter()
+            .enumerate()
+            .skip(start + 1)
+            .find(|(_, line)| {
+                let content = line.trim_end_matches(['\r', '\n']);
+                !content.is_empty()
+                    && !content.starts_with(char::is_whitespace)
+                    && !content.starts_with('#')
+            })
+            .map(|(index, _)| index)
+            .unwrap_or(lines.len());
+        if lines[start + 1..end]
+            .iter()
+            .any(|line| line.trim_end_matches(['\r', '\n']) == "  memorywhale:")
+        {
+            return config.to_string();
+        }
+        let mut output = lines[..end].concat();
+        output.push_str(SERVER);
+        output.push_str(&lines[end..].concat());
+        return output;
+    }
+
+    let mut output = config.to_string();
+    if !output.ends_with('\n') {
+        output.push('\n');
+    }
+    output.push_str("mcp_servers:\n");
+    output.push_str(SERVER);
+    output
+}

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -1,5 +1,6 @@
 //! Shared helpers for the MemoryWhale CLI binaries.
 
+pub mod hermes;
 pub mod storage;
 pub mod tui;
 

--- a/crates/mw-cli/tests/hermes_integration.rs
+++ b/crates/mw-cli/tests/hermes_integration.rs
@@ -1,0 +1,104 @@
+use std::process::Command;
+
+fn sandbox(name: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "mw-hermes-{name}-{}-{}",
+        std::process::id(),
+        std::thread::current().name().unwrap_or("test")
+    ));
+    let _ = std::fs::remove_dir_all(&path);
+    std::fs::create_dir_all(&path).unwrap();
+    path
+}
+
+#[test]
+fn user_can_install_memorywhale_into_a_fresh_hermes_config() {
+    let hermes_home = sandbox("fresh");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_mw"))
+        .args(["integrate", "hermes"])
+        .env("HERMES_HOME", &hermes_home)
+        .output()
+        .expect("run Hermes integration command");
+
+    assert!(output.status.success(), "command failed: {output:?}");
+    assert_eq!(
+        std::fs::read_to_string(hermes_home.join("config.yaml")).unwrap(),
+        "mcp_servers:\n  memorywhale:\n    command: \"mw-mcp\"\n"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("Hermes Agent"),
+        "missing success message: {output:?}"
+    );
+}
+
+#[test]
+fn installing_memorywhale_preserves_existing_hermes_settings_and_servers() {
+    let hermes_home = sandbox("existing");
+    let config_path = hermes_home.join("config.yaml");
+    std::fs::write(
+        &config_path,
+        "model: kimi-k3\nmcp_servers:\n  filesystem:\n    command: \"npx\"\ntoolsets:\n  - hermes-cli\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_mw"))
+        .args(["integrate", "hermes"])
+        .env("HERMES_HOME", &hermes_home)
+        .output()
+        .expect("run Hermes integration command");
+
+    assert!(output.status.success(), "command failed: {output:?}");
+    let updated = std::fs::read_to_string(config_path).unwrap();
+    assert!(updated.contains("model: kimi-k3\n"), "{updated}");
+    assert!(
+        updated.contains("  filesystem:\n    command: \"npx\"\n"),
+        "{updated}"
+    );
+    assert!(
+        updated.contains("  memorywhale:\n    command: \"mw-mcp\"\n"),
+        "{updated}"
+    );
+    assert!(updated.contains("toolsets:\n  - hermes-cli\n"), "{updated}");
+}
+
+#[test]
+fn installing_memorywhale_twice_does_not_duplicate_the_server() {
+    let hermes_home = sandbox("idempotent");
+
+    for _ in 0..2 {
+        let output = Command::new(env!("CARGO_BIN_EXE_mw"))
+            .args(["integrate", "hermes"])
+            .env("HERMES_HOME", &hermes_home)
+            .output()
+            .expect("run Hermes integration command");
+        assert!(output.status.success(), "command failed: {output:?}");
+    }
+
+    let updated = std::fs::read_to_string(hermes_home.join("config.yaml")).unwrap();
+    assert_eq!(updated.matches("memorywhale:").count(), 1, "{updated}");
+}
+
+#[test]
+fn invalid_hermes_yaml_is_left_untouched() {
+    let hermes_home = sandbox("invalid");
+    let config_path = hermes_home.join("config.yaml");
+    let original = "mcp_servers: [\n";
+    std::fs::write(&config_path, original).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_mw"))
+        .args(["integrate", "hermes"])
+        .env("HERMES_HOME", &hermes_home)
+        .output()
+        .expect("run Hermes integration command");
+
+    assert!(
+        !output.status.success(),
+        "invalid YAML was accepted: {output:?}"
+    );
+    assert_eq!(std::fs::read_to_string(config_path).unwrap(), original);
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("invalid Hermes config"),
+        "unexpected error: {output:?}"
+    );
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -30,6 +30,7 @@ mw prune [--min-bytes N] [--dry-run]  # delete empty auto-recorded sessions (noi
 mw memory stale <id>                  # retire an outdated lesson, preserving its row
 mw memory supersede <old> <new>       # replace an old lesson with a newer one
 mw audit                              # inspect capture policy and retained volume
+mw integrate hermes                   # register mw-mcp in Hermes Agent's config
 mw share 5 [-o file.html]             # write a self-contained HTML page of one item to send someone
 mw discard                            # inside a recording: throw the current session away
 mw context [project:name] [--last-error] [--limit N]   # compact failures digest for agents

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -6,13 +6,16 @@ failed, and it can *write down* what it figured out.
 ## 1. MCP server (recommended) — the agent reads and writes
 
 `mw-mcp` is a [Model Context Protocol](https://modelcontextprotocol.io) server
-over stdio. Register it once and the agent gets four native tools — no
+over stdio. Register it once and the agent gets six native tools — no
 copy-paste:
 
 - `recent_errors` — recent failed commands with their error output
 - `search_memory` — search commands, output, notes, and remembered lessons
 - `get_context` — a compact digest of recent failures, optionally per project
 - `remember` — save a conclusion ("the fix was X") for its future self to find
+- `similar_failures` — check whether an error recurred and whether later runs
+  resolved it
+- `stats` — inspect store health and memory counts
 
 Claude Code:
 
@@ -35,6 +38,7 @@ file differs. Per-client setup (config + a "when to use it" rule):
 - **Cline** (VS Code) → [`cline/`](cline/README.md)
 - **Continue** (VS Code / JetBrains) → [`continue/`](continue/README.md)
 - **Gemini CLI** (Google) → [`gemini-cli/`](gemini-cli/README.md)
+- **Hermes Agent** → [`hermes/`](hermes/README.md)
 - **Any other MCP client** — add a stdio server whose
   command is `mw-mcp` (no arguments). It honours `MEMORYWHALE_DATA_DIR` like the
   rest of the CLI.

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,0 +1,108 @@
+# Hermes Agent integration
+
+[Hermes Agent](https://github.com/NousResearch/hermes-agent) can run local
+stdio MCP servers. Hermes remains the agent runtime; `mw-mcp` contributes
+MemoryWhale's persistent developer-memory tools.
+
+## Prerequisites
+
+Install both `hermes` and MemoryWhale, then confirm the MCP binary is on
+`PATH`:
+
+```bash
+command -v hermes
+command -v mw-mcp
+```
+
+If `mw-mcp` is not on `PATH`, use its absolute path in the command below or in
+the configuration file.
+
+## Connect MemoryWhale
+
+Hermes' MCP management command can register the local server directly:
+
+```bash
+hermes mcp add memorywhale --command mw-mcp
+```
+
+The equivalent entry in `~/.hermes/config.yaml` is:
+
+```yaml
+mcp_servers:
+  memorywhale:
+    command: "mw-mcp"
+```
+
+If `mcp_servers` already exists, add `memorywhale` beneath it instead of
+replacing the other servers. To use a non-default MemoryWhale database, pass
+the data directory through the server environment:
+
+```yaml
+mcp_servers:
+  memorywhale:
+    command: "mw-mcp"
+    env:
+      MEMORYWHALE_DATA_DIR: "/path/to/memorywhale-data"
+```
+
+Start Hermes after saving the configuration:
+
+```bash
+hermes chat
+```
+
+Hermes prefixes MCP tool names with the server name, but normally selects them
+without being told the internal name. The six MemoryWhale tools are:
+
+- `recent_errors`
+- `search_memory`
+- `get_context`
+- `remember`
+- `similar_failures`
+- `stats`
+
+## Verify the integration
+
+Ask Hermes:
+
+> Use MemoryWhale to check whether I have encountered a similar build failure
+> before.
+
+For a deterministic transport check outside Hermes, initialize the server
+directly:
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | mw-mcp
+```
+
+## Using Kimi K3 through Hermes
+
+Kimi K3 is a model, not an MCP client. If the Hermes model provider you use
+offers Kimi K3, select it through Hermes' model configuration and keep the
+MemoryWhale MCP configuration above unchanged. The responsibilities remain
+separate:
+
+```text
+Kimi K3 (model)
+  -> Hermes Agent (reasoning and MCP client)
+  -> mw-mcp
+  -> local MemoryWhale SQLite database
+```
+
+The exact Kimi model identifier and credentials depend on the provider. Do not
+configure the model process itself to launch `mw-mcp`; Hermes owns that
+connection.
+
+## Troubleshooting
+
+- If no tools appear, restart Hermes after adding the server and confirm
+  `mw-mcp` is executable from the same environment that launches Hermes.
+- If Hermes runs in a container or remote machine, install MemoryWhale there
+  too, or point `command` at an executable available in that environment.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in the MCP server's
+  `env` block.
+- MemoryWhale remains local-first: Hermes receives tool results, but
+  MemoryWhale does not upload its SQLite database.
+
+Hermes MCP configuration details are maintained in the
+[official Hermes documentation](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/mcp.md).

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -95,10 +95,22 @@ MemoryWhale MCP configuration above unchanged. The responsibilities remain
 separate:
 
 ```text
-Kimi K3 (model)
-  -> Hermes Agent (reasoning and MCP client)
-  -> mw-mcp
-  -> local MemoryWhale SQLite database
+             ┌────────────────────┐
+             │    Hermes Agent    │
+             │                    │
+Kimi K3 ───► │  reasoning/model   │
+             │                    │
+             │     MCP client     │
+             └─────────┬──────────┘
+                       │
+                       ▼
+                    mw-mcp
+                       │
+                       ▼
+                   MemoryWhale
+                       │
+                       ▼
+              local SQLite database
 ```
 
 The exact Kimi model identifier and credentials depend on the provider. Do not

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -19,7 +19,19 @@ the configuration file.
 
 ## Connect MemoryWhale
 
-Hermes' MCP management command can register the local server directly:
+The MemoryWhale CLI can update Hermes' configuration safely while preserving
+existing settings and MCP servers:
+
+```bash
+mw integrate hermes
+```
+
+The command honours `HERMES_HOME` and otherwise writes to
+`~/.hermes/config.yaml`. It is idempotent, validates existing YAML before
+changing it, and refuses malformed configuration without overwriting it.
+
+Alternatively, Hermes' MCP management command can register the local server
+directly:
 
 ```bash
 hermes mcp add memorywhale --command mw-mcp

--- a/integrations/hermes/config.yaml
+++ b/integrations/hermes/config.yaml
@@ -1,0 +1,3 @@
+mcp_servers:
+  memorywhale:
+    command: "mw-mcp"


### PR DESCRIPTION
## Summary

- add `mw integrate hermes` for one-command installation into Hermes Agent
- preserve existing Hermes settings and MCP servers while updating YAML
- validate configuration before writing and make repeated installation idempotent
- add a dedicated Hermes guide and reusable YAML snippet
- explain the Kimi K3 boundary: Hermes supplies the MCP client while the model supplies reasoning
- update integration documentation to reflect all six current MCP tools

## Why

Hermes supports local stdio MCP servers, so it can use MemoryWhale's existing
`mw-mcp` server without adding another framework or storage layer. The new CLI
command turns that configuration into a safe, repeatable installation step.

## Validation

- verified CLI and YAML formats against the current Hermes Agent MCP documentation and source
- added CLI integration tests for fresh configuration, preservation, idempotency, and invalid YAML
- ran `cargo test -p memorywhale-core -p memorywhale-cli`
- ran Clippy for both non-desktop crates with warnings denied
- ran `scripts/check-doc-references.sh`
- ran `git diff --check`
