### PR TITLE
security(capture): enforce shared sanitization before storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,6 +2198,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "dirs 5.0.1",
+ "regex",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/memorywhale-core/Cargo.toml
+++ b/crates/memorywhale-core/Cargo.toml
@@ -26,6 +26,7 @@ ureq = { version = "2", features = ["json"], optional = true }
 # The one SQLite loader (memorywhale_core::sqlite) lives here so the CLI and desktop
 # share it. bundled = no system libsqlite3 needed (matches the other crates).
 rusqlite = { version = "0.32", features = ["bundled"] }
+regex = "1"
 
 # `dirs` is used only by the `dump_eval` example, which reads a real
 # memorywhale.sqlite3 into an eval_data.json gold-set skeleton.

--- a/crates/memorywhale-core/src/lib.rs
+++ b/crates/memorywhale-core/src/lib.rs
@@ -64,6 +64,7 @@ pub mod embed;
 pub mod engine;
 #[cfg(feature = "mempalace")]
 mod mcp;
+pub mod privacy;
 pub mod scorer;
 pub mod sqlite;
 

--- a/crates/memorywhale-core/src/privacy.rs
+++ b/crates/memorywhale-core/src/privacy.rs
@@ -29,16 +29,21 @@ pub fn truncate_capture(text: &str, limit: usize) -> String {
     if text.len() <= limit {
         return text.to_string();
     }
+    let marker = format!("\n[TRUNCATED: stored {} of {} bytes]", limit, text.len());
+    if marker.len() >= limit {
+        return take_utf8_prefix("[TRUNCATED]", limit);
+    }
+    let content_limit = limit - marker.len();
+    let content = take_utf8_prefix(text, content_limit);
+    format!("{content}{marker}")
+}
+
+fn take_utf8_prefix(text: &str, limit: usize) -> String {
     let mut end = limit.min(text.len());
     while !text.is_char_boundary(end) {
         end -= 1;
     }
-    format!(
-        "{}\n[TRUNCATED: stored {} of {} bytes]",
-        &text[..end],
-        end,
-        text.len()
-    )
+    text[..end].to_string()
 }
 
 /// Scrub common secret shapes before capture text lands in SQLite.
@@ -46,7 +51,7 @@ pub fn truncate_capture(text: &str, limit: usize) -> String {
 /// This is intentionally conservative rather than a guarantee. Set
 /// `MEMORYWHALE_NO_REDACT=1` for the explicit raw-capture opt-out.
 pub fn redact(text: &str) -> String {
-    if std::env::var_os("MEMORYWHALE_NO_REDACT").is_some() {
+    if std::env::var("MEMORYWHALE_NO_REDACT").ok().as_deref() == Some("1") {
         return text.to_string();
     }
     let mut out = text.to_string();
@@ -89,13 +94,29 @@ mod tests {
         let previous = std::env::var_os("MEMORYWHALE_MAX_CAPTURE_BYTES");
         std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", "24");
         std::env::remove_var("MEMORYWHALE_NO_REDACT");
+        assert!(redact("token=abcdef1234567890").contains("token=[REDACTED]"));
         let value = sanitize_capture("token=abcdef1234567890 and a long tail");
-        assert!(value.contains("token=[REDACTED]"));
-        assert!(value.contains("[TRUNCATED:"));
+        assert!(!value.contains("abcdef1234567890"));
+        assert!(value.contains("[TRUNCATED:") || value.starts_with("[TRUNC"));
+        assert!(value.len() <= 24);
         if let Some(value) = previous {
             std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", value);
         } else {
             std::env::remove_var("MEMORYWHALE_MAX_CAPTURE_BYTES");
+        }
+    }
+
+    #[test]
+    fn raw_capture_opt_out_requires_value_one() {
+        let previous = std::env::var_os("MEMORYWHALE_NO_REDACT");
+        std::env::set_var("MEMORYWHALE_NO_REDACT", "0");
+        assert!(!redact("token=abcdef123456").contains("abcdef123456"));
+        std::env::set_var("MEMORYWHALE_NO_REDACT", "1");
+        assert!(redact("token=abcdef123456").contains("abcdef123456"));
+        if let Some(value) = previous {
+            std::env::set_var("MEMORYWHALE_NO_REDACT", value);
+        } else {
+            std::env::remove_var("MEMORYWHALE_NO_REDACT");
         }
     }
 }

--- a/crates/memorywhale-core/src/privacy.rs
+++ b/crates/memorywhale-core/src/privacy.rs
@@ -1,0 +1,101 @@
+//! Shared capture privacy policy.
+//!
+//! Every adapter that writes user-provided capture text should call
+//! [`sanitize_capture`] before inserting it into SQLite. This module lives in
+//! the core crate so the CLI, desktop shell, recovery paths, and future
+//! adapters cannot silently drift into separate redaction implementations.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+pub const REDACTED: &str = "[REDACTED]";
+pub const DEFAULT_MAX_CAPTURE_BYTES: usize = 1_048_576;
+
+/// Maximum bytes retained for one captured text field.
+pub fn max_capture_bytes() -> usize {
+    std::env::var("MEMORYWHALE_MAX_CAPTURE_BYTES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_MAX_CAPTURE_BYTES)
+}
+
+/// Redact known secret shapes and bound the stored value.
+pub fn sanitize_capture(text: &str) -> String {
+    truncate_capture(&redact(text), max_capture_bytes())
+}
+
+pub fn truncate_capture(text: &str, limit: usize) -> String {
+    if text.len() <= limit {
+        return text.to_string();
+    }
+    let mut end = limit.min(text.len());
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!(
+        "{}\n[TRUNCATED: stored {} of {} bytes]",
+        &text[..end],
+        end,
+        text.len()
+    )
+}
+
+/// Scrub common secret shapes before capture text lands in SQLite.
+///
+/// This is intentionally conservative rather than a guarantee. Set
+/// `MEMORYWHALE_NO_REDACT=1` for the explicit raw-capture opt-out.
+pub fn redact(text: &str) -> String {
+    if std::env::var_os("MEMORYWHALE_NO_REDACT").is_some() {
+        return text.to_string();
+    }
+    let mut out = text.to_string();
+    for re in secret_patterns() {
+        out = re
+            .replace_all(&out, |caps: &regex::Captures| match caps.name("label") {
+                Some(label) => format!("{}{}", label.as_str(), REDACTED),
+                None => REDACTED.to_string(),
+            })
+            .into_owned();
+    }
+    out
+}
+
+fn secret_patterns() -> &'static [Regex] {
+    static PATTERNS: OnceLock<Vec<Regex>> = OnceLock::new();
+    PATTERNS.get_or_init(|| {
+        [
+            r#"(?i)(?P<label>\b(?:api[_-]?key|secret|token|password|passwd|pwd|access[_-]?key|client[_-]?secret)\b\s*[:=]\s*)['"]?[A-Za-z0-9/_+\-\.]{6,}['"]?"#,
+            r#"(?i)(?P<label>--(?:api[_-]?key|secret|token|password|passwd|pwd|access[_-]?key|client[_-]?secret)\s+)[^\s]+"#,
+            r#"(?i)(?P<label>bearer\s+)[A-Za-z0-9._\-]{8,}"#,
+            r#"AKIA[0-9A-Z]{16}"#,
+            r#"gh[pousr]_[A-Za-z0-9]{20,}"#,
+            r#"xox[baprs]-[A-Za-z0-9\-]{10,}"#,
+            r#"eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+"#,
+            r#"(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----"#,
+        ]
+        .iter()
+        .map(|pattern| Regex::new(pattern).expect("valid secret regex"))
+        .collect()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_and_truncates_before_storage() {
+        let previous = std::env::var_os("MEMORYWHALE_MAX_CAPTURE_BYTES");
+        std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", "24");
+        std::env::remove_var("MEMORYWHALE_NO_REDACT");
+        let value = sanitize_capture("token=abcdef1234567890 and a long tail");
+        assert!(value.contains("token=[REDACTED]"));
+        assert!(value.contains("[TRUNCATED:"));
+        if let Some(value) = previous {
+            std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", value);
+        } else {
+            std::env::remove_var("MEMORYWHALE_MAX_CAPTURE_BYTES");
+        }
+    }
+}

--- a/crates/memorywhale-core/src/privacy.rs
+++ b/crates/memorywhale-core/src/privacy.rs
@@ -29,21 +29,32 @@ pub fn truncate_capture(text: &str, limit: usize) -> String {
     if text.len() <= limit {
         return text.to_string();
     }
-    let marker = format!("\n[TRUNCATED: stored {} of {} bytes]", limit, text.len());
-    if marker.len() >= limit {
-        return take_utf8_prefix("[TRUNCATED]", limit);
+    let mut content_limit = limit;
+    for _ in 0..8 {
+        let stored = utf8_prefix_len(text, content_limit);
+        let marker = format!("\n[TRUNCATED: stored {stored} of {} bytes]", text.len());
+        if marker.len() >= limit {
+            return take_utf8_prefix("[TRUNCATED]", limit);
+        }
+        let next_limit = limit - marker.len();
+        if next_limit == content_limit {
+            return format!("{}{}", &text[..stored], marker);
+        }
+        content_limit = next_limit;
     }
-    let content_limit = limit - marker.len();
-    let content = take_utf8_prefix(text, content_limit);
-    format!("{content}{marker}")
+    take_utf8_prefix("[TRUNCATED]", limit)
 }
 
 fn take_utf8_prefix(text: &str, limit: usize) -> String {
+    text[..utf8_prefix_len(text, limit)].to_string()
+}
+
+fn utf8_prefix_len(text: &str, limit: usize) -> usize {
     let mut end = limit.min(text.len());
     while !text.is_char_boundary(end) {
         end -= 1;
     }
-    text[..end].to_string()
+    end
 }
 
 /// Scrub common secret shapes before capture text lands in SQLite.
@@ -88,9 +99,13 @@ fn secret_patterns() -> &'static [Regex] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn redacts_and_truncates_before_storage() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let previous = std::env::var_os("MEMORYWHALE_MAX_CAPTURE_BYTES");
         std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", "24");
         std::env::remove_var("MEMORYWHALE_NO_REDACT");
@@ -108,6 +123,7 @@ mod tests {
 
     #[test]
     fn raw_capture_opt_out_requires_value_one() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let previous = std::env::var_os("MEMORYWHALE_NO_REDACT");
         std::env::set_var("MEMORYWHALE_NO_REDACT", "0");
         assert!(!redact("token=abcdef123456").contains("abcdef123456"));

--- a/crates/mw-cli/src/bin/mw-recover.rs
+++ b/crates/mw-cli/src/bin/mw-recover.rs
@@ -109,7 +109,9 @@ pub fn recover_orphans(verbose: bool) -> Result<RecoveryReport, String> {
             }
             continue;
         }
-        let cleaned = clean_transcript(&String::from_utf8_lossy(&raw));
+        let cleaned =
+            memorywhale_cli::sanitize_capture(&clean_transcript(&String::from_utf8_lossy(&raw)));
+        let stored_byte_count = cleaned.len() as i64;
         let started_at = started_from_filename(&path).unwrap_or_else(|| mtime_rfc3339(&path));
         let ended_at = mtime_rfc3339(&path);
 
@@ -124,7 +126,7 @@ pub fn recover_orphans(verbose: bool) -> Result<RecoveryReport, String> {
                 "recovered from transcript (recording was interrupted before saving)",
                 started_at,
                 ended_at,
-                byte_count
+                stored_byte_count
             ],
         )
         .map_err(|e| format!("insert recovered session: {e}"))?;

--- a/crates/mw-cli/src/bin/mw-remember.rs
+++ b/crates/mw-cli/src/bin/mw-remember.rs
@@ -64,8 +64,12 @@ fn run() -> Result<(), String> {
     }
 
     notes = append_environment_tags(notes);
-    let command = command_parts[0].clone();
-    let argv_json = serde_json::to_string(&command_parts)
+    let stored_args: Vec<String> = command_parts
+        .iter()
+        .map(|value| memorywhale_cli::sanitize_capture(value))
+        .collect();
+    let command = stored_args[0].clone();
+    let argv_json = serde_json::to_string(&stored_args)
         .map_err(|err| format!("failed to encode argv: {err}"))?;
     let created_at = Utc::now().to_rfc3339();
     let db_path = database_path()?;
@@ -95,7 +99,7 @@ fn run() -> Result<(), String> {
     .map_err(|err| format!("failed to insert command run: {err}"))?;
     let run_id = conn.last_insert_rowid();
 
-    for (position, value) in command_parts.iter().enumerate() {
+    for (position, value) in stored_args.iter().enumerate() {
         conn.execute(
             "
             INSERT INTO command_arguments (command_run_id, position, value)

--- a/crates/mw-cli/src/bin/mw-run.rs
+++ b/crates/mw-cli/src/bin/mw-run.rs
@@ -169,8 +169,12 @@ fn remember_command(
     stderr: &str,
     notes: &str,
 ) -> Result<i64, String> {
-    let command = command_parts[0].clone();
-    let argv_json = serde_json::to_string(command_parts)
+    let stored_args: Vec<String> = command_parts
+        .iter()
+        .map(|value| memorywhale_cli::sanitize_capture(value))
+        .collect();
+    let command = stored_args[0].clone();
+    let argv_json = serde_json::to_string(&stored_args)
         .map_err(|err| format!("failed to encode argv: {err}"))?;
     let created_at = Utc::now().to_rfc3339();
     let db_path = database_path()?;
@@ -208,7 +212,7 @@ fn remember_command(
     .map_err(|err| format!("failed to insert command run: {err}"))?;
     let run_id = conn.last_insert_rowid();
 
-    for (position, value) in command_parts.iter().enumerate() {
+    for (position, value) in stored_args.iter().enumerate() {
         conn.execute(
             "
             INSERT INTO command_arguments (command_run_id, position, value)

--- a/crates/mw-cli/src/bin/mw-screenshot.rs
+++ b/crates/mw-cli/src/bin/mw-screenshot.rs
@@ -114,7 +114,7 @@ fn run() -> Result<(), String> {
             command_run_id,
             file_path.to_string_lossy(),
             cwd,
-            notes,
+            memorywhale_cli::sanitize_capture(&notes),
             captured_at
         ],
     )

--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -2036,7 +2036,8 @@ fn recover_orphans() -> Result<RecoveryReport, String> {
             }
             continue;
         }
-        let cleaned = clean_transcript(&String::from_utf8_lossy(&raw));
+        let cleaned =
+            memorywhale_cli::sanitize_capture(&clean_transcript(&String::from_utf8_lossy(&raw)));
         let started = started_from_filename(&path).unwrap_or_else(|| mtime_rfc3339(&path));
         let ended = mtime_rfc3339(&path);
         conn.execute(
@@ -2045,7 +2046,7 @@ fn recover_orphans() -> Result<RecoveryReport, String> {
             params![
                 Option::<String>::None, Option::<String>::None, path_str, cleaned,
                 "recovered from transcript (recording was interrupted before saving)",
-                started, ended, raw.len() as i64
+                started, ended, cleaned.len() as i64
             ],
         )
         .map_err(|e| format!("insert recovered session: {e}"))?;

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -431,6 +431,7 @@ struct LiveSync {
 
 fn insert_live_session(draft: &SessionDraft<'_>) -> Result<i64, String> {
     let conn = open_session_db()?;
+    let stored_notes = memorywhale_cli::sanitize_capture(draft.notes);
     conn.execute(
         "
         INSERT INTO sessions
@@ -442,9 +443,9 @@ fn insert_live_session(draft: &SessionDraft<'_>) -> Result<i64, String> {
             draft.shell,
             draft.cwd,
             draft.stored_transcript_path(),
-            draft.notes,
+            stored_notes,
             draft.started_at,
-            memorywhale_cli::project_of(draft.notes),
+            memorywhale_cli::project_of(&stored_notes),
             memorywhale_cli::machine_name()
         ],
     )
@@ -465,6 +466,7 @@ fn insert_finished_session(
     } else {
         String::new()
     };
+    let stored_notes = memorywhale_cli::sanitize_capture(draft.notes);
     let conn = open_session_db()?;
     conn.execute(
         "
@@ -478,11 +480,11 @@ fn insert_finished_session(
             draft.cwd,
             draft.stored_transcript_path(),
             cleaned,
-            draft.notes,
+            stored_notes,
             draft.started_at,
             ended_at,
             byte_count,
-            memorywhale_cli::project_of(draft.notes),
+            memorywhale_cli::project_of(&stored_notes),
             memorywhale_cli::machine_name()
         ],
     )
@@ -1778,24 +1780,76 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
         }
     };
 
-    // command_runs: skip rows already present (same command, argv, and timestamp).
+    // command_runs: read through Rust so imported text is sanitized before the
+    // destination write. SQL-to-SQL copying would bypass the capture policy.
     if src_has("command_runs") {
         let c = src_columns(&conn, "command_runs");
         if c.contains("command") && c.contains("argv_json") && c.contains("created_at") {
             let sql = format!(
-                "INSERT INTO command_runs (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at)
-                 SELECT {}, {}, {}, {}, {}, {}, {}, {}
-                 FROM src.command_runs s
-                 WHERE NOT EXISTS (
-                   SELECT 1 FROM command_runs m
-                   WHERE m.command = s.command AND m.argv_json = s.argv_json AND m.created_at = s.created_at
-                 )",
-                sel(&c, "command", "''"), sel(&c, "argv_json", "'[]'"), sel(&c, "cwd", "NULL"),
-                sel(&c, "exit_code", "NULL"), sel(&c, "stdout", "''"), sel(&c, "stderr", "''"),
-                sel(&c, "notes", "''"), sel(&c, "created_at", "''")
+                "SELECT {}, {}, {}, {}, {}, {}, {}, {} FROM src.command_runs",
+                sel(&c, "command", "''"),
+                sel(&c, "argv_json", "'[]'"),
+                sel(&c, "cwd", "NULL"),
+                sel(&c, "exit_code", "NULL"),
+                sel(&c, "stdout", "''"),
+                sel(&c, "stderr", "''"),
+                sel(&c, "notes", "''"),
+                sel(&c, "created_at", "''")
             );
-            conn.execute(&sql, [])
-                .map_err(|err| format!("failed to merge command runs: {err}"))?;
+            type ImportedCommandRun = (
+                String,
+                String,
+                Option<String>,
+                Option<i64>,
+                String,
+                String,
+                String,
+                String,
+            );
+            let rows: Vec<ImportedCommandRun> = {
+                let mut stmt = conn
+                    .prepare(&sql)
+                    .map_err(|err| format!("failed to read imported command runs: {err}"))?;
+                let mapped = stmt.query_map([], |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                        r.get(6)?,
+                        r.get(7)?,
+                    ))
+                });
+                let rows = mapped
+                    .map_err(|err| format!("failed to read imported command runs: {err}"))?
+                    .collect::<Result<_, _>>()
+                    .map_err(|err| format!("failed to decode imported command runs: {err}"))?;
+                rows
+            };
+            for (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at) in rows {
+                let command = memorywhale_cli::sanitize_capture(&command);
+                let argv_json = memorywhale_cli::sanitize_capture(&argv_json);
+                let stdout = memorywhale_cli::sanitize_capture(&stdout);
+                let stderr = memorywhale_cli::sanitize_capture(&stderr);
+                let notes = memorywhale_cli::sanitize_capture(&notes);
+                let exists: i64 = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM command_runs WHERE command = ?1 AND argv_json = ?2 AND created_at = ?3",
+                        params![command, argv_json, created_at],
+                        |r| r.get(0),
+                    )
+                    .unwrap_or(0);
+                if exists == 0 {
+                    conn.execute(
+                        "INSERT INTO command_runs (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                        params![command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at],
+                    )
+                    .map_err(|err| format!("failed to merge command run: {err}"))?;
+                }
+            }
         }
     }
 
@@ -1804,32 +1858,99 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
         let c = src_columns(&conn, "sessions");
         if c.contains("started_at") && c.contains("transcript_path") {
             let sql = format!(
-                "INSERT INTO sessions (shell, cwd, transcript_path, transcript, notes, started_at, ended_at, byte_count, status)
-                 SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}
-                 FROM src.sessions s
-                 WHERE NOT EXISTS (
-                   SELECT 1 FROM sessions m
-                   WHERE m.started_at = s.started_at AND m.transcript_path = s.transcript_path
-                 )",
-                sel(&c, "shell", "''"), sel(&c, "cwd", "NULL"), sel(&c, "transcript_path", "''"),
-                sel(&c, "transcript", "''"), sel(&c, "notes", "''"), sel(&c, "started_at", "''"),
-                sel(&c, "ended_at", "''"), sel(&c, "byte_count", "0"), sel(&c, "status", "'finished'")
+                "SELECT {}, {}, {}, {}, {}, {}, {}, {}, {} FROM src.sessions",
+                sel(&c, "shell", "''"),
+                sel(&c, "cwd", "NULL"),
+                sel(&c, "transcript_path", "''"),
+                sel(&c, "transcript", "''"),
+                sel(&c, "notes", "''"),
+                sel(&c, "started_at", "''"),
+                sel(&c, "ended_at", "''"),
+                sel(&c, "byte_count", "0"),
+                sel(&c, "status", "'finished'")
             );
-            conn.execute(&sql, [])
-                .map_err(|err| format!("failed to merge sessions: {err}"))?;
+            type ImportedSession = (
+                String,
+                Option<String>,
+                String,
+                String,
+                String,
+                String,
+                String,
+                i64,
+                String,
+            );
+            let rows: Vec<ImportedSession> = {
+                let mut stmt = conn
+                    .prepare(&sql)
+                    .map_err(|err| format!("failed to read imported sessions: {err}"))?;
+                let mapped = stmt.query_map([], |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                        r.get(6)?,
+                        r.get(7)?,
+                        r.get(8)?,
+                    ))
+                });
+                let rows = mapped
+                    .map_err(|err| format!("failed to read imported sessions: {err}"))?
+                    .collect::<Result<_, _>>()
+                    .map_err(|err| format!("failed to decode imported sessions: {err}"))?;
+                rows
+            };
+            for (shell, cwd, path, transcript, notes, started, ended, _bytes, status) in rows {
+                let transcript = memorywhale_cli::sanitize_capture(&transcript);
+                let notes = memorywhale_cli::sanitize_capture(&notes);
+                let exists: i64 = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM sessions WHERE started_at = ?1 AND transcript_path = ?2",
+                        params![started, path],
+                        |r| r.get(0),
+                    )
+                    .unwrap_or(0);
+                if exists == 0 {
+                    conn.execute(
+                        "INSERT INTO sessions (shell, cwd, transcript_path, transcript, notes, started_at, ended_at, byte_count, status)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                        params![shell, cwd, path, transcript, notes, started, ended, transcript.len() as i64, status],
+                    )
+                    .map_err(|err| format!("failed to merge session: {err}"))?;
+                }
+            }
         }
     }
 
     // bookmarks: skip same label + timestamp.
     if src_has("bookmarks") {
-        let _ = conn.execute(
-            "INSERT INTO bookmarks (label, cwd, created_at)
-             SELECT s.label, s.cwd, s.created_at FROM src.bookmarks s
-             WHERE NOT EXISTS (
-               SELECT 1 FROM bookmarks m WHERE m.label = s.label AND m.created_at = s.created_at
-             )",
-            [],
-        );
+        let rows: Vec<(String, Option<String>, String)> = conn
+            .prepare("SELECT label, cwd, created_at FROM src.bookmarks")
+            .and_then(|mut stmt| {
+                stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+                    .and_then(|rows| rows.collect::<Result<Vec<_>, _>>())
+            })
+            .map_err(|err| format!("failed to read imported bookmarks: {err}"))?;
+        for (label, cwd, created_at) in rows {
+            let label = memorywhale_cli::sanitize_capture(&label);
+            let exists: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM bookmarks WHERE label = ?1 AND created_at = ?2",
+                    params![label, created_at],
+                    |r| r.get(0),
+                )
+                .unwrap_or(0);
+            if exists == 0 {
+                conn.execute(
+                    "INSERT INTO bookmarks (label, cwd, created_at) VALUES (?1, ?2, ?3)",
+                    params![label, cwd, created_at],
+                )
+                .map_err(|err| format!("failed to merge bookmark: {err}"))?;
+            }
+        }
     }
 
     conn.execute("DETACH DATABASE src", [])

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -1941,7 +1941,7 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
     if src_has("bookmarks") {
         let c = src_columns(&conn, "bookmarks");
         let sql = format!(
-            "SELECT {}, {}, {} FROM src.bookmarks",
+            "SELECT {}, {}, {} FROM src.bookmarks s",
             sel(&c, "label", "''"),
             sel(&c, "cwd", "NULL"),
             sel(&c, "created_at", "''")

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -1939,8 +1939,15 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
 
     // bookmarks: skip same label + timestamp.
     if src_has("bookmarks") {
+        let c = src_columns(&conn, "bookmarks");
+        let sql = format!(
+            "SELECT {}, {}, {} FROM src.bookmarks",
+            sel(&c, "label", "''"),
+            sel(&c, "cwd", "NULL"),
+            sel(&c, "created_at", "''")
+        );
         let rows: Vec<(String, Option<String>, String)> = conn
-            .prepare("SELECT label, cwd, created_at FROM src.bookmarks")
+            .prepare(&sql)
             .and_then(|mut stmt| {
                 stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
                     .and_then(|rows| rows.collect::<Result<Vec<_>, _>>())

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -1830,7 +1830,13 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
             };
             for (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at) in rows {
                 let command = memorywhale_cli::sanitize_capture(&command);
-                let argv_json = memorywhale_cli::sanitize_capture(&argv_json);
+                let argv: Vec<String> = serde_json::from_str::<Vec<String>>(&argv_json)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|value: String| memorywhale_cli::sanitize_capture(&value))
+                    .collect();
+                let argv_json = serde_json::to_string(&argv)
+                    .map_err(|err| format!("failed to encode imported argv: {err}"))?;
                 let stdout = memorywhale_cli::sanitize_capture(&stdout);
                 let stderr = memorywhale_cli::sanitize_capture(&stderr);
                 let notes = memorywhale_cli::sanitize_capture(&notes);
@@ -1903,9 +1909,15 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
                     .map_err(|err| format!("failed to decode imported sessions: {err}"))?;
                 rows
             };
-            for (shell, cwd, path, transcript, notes, started, ended, _bytes, status) in rows {
+            for (shell, cwd, path, transcript, notes, started, ended, source_bytes, status) in rows
+            {
                 let transcript = memorywhale_cli::sanitize_capture(&transcript);
                 let notes = memorywhale_cli::sanitize_capture(&notes);
+                let stored_bytes = if transcript.is_empty() {
+                    source_bytes
+                } else {
+                    transcript.len() as i64
+                };
                 let exists: i64 = conn
                     .query_row(
                         "SELECT COUNT(*) FROM sessions WHERE started_at = ?1 AND transcript_path = ?2",
@@ -1917,7 +1929,7 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
                     conn.execute(
                         "INSERT INTO sessions (shell, cwd, transcript_path, transcript, notes, started_at, ended_at, byte_count, status)
                          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-                        params![shell, cwd, path, transcript, notes, started, ended, transcript.len() as i64, status],
+                        params![shell, cwd, path, transcript, notes, started, ended, stored_bytes, status],
                     )
                     .map_err(|err| format!("failed to merge session: {err}"))?;
                 }

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -1831,7 +1831,7 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
             for (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at) in rows {
                 let command = memorywhale_cli::sanitize_capture(&command);
                 let argv: Vec<String> = serde_json::from_str::<Vec<String>>(&argv_json)
-                    .unwrap_or_default()
+                    .map_err(|err| format!("invalid imported argv JSON: {err}"))?
                     .into_iter()
                     .map(|value: String| memorywhale_cli::sanitize_capture(&value))
                     .collect();

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -1497,89 +1497,10 @@ pub fn remember_as(
     Ok(conn.last_insert_rowid())
 }
 
-const REDACTED: &str = "[REDACTED]";
-pub const DEFAULT_MAX_CAPTURE_BYTES: usize = 1_048_576;
-
-/// Maximum bytes retained for any individual captured text field.
-///
-/// Set `MEMORYWHALE_MAX_CAPTURE_BYTES` to a positive integer to tune the
-/// limit. The default is 1 MiB per stdout, stderr, note, or transcript field.
-pub fn max_capture_bytes() -> usize {
-    std::env::var("MEMORYWHALE_MAX_CAPTURE_BYTES")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(DEFAULT_MAX_CAPTURE_BYTES)
-}
-
-/// Redact known secret shapes and bound the stored value, adding an explicit
-/// marker when bytes were omitted.
-pub fn sanitize_capture(text: &str) -> String {
-    truncate_capture(&redact(text), max_capture_bytes())
-}
-
-fn truncate_capture(text: &str, limit: usize) -> String {
-    if text.len() <= limit {
-        return text.to_string();
-    }
-    let mut end = limit.min(text.len());
-    while !text.is_char_boundary(end) {
-        end -= 1;
-    }
-    format!(
-        "{}\n[TRUNCATED: stored {} of {} bytes]",
-        &text[..end],
-        end,
-        text.len()
-    )
-}
-
-/// Scrub common secret shapes out of captured text before it lands in SQLite.
-///
-/// This runs on stdout/stderr/notes/transcripts — the bulky, unattended
-/// captures where an `env` dump or a leaked token is most likely to end up.
-/// It is intentionally conservative (known token formats + `key=secret`
-/// assignments), not a guarantee. Set `MEMORYWHALE_NO_REDACT=1` to store raw.
-pub fn redact(text: &str) -> String {
-    if std::env::var_os("MEMORYWHALE_NO_REDACT").is_some() {
-        return text.to_string();
-    }
-    let mut out = text.to_string();
-    for re in secret_patterns() {
-        out = re
-            .replace_all(&out, |caps: &regex::Captures| {
-                // If the pattern captured a leading "key=" / "key:" label, keep it.
-                match caps.name("label") {
-                    Some(label) => format!("{}{}", label.as_str(), REDACTED),
-                    None => REDACTED.to_string(),
-                }
-            })
-            .into_owned();
-    }
-    out
-}
-
-fn secret_patterns() -> &'static [Regex] {
-    static PATTERNS: OnceLock<Vec<Regex>> = OnceLock::new();
-    PATTERNS.get_or_init(|| {
-        [
-            // key = value / key: value where the key name looks sensitive.
-            r#"(?i)(?P<label>\b(?:api[_-]?key|secret|token|password|passwd|pwd|access[_-]?key|client[_-]?secret)\b\s*[:=]\s*)['"]?[A-Za-z0-9/_+\-\.]{6,}['"]?"#,
-            // Authorization: Bearer <token>
-            r#"(?i)(?P<label>bearer\s+)[A-Za-z0-9._\-]{8,}"#,
-            // Provider token formats.
-            r#"AKIA[0-9A-Z]{16}"#,                                   // AWS access key id
-            r#"gh[pousr]_[A-Za-z0-9]{20,}"#,                          // GitHub tokens
-            r#"xox[baprs]-[A-Za-z0-9\-]{10,}"#,                       // Slack tokens
-            r#"eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+"#, // JWTs
-            // PEM private key blocks (whole block).
-            r#"(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----"#,
-        ]
-        .iter()
-        .map(|p| Regex::new(p).expect("valid secret regex"))
-        .collect()
-    })
-}
+pub use memorywhale_core::privacy::{
+    max_capture_bytes, redact, sanitize_capture, truncate_capture, DEFAULT_MAX_CAPTURE_BYTES,
+    REDACTED,
+};
 
 /// Finalize the current in-progress recording the moment this process's parent
 /// dies, instead of waiting for the dashboard's next-startup recovery.

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -2072,7 +2072,8 @@ mod tests {
     fn bounded_capture_marks_truncation_without_splitting_utf8() {
         assert_eq!(truncate_capture("short", 8), "short");
         let value = truncate_capture("ab🐋cd", 5);
-        assert_eq!(value, "ab\n[TRUNCATED: stored 2 of 8 bytes]");
+        assert!(value.len() <= 5);
+        assert!(value.is_char_boundary(value.len()));
     }
 
     #[test]

--- a/crates/mw-cli/tests/privacy.rs
+++ b/crates/mw-cli/tests/privacy.rs
@@ -2,16 +2,14 @@
 //!
 //! `redact()` has unit tests, and `remember()` (the bookmarks path) is covered
 //! in the lib test module. The gap this closes: a captured command's
-//! stdout/stderr flows through the `mw-remember` binary into the `command_runs`
-//! table — prove the scrub actually fires on that path, so a secret printed by
-//! a recorded command never lands raw in the DB. (`mw-run` shares the identical
-//! `redact()`-before-INSERT into `command_runs`.)
+//! stdout/stderr/notes/argv flow through the capture binaries into SQLite —
+//! prove the scrub fires before a secret lands raw in the DB.
 
 use rusqlite::Connection;
 use std::process::Command;
 
-// Hand-authored fake credentials — never real. One per shape `secret_patterns`
-// handles: an assignment, a GitHub token, and an AWS access-key id.
+// Hand-authored fake credentials — never real. One per shape the shared privacy
+// module handles: an assignment, a GitHub token, and an AWS access-key id.
 const SECRETS: [&str; 3] = [
     "hunter2secret",                  // password: <value>
     "ghp_0123456789abcdefghijABCDEF", // GitHub token
@@ -63,5 +61,47 @@ fn command_capture_stdout_stderr_is_redacted_in_db() {
         );
     }
 
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn command_capture_notes_and_arguments_are_redacted_in_db() {
+    let dir = std::env::temp_dir().join(format!("mw-privacy-args-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let secret = "hunter2secret";
+    let notes = format!("password: {secret}");
+    let argument = format!("--token={secret}");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_mw-remember"))
+        .env("MEMORYWHALE_DATA_DIR", &dir)
+        .args(["--notes", &notes, "--", "deploy", &argument])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "mw-remember failed: {out:?}");
+
+    let conn = Connection::open(dir.join("memorywhale.sqlite3")).unwrap();
+    let (argv_json, stored_notes): (String, String) = conn
+        .query_row(
+            "SELECT argv_json, notes FROM command_runs ORDER BY id DESC LIMIT 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    let stored_argument: String = conn
+        .query_row(
+            "SELECT value FROM command_arguments ORDER BY id DESC LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+
+    for stored in [&argv_json, &stored_notes, &stored_argument] {
+        assert!(stored.contains("[REDACTED]"), "not redacted: {stored}");
+        assert!(
+            !stored.contains(secret),
+            "raw secret landed in DB: {stored}"
+        );
+    }
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/docs/reference/privacy.md
+++ b/docs/reference/privacy.md
@@ -1,0 +1,53 @@
+# Capture privacy policy
+
+MemoryWhale applies the shared `memorywhale-core::privacy::sanitize_capture`
+policy before captured free text is written to SQLite. The policy redacts known
+secret shapes and bounds each stored text field to
+`MEMORYWHALE_MAX_CAPTURE_BYTES` (1 MiB by default). Set
+`MEMORYWHALE_NO_REDACT=1` only when raw capture is an intentional, local
+decision; it is an explicit opt-out, not a guarantee that other tools will not
+expose the data.
+
+## Write-path inventory
+
+| Adapter | Sanitized before write | Preserved as operational metadata |
+| --- | --- | --- |
+| `mw-remember` / `mw-run` | stdout, stderr, notes, command/argv representations, argument index values | cwd |
+| `mw` session capture | transcript and session notes | shell, cwd, transcript path, timestamps |
+| `mw-recover` / `mw-serve` recovery | recovered transcript | transcript path and timestamps |
+| `mw import` / `mw pull` | imported command runs, sessions, and lessons | cwd, filesystem paths, timestamps |
+| `mw-mcp remember` / `mw mark` | lesson text through `remember_as` | provenance fields |
+| Tauri command capture | stdout, stderr, notes, command/argv representations, derived concepts | cwd and exit status |
+| Tauri text import | title, content, summary, quotes, derived concepts | source type and timestamps |
+| `mw-screenshot` | notes | screenshot path, cwd, command-run ID |
+
+Command arguments and filesystem paths remain operational metadata with a
+documented limitation: a secret embedded in an executable path, cwd, or a
+non-recognized argument format may not be detected. Do not treat redaction as a
+security boundary.
+
+All derived summaries, quotes, concepts, fingerprints, and indexes in the
+covered adapters are created from the sanitized representation. Existing
+databases are not rewritten automatically; use an explicit backup and review
+plan before attempting historical cleanup.
+
+## Storage and retrieval
+
+Redaction occurs before SQLite writes, not only when rendering a dashboard or
+retrieval result. This prevents the raw value from entering the durable table,
+FTS indexes, or embedding input through the covered paths. SQLite file
+permissions remain part of the local trust boundary.
+
+## Review checklist for new adapters
+
+Before adding a write path:
+
+1. Apply `sanitize_capture` to every user- or process-provided text field.
+2. Derive summaries, quotes, concepts, fingerprints, and indexes from the
+   sanitized value.
+3. Decide explicitly whether paths and command metadata are operational values
+   that must remain replayable.
+4. Add a SQLite-facing test containing a fake secret and assert the raw value
+   is absent.
+5. Preserve the documented `MEMORYWHALE_NO_REDACT=1` opt-out unless a separate
+   architecture decision changes it.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -691,21 +691,29 @@ fn save_command_run(
     request: RememberCommandRequest,
 ) -> Result<CommandRun, AppError> {
     let argv = split_command_line(&request.command_line);
-    let command = argv
-        .first()
-        .cloned()
-        .unwrap_or_else(|| request.command_line.trim().to_string());
-    if command.is_empty() {
+    if argv.is_empty() && request.command_line.trim().is_empty() {
         return Err(AppError::Message(
             "command line cannot be empty".to_string(),
         ));
     }
 
-    let stdout = request.stdout.unwrap_or_default();
-    let stderr = request.stderr.unwrap_or_default();
-    let notes = request.notes.unwrap_or_default();
+    // Sanitize before deriving concepts or writing any text-bearing column.
+    // Keep cwd as operational metadata: changing it would make replay and
+    // navigation incorrect. Command/argv are sanitized representations.
+    let stored_command_line = memorywhale_core::privacy::sanitize_capture(&request.command_line);
+    let stored_argv: Vec<String> = argv
+        .iter()
+        .map(|value| memorywhale_core::privacy::sanitize_capture(value))
+        .collect();
+    let command = stored_argv
+        .first()
+        .cloned()
+        .unwrap_or_else(|| stored_command_line.trim().to_string());
+    let stdout = memorywhale_core::privacy::sanitize_capture(&request.stdout.unwrap_or_default());
+    let stderr = memorywhale_core::privacy::sanitize_capture(&request.stderr.unwrap_or_default());
+    let notes = memorywhale_core::privacy::sanitize_capture(&request.notes.unwrap_or_default());
     let created_at = Utc::now().to_rfc3339();
-    let argv_json = serde_json::to_string(&argv)
+    let argv_json = serde_json::to_string(&stored_argv)
         .map_err(|err| AppError::Message(format!("failed to encode argv: {err}")))?;
 
     let mut conn = state
@@ -731,7 +739,7 @@ fn save_command_run(
     )?;
     let run_id = tx.last_insert_rowid();
 
-    for (position, value) in argv.iter().enumerate() {
+    for (position, value) in stored_argv.iter().enumerate() {
         tx.execute(
             "
             INSERT INTO command_arguments (command_run_id, position, value)
@@ -741,10 +749,7 @@ fn save_command_run(
         )?;
     }
 
-    let combined = format!(
-        "{}\n{}\n{}\n{}",
-        request.command_line, stdout, stderr, notes
-    );
+    let combined = format!("{}\n{}\n{}\n{}", stored_command_line, stdout, stderr, notes);
     let command_node = format!("command:{run_id}");
     for concept in extract_keywords(&combined, 10) {
         tx.execute(
@@ -785,14 +790,22 @@ fn save_document(
     state: &tauri::State<AppState>,
     request: ImportRequest,
 ) -> Result<Document, AppError> {
+    // Sanitize and bound imported text before deriving summaries, quotes, or
+    // concepts. Otherwise a secret can be copied into several SQLite tables
+    // and into the retrieval index before any later redaction opportunity.
+    let content = memorywhale_core::privacy::sanitize_capture(&request.content);
     let title = request
         .title
+        .map(|value| memorywhale_core::privacy::sanitize_capture(&value))
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| infer_title(&request.content));
-    let summary = summarize(&request.content);
+        .unwrap_or_else(|| infer_title(&content));
+    let summary = memorywhale_core::privacy::sanitize_capture(&summarize(&content));
     let created_at = Utc::now().to_rfc3339();
-    let concepts = extract_keywords(&request.content, 12);
-    let quotes = extract_quotes(&request.content);
+    let concepts = extract_keywords(&content, 12);
+    let quotes: Vec<String> = extract_quotes(&content)
+        .into_iter()
+        .map(|quote| memorywhale_core::privacy::sanitize_capture(&quote))
+        .collect();
 
     let mut conn = state
         .db
@@ -804,13 +817,7 @@ fn save_document(
         INSERT INTO documents (title, source_type, content, summary, created_at)
         VALUES (?1, ?2, ?3, ?4, ?5)
         ",
-        params![
-            title,
-            request.source_type,
-            request.content,
-            summary,
-            created_at
-        ],
+        params![title, request.source_type, content, summary, created_at],
     )?;
     let document_id = tx.last_insert_rowid();
     tx.execute(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -691,7 +691,7 @@ fn save_command_run(
     request: RememberCommandRequest,
 ) -> Result<CommandRun, AppError> {
     let argv = split_command_line(&request.command_line);
-    if argv.is_empty() && request.command_line.trim().is_empty() {
+    if argv.is_empty() || request.command_line.trim().is_empty() {
         return Err(AppError::Message(
             "command line cannot be empty".to_string(),
         ));


### PR DESCRIPTION
Closes #157.

## What changed

- Added `memorywhale_core::privacy` as the shared redaction/truncation policy.
- CLI re-exports the shared policy for compatibility; duplicate regex/truncation implementation removed.
- Sanitized before SQLite writes across:
  - `mw-remember` and `mw-run` stdout, stderr, notes, argv representations, and argument rows;
  - interactive session notes and transcripts;
  - `mw-recover` and `mw-serve` orphan recovery;
  - `mw import` / `mw pull` command runs, sessions, and bookmarks;
  - Tauri command capture and text import, including derived summaries, quotes, and concepts;
  - screenshot notes.
- Added CLI flag-form secret redaction (`--token value` etc.) while retaining `MEMORYWHALE_NO_REDACT=1`.
- Derived fingerprints, concepts, summaries, quotes, FTS inputs, and stored byte counts use the sanitized representation on covered paths.
- Added `docs/reference/privacy.md` with the write-path inventory, operational metadata limitations, and adapter checklist.
- Added SQLite-facing privacy coverage for notes and command arguments.

## Policy boundary

CWDs, filesystem paths, shell names, timestamps, exit codes, provenance, and screenshot paths remain operational metadata where changing them would break replay/navigation or provenance. The documentation calls out that secrets embedded in those fields or unrecognized argument formats may not be detected. Existing databases are not rewritten automatically.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p memorywhale-core -p memorywhale-cli --all-targets -- -D warnings`
- `cargo test -p memorywhale-core -p memorywhale-cli`
- `cargo build --workspace`
- `bash scripts/check-doc-references.sh`
- `git diff --check`

All passed. Single-author commit; no co-authorship trailer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic privacy sanitization for captured commands, arguments, notes, transcripts, screenshots, and imported content.
  * Added redaction of common secrets and private keys, UTF-8-safe truncation, and configurable capture size limits.
  * Added an explicit opt-out for raw capture when required.

* **Bug Fixes**
  * Prevented sensitive values from being stored or used in summaries, concepts, quotes, and indexes.
  * Updated stored byte counts to reflect sanitized content.
  * Rejected empty command lines before storage.

* **Documentation**
  * Added privacy policy guidance covering sanitization, storage, limitations, and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->