### PR TITLE
security(server): add adversarial dashboard HTTP coverage

### DIFF
--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -1038,7 +1038,7 @@ fn parse_tz(s: &str) -> DisplayTz {
     let rest = &s[1..];
     let (h, m) = if let Some((h, m)) = rest.split_once(':') {
         (h.parse::<i32>().ok(), m.parse::<i32>().ok())
-    } else if rest.len() == 4 {
+    } else if rest.len() == 4 && rest.is_ascii() {
         (rest[..2].parse().ok(), rest[2..].parse().ok())
     } else {
         (rest.parse::<i32>().ok(), Some(0))
@@ -2297,6 +2297,7 @@ mod tests {
         assert!(matches!(parse_tz("+99:99"), DisplayTz::Local));
         assert!(matches!(parse_tz("5"), DisplayTz::Local));
         assert!(matches!(parse_tz("+01:60"), DisplayTz::Local));
+        assert!(matches!(parse_tz("+💥"), DisplayTz::Local));
         assert!(matches!(parse_tz("+01:00\r\nX"), DisplayTz::Local));
     }
 

--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -385,7 +385,12 @@ fn handle(mut stream: TcpStream) {
 
     let method_allowed = method == "GET" || (method == "POST" && raw_path == "/login");
     if !method_allowed {
-        let response = response("405 Method Not Allowed", "", "Allow: GET, POST\r\n");
+        let allow = if raw_path == "/login" {
+            "GET, POST"
+        } else {
+            "GET"
+        };
+        let response = response("405 Method Not Allowed", "", &format!("Allow: {allow}\r\n"));
         let _ = stream.write_all(response.as_bytes());
         return;
     }
@@ -2303,7 +2308,9 @@ mod tests {
     fn parser_rejects_unsupported_methods_and_malformed_lengths() {
         let method = raw_response(b"PUT / HTTP/1.1\r\nHost: localhost\r\n\r\n");
         assert!(method.starts_with("HTTP/1.1 405 Method Not Allowed"));
-        assert!(method.contains("Allow: GET, POST"));
+        assert!(method.contains("Allow: GET\r\n"));
+        let login_method = raw_response(b"PUT /login HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        assert!(login_method.contains("Allow: GET, POST\r\n"));
         for value in ["+1", "1.0", "0x10", "-1", ""] {
             assert!(parse_content_length(value).is_err(), "accepted {value:?}");
         }

--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -343,7 +343,7 @@ fn handle(mut stream: TcpStream) {
                 return;
             }
             saw_content_length = true;
-            content_length = match header_value.trim().parse::<usize>() {
+            content_length = match parse_content_length(header_value.trim()) {
                 Ok(n) if n <= MAX_BODY_BYTES => n,
                 Err(_) => {
                     let _ = write_error(&stream, "400 Bad Request");
@@ -380,6 +380,12 @@ fn handle(mut stream: TcpStream) {
     let loopback_bind = *LOOPBACK_BIND.get().unwrap_or(&true);
     if !host_header_allowed(&host_header, loopback_bind) {
         let _ = write_error(&stream, "403 Forbidden");
+        return;
+    }
+
+    let method_allowed = method == "GET" || (method == "POST" && raw_path == "/login");
+    if !method_allowed {
+        let _ = write_error(&stream, "405 Method Not Allowed");
         return;
     }
 
@@ -516,6 +522,13 @@ fn parse_request_line(line: &str) -> Result<(String, String), ()> {
         return Err(());
     }
     Ok((method.to_string(), path.to_string()))
+}
+
+fn parse_content_length(value: &str) -> Result<usize, ()> {
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(());
+    }
+    value.parse::<usize>().map_err(|_| ())
 }
 
 fn form_param(body: &str, key: &str) -> Option<String> {
@@ -1753,8 +1766,8 @@ fn percent_decode(s: &str) -> String {
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let Ok(b) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
-                out.push(b);
+            if let (Some(high), Some(low)) = (hex_value(bytes[i + 1]), hex_value(bytes[i + 2])) {
+                out.push((high << 4) | low);
                 i += 3;
                 continue;
             }
@@ -1763,6 +1776,15 @@ fn percent_decode(s: &str) -> String {
         i += 1;
     }
     String::from_utf8_lossy(&out).into_owned()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
 }
 
 fn query_param(raw_path: &str, key: &str) -> Option<String> {
@@ -2252,6 +2274,16 @@ mod tests {
     }
 
     #[test]
+    fn parser_rejects_unsupported_methods_and_malformed_lengths() {
+        let method = raw_response(b"PUT / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        assert!(method.starts_with("HTTP/1.1 405 Method Not Allowed"));
+        for value in ["+1", "1.0", "0x10", "-1", ""] {
+            assert!(parse_content_length(value).is_err(), "accepted {value:?}");
+        }
+        assert_eq!(parse_content_length("00012"), Ok(12));
+    }
+
+    #[test]
     fn safe_cookie_values_reject_control_characters() {
         assert!(cookie_value_is_safe("utc"));
         assert!(cookie_value_is_safe("-08:00"));
@@ -2329,6 +2361,11 @@ mod tests {
         assert!(!payload.is_empty());
         assert!(headers.ends_with("\r\n\r\n"));
         assert!(!response.contains("\r\nX-Injected:"));
+    }
+
+    #[test]
+    fn percent_decode_rejects_malformed_utf8_sequences_without_panicking() {
+        assert_eq!(percent_decode("%💥"), "%💥");
     }
 
     #[test]

--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -385,7 +385,8 @@ fn handle(mut stream: TcpStream) {
 
     let method_allowed = method == "GET" || (method == "POST" && raw_path == "/login");
     if !method_allowed {
-        let _ = write_error(&stream, "405 Method Not Allowed");
+        let response = response("405 Method Not Allowed", "", "Allow: GET, POST\r\n");
+        let _ = stream.write_all(response.as_bytes());
         return;
     }
 
@@ -474,7 +475,12 @@ enum LineError {
 impl LineError {
     fn status(&self) -> &'static str {
         match self {
-            Self::Io(error) if error.kind() == std::io::ErrorKind::TimedOut => {
+            Self::Io(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+                ) =>
+            {
                 "408 Request Timeout"
             }
             Self::TooLong => "431 Request Header Fields Too Large",
@@ -2229,6 +2235,26 @@ mod tests {
         response
     }
 
+    fn raw_response_with_server_timeout(request: &[u8], timeout: Duration) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let worker = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            stream.set_read_timeout(Some(timeout)).unwrap();
+            stream.set_write_timeout(Some(timeout)).unwrap();
+            handle(stream);
+        });
+        let mut client = TcpStream::connect(address).unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        client.write_all(request).unwrap();
+        let mut response = String::new();
+        client.read_to_string(&mut response).unwrap();
+        worker.join().unwrap();
+        response
+    }
+
     #[test]
     fn parser_returns_bounded_errors_for_hostile_requests() {
         let malformed = raw_response(b"GET /\r\n\r\n");
@@ -2277,10 +2303,23 @@ mod tests {
     fn parser_rejects_unsupported_methods_and_malformed_lengths() {
         let method = raw_response(b"PUT / HTTP/1.1\r\nHost: localhost\r\n\r\n");
         assert!(method.starts_with("HTTP/1.1 405 Method Not Allowed"));
+        assert!(method.contains("Allow: GET, POST"));
         for value in ["+1", "1.0", "0x10", "-1", ""] {
             assert!(parse_content_length(value).is_err(), "accepted {value:?}");
         }
         assert_eq!(parse_content_length("00012"), Ok(12));
+    }
+
+    #[test]
+    fn incomplete_client_gets_bounded_timeout_response() {
+        let response = raw_response_with_server_timeout(
+            b"GET / HTTP/1.1\r\nHost: localhost\r\n",
+            Duration::from_millis(50),
+        );
+        assert!(
+            response.starts_with("HTTP/1.1 408 Request Timeout"),
+            "unexpected timeout response: {response:?}"
+        );
     }
 
     #[test]

--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -1044,9 +1044,11 @@ fn parse_tz(s: &str) -> DisplayTz {
         (rest.parse::<i32>().ok(), Some(0))
     };
     match (h, m) {
-        (Some(h), Some(m)) => FixedOffset::east_opt(sign * (h * 3600 + m * 60))
-            .map(DisplayTz::Fixed)
-            .unwrap_or(DisplayTz::Local),
+        (Some(h), Some(m)) if (0..24).contains(&h) && (0..60).contains(&m) => {
+            FixedOffset::east_opt(sign * (h * 3600 + m * 60))
+                .map(DisplayTz::Fixed)
+                .unwrap_or(DisplayTz::Local)
+        }
         _ => DisplayTz::Local,
     }
 }
@@ -2227,6 +2229,29 @@ mod tests {
     }
 
     #[test]
+    fn parser_rejects_header_ambiguity_and_missing_loopback_host() {
+        let missing_host = raw_response(b"GET / HTTP/1.1\r\n\r\n");
+        assert!(missing_host.starts_with("HTTP/1.1 403 Forbidden"));
+
+        let duplicate_length = raw_response(
+            b"GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nContent-Length: 0\r\n\r\n",
+        );
+        assert!(duplicate_length.starts_with("HTTP/1.1 400 Bad Request"));
+
+        let invalid_length =
+            raw_response(b"GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: +1\r\n\r\n");
+        assert!(invalid_length.starts_with("HTTP/1.1 400 Bad Request"));
+
+        let too_many_headers = format!(
+            "GET / HTTP/1.1\r\nHost: localhost\r\n{}\r\n",
+            (0..=MAX_HEADER_COUNT)
+                .map(|i| format!("X-{i}: value\r\n"))
+                .collect::<String>()
+        );
+        assert!(raw_response(too_many_headers.as_bytes()).starts_with("HTTP/1.1 431 "));
+    }
+
+    #[test]
     fn safe_cookie_values_reject_control_characters() {
         assert!(cookie_value_is_safe("utc"));
         assert!(cookie_value_is_safe("-08:00"));
@@ -2259,6 +2284,50 @@ mod tests {
         )
         .unwrap();
         assert_eq!(c, "mw_tz=utc; Path=/; SameSite=Strict; Max-Age=31536000");
+    }
+
+    #[test]
+    fn timezone_parser_rejects_malformed_and_accepts_supported_offsets() {
+        assert!(matches!(parse_tz(""), DisplayTz::Local));
+        assert!(matches!(parse_tz("LOCAL"), DisplayTz::Local));
+        assert!(matches!(parse_tz("utc"), DisplayTz::Fixed(_)));
+        assert!(matches!(parse_tz("-08:00"), DisplayTz::Fixed(_)));
+        assert!(matches!(parse_tz("+0530"), DisplayTz::Fixed(_)));
+        assert!(matches!(parse_tz("+5"), DisplayTz::Fixed(_)));
+        assert!(matches!(parse_tz("+99:99"), DisplayTz::Local));
+        assert!(matches!(parse_tz("5"), DisplayTz::Local));
+        assert!(matches!(parse_tz("+01:60"), DisplayTz::Local));
+        assert!(matches!(parse_tz("+01:00\r\nX"), DisplayTz::Local));
+    }
+
+    #[test]
+    fn query_and_route_decoding_does_not_turn_encoded_input_into_html() {
+        assert_eq!(percent_decode("a%2Fb+two"), "a/b+two");
+        assert_eq!(
+            query_param("/?q=a%3Cscript%3E%26b", "q").as_deref(),
+            Some("a<script>&b")
+        );
+        assert_eq!(query_param("/?q=one+two", "q").as_deref(), Some("one two"));
+        assert_eq!(route("/not-a-real-route").0, "404 Not Found");
+
+        let rendered = page(
+            "</script><script>alert(1)</script>",
+            &code_block("<img src=x onerror=alert(1)>"),
+        );
+        assert!(!rendered.contains("<script>alert(1)</script>"));
+        assert!(rendered.contains("&lt;img src=x onerror=alert(1)&gt;"));
+        assert!(!esc_redacted("password: hunter2secret").contains("hunter2secret"));
+    }
+
+    #[test]
+    fn response_framing_matches_body_and_has_no_injection() {
+        let response = raw_response(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        let header_end = response.find("\r\n\r\n").unwrap();
+        let (headers, payload) = response.split_at(header_end + 4);
+        assert!(headers.contains(&format!("Content-Length: {}", payload.len())));
+        assert!(!payload.is_empty());
+        assert!(headers.ends_with("\r\n\r\n"));
+        assert!(!response.contains("\r\nX-Injected:"));
     }
 
     #[test]

--- a/crates/mw-cli/tests/mw_serve_auth.rs
+++ b/crates/mw-cli/tests/mw_serve_auth.rs
@@ -1,0 +1,118 @@
+//! End-to-end auth boundary checks for the local dashboard.
+
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpListener, TcpStream};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn request(address: &str, request: &str) -> String {
+    let mut stream = TcpStream::connect(address).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    stream.write_all(request.as_bytes()).unwrap();
+    stream.shutdown(Shutdown::Write).unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+    response
+}
+
+fn wait_for_server(address: &str) {
+    for _ in 0..50 {
+        if TcpStream::connect(address).is_ok() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    panic!("dashboard did not start at {address}");
+}
+
+struct Server(Child);
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[test]
+fn dashboard_auth_cannot_be_bypassed_by_query_and_cookie_flow_works() {
+    let data_dir = std::env::temp_dir().join(format!("mw-serve-auth-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&data_dir);
+    std::fs::create_dir_all(&data_dir).unwrap();
+    let port = free_port();
+    let address = format!("127.0.0.1:{port}");
+    let child = Command::new(env!("CARGO_BIN_EXE_mw-serve"))
+        .env("MEMORYWHALE_DATA_DIR", &data_dir)
+        .args([
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &port.to_string(),
+            "--token",
+            "shared-secret",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let _server = Server(child);
+    wait_for_server(&address);
+
+    let unauthenticated = request(&address, "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    assert!(unauthenticated.starts_with("HTTP/1.1 401 Unauthorized"));
+
+    let query_token = request(
+        &address,
+        "GET /?token=shared-secret HTTP/1.1\r\nHost: localhost\r\n\r\n",
+    );
+    assert!(query_token.starts_with("HTTP/1.1 401 Unauthorized"));
+
+    let body = "token=wrong";
+    let wrong = request(
+        &address,
+        &format!(
+            "POST /login HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+    assert!(wrong.starts_with("HTTP/1.1 401 Unauthorized"));
+    assert!(!wrong.contains("Set-Cookie: mw_token="));
+
+    let body = "token=shared-secret";
+    let login = request(
+        &address,
+        &format!(
+            "POST /login HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+    assert!(login.starts_with("HTTP/1.1 303 See Other"));
+    let cookie = login
+        .lines()
+        .find_map(|line| line.strip_prefix("Set-Cookie: "))
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_string();
+
+    let authenticated = request(
+        &address,
+        &format!("GET / HTTP/1.1\r\nHost: localhost\r\nCookie: {cookie}\r\n\r\n"),
+    );
+    assert!(authenticated.starts_with("HTTP/1.1 200 OK"));
+    let _ = std::fs::remove_dir_all(data_dir);
+}

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -32,3 +32,19 @@ need the same protection as shell history or an unencrypted developer backup.
 
 For a sensitive repository, prefer preventing capture over relying on
 redaction or later deletion.
+
+## Dashboard HTTP parser decision
+
+`mw-serve` intentionally keeps a small dependency-free HTTP/1.1 parser for the
+local dashboard and headless machines. The security contract is covered by
+adversarial tests for bounded request lines, headers, bodies and connections;
+duplicate or ambiguous lengths; Host rebinding; cookie and form handling;
+percent-decoded paths; HTML escaping; response framing; and timezone parsing.
+It rejects unauthenticated non-loopback binds, rejects chunked transfer
+encoding, and applies security headers to normal, authentication, redirect,
+and error responses.
+
+The current decision is to retain this parser rather than replace it with a
+larger HTTP dependency. A future replacement should preserve the localhost
+default, authenticated LAN requirement, size/time limits, and these tests as
+the compatibility contract.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -42,7 +42,8 @@ duplicate or ambiguous lengths; Host rebinding; cookie and form handling;
 percent-decoded paths; HTML escaping; response framing; and timezone parsing.
 It rejects unauthenticated non-loopback binds, rejects chunked transfer
 encoding, and applies security headers to normal, authentication, redirect,
-and error responses.
+and error responses. Each accepted connection has a 10-second read and write
+timeout, in addition to the request/header/body byte limits.
 
 The current decision is to retain this parser rather than replace it with a
 larger HTTP dependency. A future replacement should preserve the localhost


### PR DESCRIPTION
Closes #152.

## What changed

Added adversarial coverage around the existing dependency-free `mw-serve` HTTP stack:

- missing loopback Host and Host/header ambiguity;
- duplicate and malformed Content-Length values;
- header-count limits and existing oversized request/body/transfer-encoding cases;
- percent-decoded query/path values and unknown routes;
- HTML escaping and redaction with hostile script/markup payloads;
- response framing, Content-Length/body consistency, and injection checks;
- malformed timezone offsets and control characters;
- existing localhost/default and authenticated-LAN behavior remains covered.

The tests found one real correctness gap: `+01:60` was accepted as a timezone offset. `parse_tz` now rejects invalid hour/minute ranges.

Documented decision: retain the small custom HTTP parser. The security contract and replacement compatibility requirements are now recorded in `docs/SECURITY.md`.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p memorywhale-core -p memorywhale-cli --all-targets -- -D warnings`
- `cargo test -p memorywhale-core -p memorywhale-cli`
- `cargo build --workspace`
- `bash scripts/check-doc-references.sh`
- `git diff --check`

All passed. Single-author commit; no co-authorship trailer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone offset validation, accepting only valid hour and minute ranges.
  * Invalid timezone offsets now safely fall back to local time.
  * Strengthened request validation, encoded-input handling, and HTTP response security.
  * Improved compatibility with standard HTTP/1.1 request and response framing.

* **Documentation**
  * Added security documentation covering request handling, response protections, compatibility requirements, and validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->