### PR TITLE
ci: run repository consistency checks on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         run: cargo clippy -p memorywhale-core -p memorywhale-cli --all-targets -- -D warnings
       - name: Test non-desktop crates
         run: cargo test -p memorywhale-core -p memorywhale-cli
+      - name: Check documentation references
+        run: bash scripts/check-doc-references.sh
 
   frontend:
     name: Frontend build, tests, and audit
@@ -35,6 +37,8 @@ jobs:
         run: npm ci
       - name: Test
         run: npm test
+      - name: Check release version consistency
+        run: bash scripts/check-release-version.sh
       - name: Check landing page contracts
         run: npm run test:site
       - name: Install browser for landing-page smoke test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,17 @@ cargo test -p memorywhale-core -p memorywhale-cli
 cargo build --workspace
 ```
 
+Run repository consistency checks:
+
+```bash
+bash scripts/check-release-version.sh
+bash scripts/check-doc-references.sh
+```
+
+The release-version check keeps the CLI, npm, lockfile, and Tauri versions in
+sync. The documentation-reference check verifies the MCP tool list and CLI
+binary names against the runtime and reference docs.
+
 Try the terminal memory helper:
 
 ```bash


### PR DESCRIPTION
Closes #131.

Adds the repository consistency checks to normal pull-request CI:

- `scripts/check-doc-references.sh` runs in the Rust quality job after Cargo setup.
- `scripts/check-release-version.sh` runs in the frontend job after Node/npm setup.
- `CONTRIBUTING.md` documents both local commands and what they validate.

No scripts or release behavior changed.

Local verification:

- `bash scripts/check-release-version.sh`
- `bash scripts/check-doc-references.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup guidance with instructions for validating release versions and documentation references.
  * Added descriptions of the consistency checks contributors should perform.

* **Chores**
  * Automated documentation-reference and release-version validation in continuous integration to help detect inconsistencies earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->