### PR TITLE
feat(dashboard): show client integration support grid

### DIFF
--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -746,7 +746,61 @@ fn dashboard(query: &str) -> String {
     }
     body.push_str("</div>\n");
 
+    body.push_str(&integrations_section());
+
     page("MemoryWhale — terminal memory", &body)
+}
+
+/// Supported client integrations, mirroring the capability matrix in
+/// `integrations/README.md`. Keep the two in sync when adding a client.
+/// (display name, matrix slug for the guide link, MCP support badge)
+const INTEGRATIONS: &[(&str, &str, &str)] = &[
+    ("Claude Code", "claude-code", "MCP · capture"),
+    ("Claude Desktop", "claude-desktop", "MCP"),
+    ("Cline", "cline", "MCP"),
+    ("CodeWhale", "codewhale", "MCP"),
+    ("Codex CLI", "codex", "MCP"),
+    ("Continue", "continue", "MCP"),
+    ("CrowClaw", "crowclaw", "MCP"),
+    ("Cursor", "cursor", "MCP"),
+    ("Gemini CLI", "gemini-cli", "MCP"),
+    ("Goose", "goose", "MCP"),
+    ("Hermes Agent", "hermes", "MCP"),
+    ("Jan Desktop", "jan", "MCP"),
+    ("OpenClaw", "openclaw", "MCP"),
+    ("OpenCode", "opencode", "MCP"),
+    ("Pi coding agent", "pi", "unverified"),
+    ("Rho", "rho", "MCP"),
+    ("VS Code / Copilot", "vscode", "MCP"),
+    ("Windsurf", "windsurf", "MCP"),
+    ("Zed", "zed", "MCP"),
+    ("Neovim plugin", "neovim", "CLI"),
+    ("Any stdio MCP client", "generic-mcp", "MCP"),
+];
+
+/// The integration-support grid on the dashboard: one cell per client with a
+/// letter-mark icon and its MCP support level, linking to the setup guide.
+fn integrations_section() -> String {
+    let mut cells = String::new();
+    for (name, slug, badge) in INTEGRATIONS {
+        // Letter-mark icon: first alnum characters of the display name.
+        let mark: String = name
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric())
+            .take(2)
+            .collect::<String>()
+            .to_uppercase();
+        cells.push_str(&format!(
+            "<a class=\"icell\" href=\"https://github.com/wuisabel-gif/MemWhale/tree/main/integrations/{slug}\" title=\"{name} setup guide\">\
+<span class=\"imark\" aria-hidden=\"true\">{mark}</span><span class=\"iname\">{}</span><span class=\"ibadge{}\">{badge}</span></a>\n",
+            esc(name),
+            if *badge == "unverified" { " off" } else { "" },
+        ));
+    }
+    format!(
+        "<h2>Integrations</h2>\n<p class=\"sub\">MemoryWhale plugs into these coding agents and editors — \
+each cell links to its setup guide in the repository.</p>\n<div class=\"igrid\">\n{cells}</div>\n"
+    )
 }
 
 /// Extract a `project:<name>` tag from a notes string, if present.
@@ -2262,5 +2316,25 @@ mod tests {
         // Set-Cookie extras are still appended for normal routes.
         let r2 = response("200 OK", "x", "Set-Cookie: mw_tz=utc\r\n");
         assert!(r2.contains("Set-Cookie: mw_tz=utc"));
+    }
+
+    #[test]
+    fn integrations_section_has_a_guide_link_for_every_client() {
+        let html = integrations_section();
+        assert_eq!(INTEGRATIONS.len(), 21);
+        for (name, slug, badge) in INTEGRATIONS {
+            assert!(html.contains(&format!(
+                "href=\"https://github.com/wuisabel-gif/MemWhale/tree/main/integrations/{slug}\""
+            )));
+            assert!(html.contains(&format!("<span class=\"iname\">{}</span>", esc(name))));
+            if *badge == "unverified" {
+                assert!(html.contains("class=\"ibadge off\">unverified"));
+            }
+        }
+        assert_eq!(html.matches("class=\"icell\"").count(), INTEGRATIONS.len());
+        assert_eq!(
+            html.matches("aria-hidden=\"true\"").count(),
+            INTEGRATIONS.len()
+        );
     }
 }

--- a/crates/mw-cli/src/bin/mw-serve/styles.css
+++ b/crates/mw-cli/src/bin/mw-serve/styles.css
@@ -51,6 +51,14 @@ pre.err{color:#ffd9c9}
 .chip{display:inline-flex;align-items:center;gap:8px;background:var(--card);border:1px solid var(--line);border-radius:999px;padding:7px 14px;font:600 .85rem ui-monospace,monospace;color:var(--azure)}
 .chip span{background:#eaeefe;border-radius:999px;padding:1px 8px;font-size:.72rem}
 .chip:hover{border-color:var(--azure)}
+.igrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:10px;margin-top:10px}
+.icell{display:flex;flex-direction:column;align-items:flex-start;gap:7px;background:var(--card);border:1px solid var(--line);border-radius:12px;padding:12px;text-decoration:none;color:inherit}
+.icell:hover{border-color:var(--azure)}
+.icell:focus-visible{outline:3px solid var(--azure);outline-offset:2px}
+.imark{display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;border-radius:9px;background:#eaeefe;color:var(--azure);font:700 .82rem ui-monospace,monospace;letter-spacing:.04em}
+.iname{font:600 .85rem ui-monospace,monospace;color:var(--ink)}
+.ibadge{display:inline-block;font:600 .68rem ui-monospace,monospace;background:#e6f6ef;color:var(--ok);border-radius:999px;padding:2px 8px}
+.ibadge.off{background:#fff4d8;color:#9a5b00}
 canvas{max-width:100%;background:#fff;border:1px solid var(--line);border-radius:12px;margin-top:8px}
 .legend{display:flex;align-items:center;gap:8px;font:.8rem ui-monospace,monospace;color:var(--muted);margin:4px 0 0}
 .legend .dot{width:11px;height:11px;border-radius:999px;display:inline-block;margin-left:14px}


### PR DESCRIPTION
Adds an integrations-support section to the local `mw-serve` dashboard.

## Included

- New **Integrations** section under bookmarks.
- 21 client cards mirroring the current integration matrix, including:
  - CodeWhale, OpenClaw, OpenCode, Rho, Jan, and other MCP clients
  - Pi's `unverified` status
  - Neovim's CLI-only status
  - Claude Code's MCP + capture status
- Two-letter decorative marks (no external icon/CDN dependency).
- Each card links to its corresponding setup guide in the repository.
- Capability badges show MCP, CLI, capture, or unverified status.
- Keyboard-visible `:focus-visible` styling for accessibility.
- Decorative marks marked `aria-hidden` so screen readers receive the client name and capability once.
- Regression test verifies all 21 generated cards, guide links, names, and accessibility marks.

## Verification

- `cargo build -p memorywhale-cli --bin mw-serve`
- `cargo fmt --all --check`
- `cargo clippy -p memorywhale-cli --all-targets -- -D warnings`
- `cargo test -p memorywhale-cli --bin mw-serve` — 17 passed
- `bash scripts/check-doc-references.sh`
- `git diff --check`
- Rendered Chrome smoke test against the rebuilt binary:
  - 21 `.icell` cards rendered
  - guide href verified
  - decorative icon `aria-hidden` verified
  - keyboard focus applied to the first card

The list is intentionally maintained alongside `integrations/README.md`; the test validates the generated static list but does not claim automatic synchronization with that matrix.