### PR TITLE
docs(integrations): add Pi coding agent workflow

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -37,6 +37,7 @@ features.
 | Goose | Yes | No | Yes | [Guide](goose/README.md) |
 | Hermes Agent | Yes | No | Example prompt | [Guide](hermes/README.md) |
 | OpenClaw | Yes | No | Yes | [Guide](openclaw/README.md) |
+| Pi coding agent | Unverified | No | No | [Guide](pi/README.md) |
 | VS Code / GitHub Copilot | Yes | No | Yes | [Guide](vscode/README.md) |
 | Windsurf | Yes | No | Yes | [Guide](windsurf/README.md) |
 | Zed | Yes | No | Yes | [Guide](zed/README.md) |

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -53,6 +53,13 @@ mw context --last-error
 
 `mw-mcp` exposes six tools over newline-delimited JSON-RPC 2.0 on stdio:
 
+- `recent_errors`
+- `search_memory`
+- `get_context`
+- `remember`
+- `similar_failures`
+- `stats`
+
 - **Cursor** → [`cursor/`](cursor/README.md)
 - **VS Code / GitHub Copilot** (agent mode) → [`vscode/`](vscode/README.md)
 - **Windsurf** → [`windsurf/`](windsurf/README.md)

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -1,0 +1,101 @@
+# Pi coding agent + MemoryWhale
+
+## Status
+
+CLI/context workflows are documented against the Pi coding agent documentation
+available in August 2026. MemoryWhale does not currently provide a native Pi
+MCP adapter. Pi supports TypeScript extensions, but an official built-in MCP
+configuration was not verified. Treat third-party MCP adapters as separate
+software and review them before installing.
+
+- [Pi settings](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/settings.md)
+- [Pi extensions](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md)
+- [MemoryWhale generic MCP contract](../generic-mcp/README.md)
+
+## Requirements
+
+- MemoryWhale installed and `mw` available on `PATH`.
+- Pi coding agent installed separately.
+- A shell environment where Pi and MemoryWhale use the intended
+  `MEMORYWHALE_DATA_DIR`, if a non-default store is needed.
+
+## Capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Unverified; no native Pi MCP setup is documented here |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, through a Pi project instruction or extension |
+
+## Setup: use the CLI today
+
+MemoryWhale can be used with Pi without a Pi-specific plugin. Capture a command
+explicitly, then give Pi the retrieved context:
+
+```bash
+mw-run -- cargo test
+mw context --last-error
+mw search "linker error"
+```
+
+You can paste the output of `mw context --last-error` into a Pi conversation.
+For a different store, set the variable in the same shell environment:
+
+```bash
+MEMORYWHALE_DATA_DIR=/path/to/store mw context --last-error
+```
+
+## Optional Pi guidance
+
+Pi supports project-local extensions and other project resources. Add a short
+instruction to the project guidance you already use, or create a trusted Pi
+extension, telling Pi when to consult MemoryWhale:
+
+> When a build, test, or deploy fails, ask the user for the output of
+> `mw context --last-error` or `mw search "<distinctive error>"` before proposing
+> a fix. After the cause is confirmed, suggest saving the lesson with
+> `mw remember "<what fixed it>"`.
+
+Do not place secrets or a private database path in project guidance.
+
+## Verify
+
+Verify the MemoryWhale side independently:
+
+```bash
+command -v mw
+mw doctor
+mw context --last-error
+```
+
+An empty store may return an empty context. That is expected. If you later add
+an MCP adapter, verify its tool discovery separately and use the canonical
+[MCP reference](../../docs/reference/mcp.md) for the six MemoryWhale tools.
+
+## Automatic capture
+
+This integration does not automatically record Pi prompts, responses, or shell
+commands. `mw-run` captures an explicitly wrapped command; normal terminal
+capture and supported hooks remain separate. MCP access, if added through a
+third-party adapter, would provide memory access rather than automatic capture.
+
+## Limitations
+
+- There is no verified native Pi-to-`mw-mcp` configuration in this repository.
+- The CLI workflow requires copying or piping context into Pi.
+- Pi project extensions execute with broad local permissions; only install
+  extensions you trust.
+- MemoryWhale does not silently synchronize the local database.
+
+## Troubleshooting
+
+- Run `command -v mw` from the environment used to start Pi.
+- Use the absolute path to `mw` if Pi's environment has a different `PATH`.
+- Set `MEMORYWHALE_DATA_DIR` explicitly when selecting a non-default store.
+- Run `mw doctor` before debugging a missing or empty store.
+
+## Remove integration
+
+Remove any Pi-specific instruction or extension you added. This does not delete
+the MemoryWhale database; use the documented `mw rm` or retention commands for
+data lifecycle operations.


### PR DESCRIPTION
Adds a conservative Pi coding-agent integration guide.

## What is documented

- Pi is listed in the integration capability matrix.
- The verified workflow uses `mw-run`, `mw context --last-error`, and `mw search` with explicit context handoff.
- Optional Pi project guidance explains when to consult and save MemoryWhale lessons.
- Automatic capture is explicitly marked unsupported.
- Native Pi MCP is marked unverified; the guide does not claim a native `mcpServers` configuration without official confirmation.
- Pi extension trust and third-party MCP adapter limitations are called out.

## Verification

- `bash scripts/check-doc-references.sh`
- `git diff --check`
- Official Pi settings/extensions documentation linked in the guide.

The guide follows `integrations/TEMPLATE.md` and keeps client-specific behavior out of MemoryWhale core.