### PR TITLE
docs(mcp): document the local stdio trust model

### DIFF
--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -37,6 +37,9 @@ data directory. Do not treat an application token passed to a same-user stdio
 process as an independent boundary: that process can commonly inspect the
 environment or read the underlying files directly.
 
+For broader guidance on protecting captured terminal data, see the
+[local data threat model](../SECURITY.md).
+
 ## Wire it into an agent
 
 Claude Code, one line:

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -12,6 +12,31 @@ If you're working from a source checkout, the binary is
 your PATH (see the README's Install section). It reads the same local database
 as the `mw` CLI — nothing leaves your machine.
 
+## Trust model
+
+`mw-mcp` is a local stdio process: the MCP client starts it and communicates
+over its standard input and output. It does not listen on a network port and
+has no separate protocol authentication. The spawning process and the
+permissions of the operating-system user establish the local trust context.
+
+A process running as the same OS user may already be able to read the
+MemoryWhale database and environment. MCP access nevertheless matters because
+it gives an agent a supported interface for retrieving terminal evidence and
+for writing agent-authored memories through `remember`.
+
+| Actor | Capability | Exposure | Mitigation | Residual limitation |
+| --- | --- | --- | --- | --- |
+| Configured MCP client or agent | Call all six `mw-mcp` tools | Reads can reveal commands, paths, output, errors, and saved lessons | Grant MCP access only to clients you trust with the selected store; prevent sensitive capture where possible | Tool access cannot make already captured sensitive evidence non-sensitive |
+| Agent using `remember` | Add a lesson that can influence later retrieval | Incorrect or adversarial memories can bias future context | Review agent-authored memories and remove entries that are not supported by evidence | Review reduces poisoning risk but does not prove a memory is correct |
+| Other process running as the same OS user | Read files available to that user and potentially start `mw-mcp` | The local database is not isolated from peer same-user processes | Run untrusted agents under a separate OS identity or stronger sandbox | OS-user separation is only one boundary and may not satisfy every threat model |
+| Client configured with `MEMORYWHALE_DATA_DIR` | Select a different MemoryWhale store | Accidental mixing of client data can be reduced | Use a dedicated directory, ideally with a separate OS identity and restrictive filesystem permissions | The variable scopes storage; it is not authentication or an access-control mechanism |
+
+Treat the client process as trusted for the store it can reach. For stronger
+isolation, use a separate OS identity or sandbox with a separately protected
+data directory. Do not treat an application token passed to a same-user stdio
+process as an independent boundary: that process can commonly inspect the
+environment or read the underlying files directly.
+
 ## Wire it into an agent
 
 Claude Code, one line:

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -62,8 +62,9 @@ mw context --last-error
   command is `mw-mcp` (no arguments). It honours `MEMORYWHALE_DATA_DIR` like the
   rest of the CLI.
 
-The [MCP reference](../docs/reference/mcp.md) is authoritative for parameters
-and responses. A transport-level check is:
+The [MCP reference](../docs/reference/mcp.md) is authoritative for parameters,
+responses, and the [local stdio trust model](../docs/reference/mcp.md#trust-model).
+A transport-level check is:
 
 ```bash
 printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | mw-mcp

--- a/integrations/generic-mcp/README.md
+++ b/integrations/generic-mcp/README.md
@@ -31,7 +31,9 @@ args: []
 
 The exact surrounding schema depends on the client. No arguments are required.
 To select another database, set `MEMORYWHALE_DATA_DIR` in the server's
-environment.
+environment. This scopes the client to a store but is not an access-control
+mechanism. Before granting an agent access, review the canonical
+[local stdio trust model](../../docs/reference/mcp.md#trust-model).
 
 ## Verify
 


### PR DESCRIPTION
## What this changes

Documents the local stdio trust boundary for `mw-mcp` and links that explanation from both the generic MCP guide and the integration index.

## Why it matters

MemoryWhale can retain sensitive terminal evidence, while agent-authored memories can influence later retrieval. Users need to understand what access a configured local MCP client receives without confusing stdio with an unauthenticated network service.

Closes #149

## What's in it

- Add a threat-model table covering actor, capability, exposure, mitigation, and residual limitation.
- Explain same-user access, read exposure, and agent-authored memory poisoning.
- Clarify that `MEMORYWHALE_DATA_DIR` scopes storage but is not access control.
- Link the canonical trust model from the generic integration guide and integration index.

## Verification

- [x] Documentation links and anchors reviewed against the repository layout.
- [x] Scope checked against the issue acceptance criteria.
- [x] No executable code changed.
- [x] `npm test` passes when frontend code changes — not applicable
- [x] `npm run build` passes when frontend code changes — not applicable
- [x] `cargo fmt --all -- --check` passes when Rust code changes — not applicable
- [x] `cargo clippy -p memorywhale-core -p memorywhale-cli --all-targets -- -D warnings` passes when Rust code changes — not applicable
- [x] `cargo test -p memorywhale-core -p memorywhale-cli` passes when Rust code changes — not applicable
- [x] `cargo build --workspace` passes for workspace changes — not applicable
- [x] Tested locally against my own MemoryWhale data — not applicable

## Contribution rules checklist

- [x] Preserves original evidence; capture behavior is unchanged.
- [x] No implicit cloud sync.
- [x] No database changes.
- [x] Still works fully offline, with no account or server.