### PR TITLE
fix(completions): sync mw and mw-serve completions with the CLI

### DIFF
--- a/linux/completions/_mw
+++ b/linux/completions/_mw
@@ -63,7 +63,13 @@ _mw() {
       _values 'action' stale supersede
       ;;
     hooks)
-      _values 'action' install uninstall remove
+      case ${words[3]} in
+        install|uninstall|remove) _values 'shell' pwsh ;;
+        *) _values 'action' install uninstall remove ;;
+      esac
+      ;;
+    pet)
+      _arguments '--watch[animate the whale whose mood reflects your memory store]'
       ;;
     integrate)
       _values 'target' hermes

--- a/linux/completions/_mw
+++ b/linux/completions/_mw
@@ -13,14 +13,14 @@ _mw() {
     'show:print the full transcript of a session'
     'mark:bookmark the current debugging moment'
     'remember:save a lesson or conclusion for later'
+    'memory:retire or replace a saved lesson (stale/supersede)'
     'rm:delete a saved session or command run'
     'prune:delete empty auto-recorded sessions'
+    'audit:inspect capture policy and retained volume'
     'share:write a self-contained HTML page to send to someone'
     'discard:inside a recording, throw the current session away'
     'replay:rerun a saved command run'
     'demo:seed a small demo dataset'
-    'search:search commands, output, notes, and transcripts'
-    'git-fix:diagnose the last failed git command'
     'export:export memory to a bundle (Markdown + JSON + SQLite)'
     'import:merge another machine'\''s exported memory'
     'push:send this machine'\''s memory to a teammate over SSH'
@@ -28,8 +28,20 @@ _mw() {
     'context:print a compact digest for an AI agent'
     'agent:export a session as text to paste into an agent'
     'ask:package the last failure for ChatGPT/Claude (clipboard)'
+    'search:search commands, output, notes, and transcripts'
+    'explain:why this memory ranks: per-signal breakdown'
+    'link:link two memories (typed edge)'
+    'unlink:remove a typed edge between two memories'
+    'links:show a memory'\''s linked neighbors in both directions'
+    'pet:snapshot your memory whale'\''s growth (--watch animates)'
+    'tui:interactive terminal browser'
+    'sync-mempalace:mirror memories into MemPalace'
+    'git-fix:diagnose the last failed git command'
     'doctor:check the install'
     'global:auto-record every new terminal (on/off/status)'
+    'status:show global auto-record state'
+    'hooks:install or remove shell auto-record hooks'
+    'integrate:register the MCP server with a host (hermes)'
   )
 
   if (( CURRENT == 2 )); then
@@ -37,6 +49,7 @@ _mw() {
       '--live[autosave the session to SQLite while running]' \
       '--notes[attach a note to this session]:note:' \
       '(-h --help)'{-h,--help}'[show help]' \
+      '(-V --version)'{-V,--version}'[print the installed version]' \
       '*::command:->cmds'
     _describe -t commands 'mw command' subcmds
     return
@@ -45,6 +58,21 @@ _mw() {
   case ${words[2]} in
     global)
       _values 'state' on off status
+      ;;
+    memory)
+      _values 'action' stale supersede
+      ;;
+    hooks)
+      _values 'action' install uninstall remove
+      ;;
+    integrate)
+      _values 'target' hermes
+      ;;
+    sync-mempalace)
+      _arguments \
+        '--wing[name of the MemPalace wing]:wing:' \
+        '--limit[max memories to sync]:count:' \
+        '--dry-run[print the plan without contacting the server]'
       ;;
     show)
       local -a ids

--- a/linux/completions/_mw-extra
+++ b/linux/completions/_mw-extra
@@ -6,6 +6,7 @@ _mw_extra() {
   case $service in
     mw-serve)
       _arguments \
+        '--lan[serve on the LAN (bind 0.0.0.0)]' \
         '--host[bind address]:addr:' \
         '--port[port]:port:' \
         '--token[require a shared token]:token:' \

--- a/linux/completions/mw-extra.bash
+++ b/linux/completions/mw-extra.bash
@@ -4,7 +4,7 @@
 # bash-completion's on-demand loader picks it up.
 
 _mw_serve_complete() {
-  COMPREPLY=( $(compgen -W "--host --port --token --help" -- "${COMP_WORDS[COMP_CWORD]}") )
+  COMPREPLY=( $(compgen -W "--lan --host --port --token --help" -- "${COMP_WORDS[COMP_CWORD]}") )
 }
 complete -F _mw_serve_complete mw-serve
 

--- a/linux/completions/mw.bash
+++ b/linux/completions/mw.bash
@@ -9,15 +9,28 @@ _mw_complete() {
 
   if [ "$COMP_CWORD" -eq 1 ]; then
     COMPREPLY=( $(compgen -W "\
-list show mark remember replay demo search git-fix rm prune share discard \
-export import push pull agent ask context doctor global \
---live --notes --help" -- "$cur") )
+list show mark remember memory rm prune audit share discard replay demo \
+export import push pull context agent ask search explain link unlink links \
+pet tui sync-mempalace git-fix doctor global status hooks integrate \
+--live --notes --version --help" -- "$cur") )
     return
   fi
 
   case "${COMP_WORDS[1]}" in
     global)
       [ "$COMP_CWORD" -eq 2 ] && COMPREPLY=( $(compgen -W "on off status" -- "$cur") )
+      ;;
+    memory)
+      [ "$COMP_CWORD" -eq 2 ] && COMPREPLY=( $(compgen -W "stale supersede" -- "$cur") )
+      ;;
+    hooks)
+      [ "$COMP_CWORD" -eq 2 ] && COMPREPLY=( $(compgen -W "install uninstall remove" -- "$cur") )
+      ;;
+    integrate)
+      [ "$COMP_CWORD" -eq 2 ] && COMPREPLY=( $(compgen -W "hermes" -- "$cur") )
+      ;;
+    sync-mempalace)
+      COMPREPLY=( $(compgen -W "--wing --limit --dry-run" -- "$cur") )
       ;;
     show)
       # session ids come from `mw list`; offer them when available.

--- a/linux/completions/mw.bash
+++ b/linux/completions/mw.bash
@@ -12,7 +12,7 @@ _mw_complete() {
 list show mark remember memory rm prune audit share discard replay demo \
 export import push pull context agent ask search explain link unlink links \
 pet tui sync-mempalace git-fix doctor global status hooks integrate \
---live --notes --version --help" -- "$cur") )
+--live --autosave --notes --version --help" -- "$cur") )
     return
   fi
 
@@ -24,12 +24,22 @@ pet tui sync-mempalace git-fix doctor global status hooks integrate \
       [ "$COMP_CWORD" -eq 2 ] && COMPREPLY=( $(compgen -W "stale supersede" -- "$cur") )
       ;;
     hooks)
-      [ "$COMP_CWORD" -eq 2 ] && COMPREPLY=( $(compgen -W "install uninstall remove" -- "$cur") )
+      if [ "$COMP_CWORD" -eq 2 ]; then
+        COMPREPLY=( $(compgen -W "install uninstall remove" -- "$cur") )
+      elif [ "$COMP_CWORD" -eq 3 ] && [[ " install uninstall remove " == *" ${COMP_WORDS[2]} "* ]]; then
+        COMPREPLY=( $(compgen -W "pwsh" -- "$cur") )
+      fi
+      ;;
+    pet)
+      [ "$COMP_CWORD" -eq 2 ] && COMPREPLY=( $(compgen -W "--watch" -- "$cur") )
       ;;
     integrate)
       [ "$COMP_CWORD" -eq 2 ] && COMPREPLY=( $(compgen -W "hermes" -- "$cur") )
       ;;
     sync-mempalace)
+      case "$prev" in
+        --wing|--limit) COMPREPLY=(); return ;;
+      esac
       COMPREPLY=( $(compgen -W "--wing --limit --dry-run" -- "$cur") )
       ;;
     show)


### PR DESCRIPTION
Closes #122

## Why

The bash/zsh completions are missing 12 top-level `mw` commands that the dispatch table already handles (`memory`, `audit`, `status`, `explain`, `link`, `unlink`, `links`, `pet`, `tui`, `sync-mempalace`, `hooks`, `integrate`), and `mw-serve` completion omits `--lan` — all added since the completion files were written.

## What

- **mw.bash** — top-level word list brought in sync with the dispatch table; new subcommand branches for `memory`, `hooks`, `integrate`, and `sync-mempalace`.
- **_mw** — `subcmds` array updated with the 12 commands + `--version` flag; new `case` branches for `memory`, `hooks`, `integrate`, `sync-mempalace`.
- **mw-extra.bash / _mw-extra** — `mw-serve` completion includes `--lan`.

Options are taken from the actual arg parsers (`memory stale|supersede`, `hooks install|uninstall|remove`, `integrate hermes`, `sync-mempalace --wing/--limit/--dry-run`, `pet --watch`), not guessed. No removed or fictional commands added.

## Validation

- `bash -n` clean on both bash files.
- `zsh -n` clean on both zsh files.
- `git diff` touches only the four completion files; no Rust changes.

## Surface area

Completion only — nothing at runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Expanded shell autocomplete support for memory, auditing, status, hooks, integrations, synchronization, search, linking, TUI, pet, explanation, and version commands.
  * Added context-sensitive completion for command arguments, options, shell targets, and integration targets.
  * Added `--lan` autocomplete for the server command, indicating that it binds to all network interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->