### PR TITLE
docs(integrations): add Rho harness workflow

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -39,6 +39,7 @@ features.
 | Jan Desktop | Yes | No | No | [Guide](jan/README.md) |
 | OpenClaw | Yes | No | Yes | [Guide](openclaw/README.md) |
 | Pi coding agent | Unverified | No | No | [Guide](pi/README.md) |
+| Rho | No; uses the CLI directly | No | Yes, via `AGENTS.md` | [Guide](rho/README.md) |
 | VS Code / GitHub Copilot | Yes | No | Yes | [Guide](vscode/README.md) |
 | Windsurf | Yes | No | Yes | [Guide](windsurf/README.md) |
 | Zed | Yes | No | Yes | [Guide](zed/README.md) |

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -39,7 +39,7 @@ features.
 | Jan Desktop | Yes | No | No | [Guide](jan/README.md) |
 | OpenClaw | Yes | No | Yes | [Guide](openclaw/README.md) |
 | Pi coding agent | Unverified | No | No | [Guide](pi/README.md) |
-| Rho | No; uses the CLI directly | No | Yes, via `AGENTS.md` | [Guide](rho/README.md) |
+| Rho | Yes | No | Yes, via `AGENTS.md` | [Guide](rho/README.md) |
 | VS Code / GitHub Copilot | Yes | No | Yes | [Guide](vscode/README.md) |
 | Windsurf | Yes | No | Yes | [Guide](windsurf/README.md) |
 | Zed | Yes | No | Yes | [Guide](zed/README.md) |

--- a/integrations/rho/README.md
+++ b/integrations/rho/README.md
@@ -1,155 +1,150 @@
 # Rho + MemoryWhale
 
-[Rho](https://github.com/opencode-ai/rho) is a coding-agent harness. Rho does
-not currently expose a native MCP-server configuration, so MemoryWhale connects
-through its CLI: Rho invokes `mw` commands through its shell tool, and durable
-instructions in an `AGENTS.md` file tell the agent when to recall and record.
+[Rho](https://github.com/opencode-ai/rho) is a coding-agent harness with native
+support for Model Context Protocol servers. `mw-mcp` plugs in as a local stdio
+MCP server, giving the Rho agent direct access to MemoryWhale's six
+retrieval tools.
 
-This keeps the two systems cleanly separated: Rho owns session transcripts and
-compaction; MemoryWhale owns the cross-session evidence that survives across
-Rho restarts, different machines, and different agents.
+Rho also loads durable instructions from `AGENTS.md` files, which complements MCP
+by telling the agent *when* to consult and update memory.
 
 ## Status
 
-Verified against Rho 1.41.0 in August 2026. Rho's `~/.rho/config.toml` and
-built-in configuration guidance expose no MCP-server configuration, so this
-guide documents a CLI + instructions workflow. If Rho adds native stdio MCP
-support, the [Generic MCP guide](../generic-mcp/README.md) will be the right
-starting point and this guide should be updated.
+Verified against Rho 1.41.0 in August 2026. MCP servers are configured under
+`[mcp.servers]` in `~/.rho/config.toml` (global) or a project-level Rho config.
+Confirm with `rho mcp list` and `rho mcp show <id>`.
 
-- [Rho configuration](https://github.com/opencode-ai/rho) — `~/.rho/config.toml`, `~/.rho/AGENTS.md`
-- [MemoryWhale CLI reference](../../docs/reference/cli.md)
+- `rho mcp list` — list configured MCP servers
+- `rho mcp show <id>` — show one server by its `[mcp.servers.<id>]` key
+
 - [MemoryWhale MCP reference](../../docs/reference/mcp.md)
+- [MemoryWhale CLI reference](../../docs/reference/cli.md)
 
 ## Requirements
 
-- MemoryWhale installed with `mw` on `PATH` (the path Rho's shell tool sees).
+- MemoryWhale installed with `mw-mcp` on `PATH`.
 - Rho installed and running.
-- A project tag so related work groups across sessions. Example: `project:myapp`.
+- Optional: a deliberate `MEMORYWHALE_DATA_DIR` if a non-default store is needed.
 
 ## Capabilities
 
 | Capability | Available |
 | --- | --- |
-| MCP memory access | No — Rho has no verified native MCP-server config |
-| Automatic execution capture | No — Rho shell-tool calls are not auto-captured |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
 | Memory-use guidance | Yes — through Rho's `AGENTS.md` (global or project) |
-| Explicit CLI read/write | Yes — `mw search`, `mw context`, `mw remember`, `mw-run` |
 
 ## Setup
 
-### 1. Confirm the CLI is visible
+### 1. Connect the MCP server
 
-```bash
-command -v mw
-mw doctor
+Add the server to `~/.rho/config.toml`:
+
+```toml
+[mcp.servers.memorywhale]
+command = "mw-mcp"
 ```
 
-If `mw` is not on the `PATH` Rho's shell tool uses, reference its absolute path
-in the instructions instead.
+For a non-default store, add the environment:
 
-### 2. Add durable instructions
+```toml
+[mcp.servers.memorywhale]
+command = "mw-mcp"
+env = { MEMORYWHALE_DATA_DIR = "/path/to/store" }
+```
+
+If `mw-mcp` is not on the `PATH` Rho sees, use its absolute path as the
+`command`.
+
+### 2. Verify the connection
+
+```bash
+rho mcp list
+rho mcp show memorywhale
+```
+
+`rho mcp list` should show `memorywhale`; `rho mcp show memorywhale` should
+display the configured command. If Rho does not discover the server, restart
+Rho after saving the config.
+
+Confirm the server works independently:
+
+```bash
+command -v mw-mcp
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | mw-mcp
+```
+
+### 3. Add memory-use guidance (optional)
 
 Rho loads a global `~/.rho/AGENTS.md` (every session) and a project-local
-`AGENTS.md` (project sessions, loaded after the global file). Add the recall
-and record guidance to whichever scope fits:
-
-**Per-project** — create or edit `AGENTS.md` in the repository root:
+`AGENTS.md` (project sessions). Add guidance to whichever scope fits:
 
 ```markdown
 ## Use MemoryWhale as durable terminal memory
 
-Before debugging a build/test/deploy error, check whether it was solved
-before:
-
-    mw search "linker error"
-    mw context --last-error
-
-Once you have figured out *why* something failed or *how* a fix worked, save
-the conclusion so a future session does not re-derive it:
-
-    mw remember "the E0308 was a string field parsed as i32; fix: parse i32"
-
-Tag related work: `mw-remember --notes "project:myapp …" -- <command>`.
+Before debugging a build/test/deploy error, use the MemoryWhale MCP tools
+(`search_memory`, `recent_errors`, `similar_failures`) to check whether it
+was solved before. Once you have figured out why something failed or how a
+fix worked, use `remember` to save that conclusion.
 ```
-
-**Global** — edit `~/.rho/AGENTS.md` with the same content to apply it to every
-Rho session regardless of project. Project files load later and take
-precedence on conflict.
-
-### 3. Select a non-default store (optional)
-
-If a project should use its own MemoryWhale database, set the variable in the
-shell environment before launching Rho or in the project's setup:
-
-```bash
-MEMORYWHALE_DATA_DIR=/path/to/store mw doctor
-```
-
-Scoping a store is not an access-control mechanism; review the
-[local stdio trust model](../../docs/reference/mcp.md#trust-model) before
-sharing a sensitive store.
 
 ## Verify
 
-From a Rho shell-tool call, confirm each read and write path:
+Ask Rho:
 
-```bash
-# write a marker
-mw-remember --cwd "$(pwd)" --exit-code 0 \
-  --notes "project:rho-integration-test" -- echo "rho test marker qzx"
+> Use MemoryWhale to check whether I have encountered a similar build failure
+> before. Search for `openssl` and explain which saved evidence is relevant
+> before suggesting a fix.
 
-# recall it
-mw search "qzx"
-mw context project:rho-integration-test
-```
+The MemoryWhale MCP server exposes six tools:
 
-`mw search` should list the recorded command; `mw context` should show an
-empty-but-valid digest (no failures yet). An empty store is valid — the tools
-return empty results, not errors.
+- `recent_errors`
+- `search_memory`
+- `get_context`
+- `remember`
+- `similar_failures`
+- `stats`
+
+An empty store is valid — the tools return empty results, not errors. `stats`
+should report zero records on a fresh store.
 
 ## The loop
 
-1. **Session start** — recall relevant prior work before acting:
+1. **Session start** — recall relevant prior work:
 
    ```bash
-   mw context project:myapp          # recent failures + lessons, compact
+   mw context project:myapp          # compact digest for pasting
    mw search "openssl linker"        # targeted full-text recall
    ```
 
 2. **During work** — capture a command you want recorded:
 
    ```bash
-   mw-run -- cargo test              # captures the command + output + exit code
+   mw-run -- cargo test              # captures command + output + exit code
    ```
 
-3. **After solving something non-obvious** — save the conclusion, not the
-   process:
+3. **After solving something non-obvious** — save the conclusion:
 
    ```bash
    mw remember "the segfault was a use-after-free in camera-driver; fix: drop the buffer before recv"
    ```
 
-4. **Session handoff** — export the session for a later agent or a teammate:
+4. **Session handoff** — export for a later agent or teammate:
 
    ```bash
-   mw agent > session.md   # full transcript as Markdown
-   mw context project:myapp  # compact paste-ready digest
+   mw agent > session.md             # full transcript as Markdown
+   mw context project:myapp          # compact paste-ready digest
    ```
 
 ## Automatic capture
 
 Rho's `bash` tool calls are **not** automatically recorded by MemoryWhale.
-MemoryWhale captures commands in three ways, none of which is Rho-specific:
+MCP access lets the agent read and explicitly write memory, but ordinary
+commands are captured only through:
 
 - `mw-run -- <command>` wraps and records one command explicitly.
 - `mw-remember` saves a command with output you already have.
-- `mw --notes "project:…"` records a whole interactive shell session (separate
-  from the Rho session).
-
-MCP access — if Rho adds it in the future — would let the agent read and
-explicitly write memory; it would still not auto-capture Rho's internal tool
-calls.
+- `mw --notes "project:…"` records a whole interactive shell session.
 
 ## How Rho sessions and MemoryWhale differ
 
@@ -161,18 +156,27 @@ MemoryWhale data survives Rho restarts and machine transfers. Use `mw agent`
 or `mw context` to bridge a Rho session into MemoryWhale when you want the
 evidence to outlive the current session.
 
+## Security
+
+`mw-mcp` is a local stdio process. Review the canonical
+[local stdio trust model](../../docs/reference/mcp.md#trust-model) before
+connecting a sensitive store. Only connect stores you intend the Rho agent to
+read and write. Scoping with `MEMORYWHALE_DATA_DIR` is not an access-control
+mechanism.
+
 ## Troubleshooting
 
-- Run `command -v mw` inside a Rho shell-tool call to confirm `PATH` visibility.
-- Use the absolute path to `mw` if Rho's environment differs from your shell.
+- Run `command -v mw-mcp` from the environment used to launch Rho.
+- Use the absolute path to `mw-mcp` if Rho cannot find your shell's `PATH`.
+- Run `rho mcp list` to confirm the server is discovered.
 - Run `mw doctor` to verify the data directory, database, and `script` status.
-- Set `MEMORYWHALE_DATA_DIR` in the environment that launches Rho, not only in
-  an unrelated terminal.
-- If `mw search` returns nothing, the store may genuinely be empty — run
-  `mw doctor` to confirm it can see the database.
+- Set `MEMORYWHALE_DATA_DIR` in the server's `env` block, not only in an
+  unrelated terminal.
+- Restart Rho after changing the MCP configuration.
 
 ## Remove integration
 
-Remove the MemoryWhale section from `~/.rho/AGENTS.md` or the project
-`AGENTS.md`. This does not delete the MemoryWhale database; use `mw rm` or the
-documented retention commands for data lifecycle operations.
+Remove the `[mcp.servers.memorywhale]` entry from `~/.rho/config.toml` and
+remove any MemoryWhale section from `~/.rho/AGENTS.md` or the project
+`AGENTS.md`. Restart Rho. This does not delete the MemoryWhale database; use
+`mw rm` or the documented retention commands for data lifecycle operations.

--- a/integrations/rho/README.md
+++ b/integrations/rho/README.md
@@ -1,0 +1,178 @@
+# Rho + MemoryWhale
+
+[Rho](https://github.com/opencode-ai/rho) is a coding-agent harness. Rho does
+not currently expose a native MCP-server configuration, so MemoryWhale connects
+through its CLI: Rho invokes `mw` commands through its shell tool, and durable
+instructions in an `AGENTS.md` file tell the agent when to recall and record.
+
+This keeps the two systems cleanly separated: Rho owns session transcripts and
+compaction; MemoryWhale owns the cross-session evidence that survives across
+Rho restarts, different machines, and different agents.
+
+## Status
+
+Verified against Rho 1.41.0 in August 2026. Rho's `~/.rho/config.toml` and
+built-in configuration guidance expose no MCP-server configuration, so this
+guide documents a CLI + instructions workflow. If Rho adds native stdio MCP
+support, the [Generic MCP guide](../generic-mcp/README.md) will be the right
+starting point and this guide should be updated.
+
+- [Rho configuration](https://github.com/opencode-ai/rho) — `~/.rho/config.toml`, `~/.rho/AGENTS.md`
+- [MemoryWhale CLI reference](../../docs/reference/cli.md)
+- [MemoryWhale MCP reference](../../docs/reference/mcp.md)
+
+## Requirements
+
+- MemoryWhale installed with `mw` on `PATH` (the path Rho's shell tool sees).
+- Rho installed and running.
+- A project tag so related work groups across sessions. Example: `project:myapp`.
+
+## Capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | No — Rho has no verified native MCP-server config |
+| Automatic execution capture | No — Rho shell-tool calls are not auto-captured |
+| Memory-use guidance | Yes — through Rho's `AGENTS.md` (global or project) |
+| Explicit CLI read/write | Yes — `mw search`, `mw context`, `mw remember`, `mw-run` |
+
+## Setup
+
+### 1. Confirm the CLI is visible
+
+```bash
+command -v mw
+mw doctor
+```
+
+If `mw` is not on the `PATH` Rho's shell tool uses, reference its absolute path
+in the instructions instead.
+
+### 2. Add durable instructions
+
+Rho loads a global `~/.rho/AGENTS.md` (every session) and a project-local
+`AGENTS.md` (project sessions, loaded after the global file). Add the recall
+and record guidance to whichever scope fits:
+
+**Per-project** — create or edit `AGENTS.md` in the repository root:
+
+```markdown
+## Use MemoryWhale as durable terminal memory
+
+Before debugging a build/test/deploy error, check whether it was solved
+before:
+
+    mw search "linker error"
+    mw context --last-error
+
+Once you have figured out *why* something failed or *how* a fix worked, save
+the conclusion so a future session does not re-derive it:
+
+    mw remember "the E0308 was a string field parsed as i32; fix: parse i32"
+
+Tag related work: `mw-remember --notes "project:myapp …" -- <command>`.
+```
+
+**Global** — edit `~/.rho/AGENTS.md` with the same content to apply it to every
+Rho session regardless of project. Project files load later and take
+precedence on conflict.
+
+### 3. Select a non-default store (optional)
+
+If a project should use its own MemoryWhale database, set the variable in the
+shell environment before launching Rho or in the project's setup:
+
+```bash
+MEMORYWHALE_DATA_DIR=/path/to/store mw doctor
+```
+
+Scoping a store is not an access-control mechanism; review the
+[local stdio trust model](../../docs/reference/mcp.md#trust-model) before
+sharing a sensitive store.
+
+## Verify
+
+From a Rho shell-tool call, confirm each read and write path:
+
+```bash
+# write a marker
+mw-remember --cwd "$(pwd)" --exit-code 0 \
+  --notes "project:rho-integration-test" -- echo "rho test marker qzx"
+
+# recall it
+mw search "qzx"
+mw context project:rho-integration-test
+```
+
+`mw search` should list the recorded command; `mw context` should show an
+empty-but-valid digest (no failures yet). An empty store is valid — the tools
+return empty results, not errors.
+
+## The loop
+
+1. **Session start** — recall relevant prior work before acting:
+
+   ```bash
+   mw context project:myapp          # recent failures + lessons, compact
+   mw search "openssl linker"        # targeted full-text recall
+   ```
+
+2. **During work** — capture a command you want recorded:
+
+   ```bash
+   mw-run -- cargo test              # captures the command + output + exit code
+   ```
+
+3. **After solving something non-obvious** — save the conclusion, not the
+   process:
+
+   ```bash
+   mw remember "the segfault was a use-after-free in camera-driver; fix: drop the buffer before recv"
+   ```
+
+4. **Session handoff** — export the session for a later agent or a teammate:
+
+   ```bash
+   mw agent > session.md   # full transcript as Markdown
+   mw context project:myapp  # compact paste-ready digest
+   ```
+
+## Automatic capture
+
+Rho's `bash` tool calls are **not** automatically recorded by MemoryWhale.
+MemoryWhale captures commands in three ways, none of which is Rho-specific:
+
+- `mw-run -- <command>` wraps and records one command explicitly.
+- `mw-remember` saves a command with output you already have.
+- `mw --notes "project:…"` records a whole interactive shell session (separate
+  from the Rho session).
+
+MCP access — if Rho adds it in the future — would let the agent read and
+explicitly write memory; it would still not auto-capture Rho's internal tool
+calls.
+
+## How Rho sessions and MemoryWhale differ
+
+Rho keeps its own saved session transcripts in `~/.rho/sessions/` and may
+compact or summarize them. MemoryWhale stores durable evidence in its own
+SQLite database at `<data_local>/MemoryWhale/memorywhale.sqlite3`. The two are
+independent: compaction in Rho does not touch MemoryWhale data, and
+MemoryWhale data survives Rho restarts and machine transfers. Use `mw agent`
+or `mw context` to bridge a Rho session into MemoryWhale when you want the
+evidence to outlive the current session.
+
+## Troubleshooting
+
+- Run `command -v mw` inside a Rho shell-tool call to confirm `PATH` visibility.
+- Use the absolute path to `mw` if Rho's environment differs from your shell.
+- Run `mw doctor` to verify the data directory, database, and `script` status.
+- Set `MEMORYWHALE_DATA_DIR` in the environment that launches Rho, not only in
+  an unrelated terminal.
+- If `mw search` returns nothing, the store may genuinely be empty — run
+  `mw doctor` to confirm it can see the database.
+
+## Remove integration
+
+Remove the MemoryWhale section from `~/.rho/AGENTS.md` or the project
+`AGENTS.md`. This does not delete the MemoryWhale database; use `mw rm` or the
+documented retention commands for data lifecycle operations.


### PR DESCRIPTION
Adds a Rho coding-agent-harness integration guide using Rho's native MCP support.

## Included

- Rho in the integration capability matrix (MCP access: Yes).
- `integrations/rho/README.md` following the repo template:
  - **MCP setup**: `[mcp.servers.memorywhale]` in `~/.rho/config.toml` with `command = "mw-mcp"`
  - verification with `rho mcp list` and `rho mcp show memorywhale`
  - optional `MEMORYWHALE_DATA_DIR` for non-default stores
  - optional memory-use guidance through `~/.rho/AGENTS.md` or project `AGENTS.md`
  - the recall → record → handoff loop: `mw context`, `mw search`, `mw-run`, `mw remember`, `mw agent`
  - clear separation between Rho session transcripts and MemoryWhale durable storage
  - automatic capture explicitly marked unsupported
  - security, troubleshooting, and removal

## How Rho MCP was verified

Rho 1.41.0 exposes MCP natively:

```text
$ rho --help
  mcp    Inspect configured Model Context Protocol servers

$ rho mcp list
no MCP servers configured
add servers under [mcp.servers] in the selected Rho config

$ rho mcp show --help
  <ID>  Server table key from `[mcp.servers.<id>]`
```

Servers are configured under `[mcp.servers]` in `~/.rho/config.toml`.

## Verification

- `bash scripts/check-doc-references.sh` — passes (6 MCP tools + all CLI binaries)
- `git diff --check` — passes
- Diff: only `integrations/README.md` (one matrix row) + `integrations/rho/README.md`

Documentation-only; no code or behavior changes.