### PR TITLE
docs: fix broken MemoryWhale recall path in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ Database: `<data_local>/MemoryWhale/memorywhale.sqlite3`
 Before debugging a build/environment error, check whether it was solved before:
 
 ```bash
-bash .claude/skills/memorywhale/recall.sh "linker cc not found"
+mw search "linker cc not found"      # full-text recall across commands, output, notes
+mw context --last-error              # the most recent failure, with its error tail
 ```
 
 It shows prior matching runs and what was run right after a past failure (often
@@ -66,4 +67,4 @@ Tag related work across terminals with the same `project:<name>` to group it.
   <path>`) or it gets `Killed: 9`. See `DEBUG.md`.
 - Full usage: `docs/reference/cli.md`. Setup/troubleshooting: `DEBUG.md`.
 
-The Claude Code form of this guidance lives in `.claude/skills/memorywhale/`.
+The Claude Code form of this guidance lives in `integrations/claude-code/memorywhale/`.


### PR DESCRIPTION
## Problem

`AGENTS.md` told agents to recall prior failures by running:

```bash
bash .claude/skills/memorywhale/recall.sh "linker cc not found"
```

That script does **not exist anywhere in the repository**, and the `.claude/skills/memorywhale/` directory does not exist either. Any agent following the "Recall before you act" section would hit a missing-file failure instead of recalling memory.

The real Claude Code skill lives at `integrations/claude-code/memorywhale/SKILL.md`, which uses the CLI directly (`mw search` / `mw context --last-error`) — no shell script.

## Fix

- Replace the broken `recall.sh` command with the actual CLI recall commands.
- Correct the stale skill directory reference to `integrations/claude-code/memorywhale/`.

```diff
-bash .claude/skills/memorywhale/recall.sh "linker cc not found"
+mw search "linker cc not found"      # full-text recall across commands, output, notes
+mw context --last-error              # the most recent failure, with its error tail
```

## Verification

Found by dogfooding MemoryWhale on itself: followed AGENTS.md literally, hit the missing-script failure, then confirmed via whole-repo `find` that `recall.sh` does not exist.

- `bash scripts/check-doc-references.sh` — passes
- `git diff --check` — passes
- Both new recall commands run cleanly (empty store returns empty results, not an error)
- All 8 listed binaries exist and build: `cargo build --release -p memorywhale-cli --bins`

`AGENTS.md` only.