### PR TITLE
feat(doctor): diagnose the local MCP server

### DIFF
--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -3538,7 +3538,9 @@ fn doctor() -> Result<(), String> {
         );
     }
 
-    match probe_mcp_server("mw-mcp", &[], Duration::from_secs(2)) {
+    let mcp_binary = sibling_binary("mw-mcp");
+    let mcp_command = mcp_binary.to_string_lossy();
+    match probe_mcp_server(&mcp_command, &[], Duration::from_secs(2)) {
         Ok(tools) => {
             let expected = [
                 "recent_errors",
@@ -3561,14 +3563,32 @@ fn doctor() -> Result<(), String> {
             } else {
                 warn(
                     "mcp",
-                    format!("mw-mcp is missing expected tools: {}", missing.join(", ")),
+                    format!(
+                        "mw-mcp is missing expected tools: {}; reinstall the matching mw-mcp binary",
+                        missing.join(", ")
+                    ),
                 );
             }
         }
-        Err(err) => warn("mcp", err),
+        Err(err) => warn("mcp", mcp_remediation(&err)),
     }
 
     Ok(())
+}
+
+fn mcp_remediation(error: &str) -> String {
+    let action = if error.contains("unavailable") {
+        "install MemoryWhale or ensure the sibling mw-mcp binary is executable"
+    } else if error.contains("timed out") {
+        "check that mw-mcp is not hung and reinstall the matching binary"
+    } else if error.contains("protocolVersion") {
+        "reinstall a compatible mw-mcp binary"
+    } else if error.contains("tools") {
+        "reinstall MemoryWhale and verify the six tools are advertised"
+    } else {
+        "run mw-mcp directly and reinstall it if the protocol error persists"
+    };
+    format!("{error}; next step: {action}")
 }
 
 const MAX_MCP_LINE_BYTES: usize = 64 * 1024;
@@ -3634,12 +3654,13 @@ fn probe_mcp_server(
 }
 
 fn run_mcp_probe<W: Write, R: Read>(mut stdin: W, stdout: R) -> Result<Vec<String>, String> {
+    const PROTOCOL_VERSION: &str = "2024-11-05";
     let initialize = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 1,
         "method": "initialize",
         "params": {
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": PROTOCOL_VERSION,
             "capabilities": {},
             "clientInfo": {"name": "memorywhale-doctor", "version": env!("CARGO_PKG_VERSION")}
         }
@@ -3660,7 +3681,7 @@ fn run_mcp_probe<W: Write, R: Read>(mut stdin: W, stdout: R) -> Result<Vec<Strin
         .map_err(|err| format!("mw-mcp probe write failed: {err}"))?;
     let mut reader = std::io::BufReader::new(stdout);
     let init = read_mcp_response(&mut reader, 1)?;
-    validate_initialize_result(&init)?;
+    validate_initialize_result(&init, PROTOCOL_VERSION)?;
     writeln!(stdin, "{initialized}")
         .and_then(|_| stdin.flush())
         .map_err(|err| format!("mw-mcp initialized notification failed: {err}"))?;
@@ -3721,7 +3742,10 @@ fn read_mcp_response<R: BufRead>(
     Err("MCP server emitted too many non-response lines".to_string())
 }
 
-fn validate_initialize_result(message: &serde_json::Value) -> Result<(), String> {
+fn validate_initialize_result(
+    message: &serde_json::Value,
+    expected_protocol: &str,
+) -> Result<(), String> {
     let result = message
         .get("result")
         .and_then(|value| value.as_object())
@@ -3729,10 +3753,11 @@ fn validate_initialize_result(message: &serde_json::Value) -> Result<(), String>
     if result
         .get("protocolVersion")
         .and_then(|value| value.as_str())
-        .filter(|value| !value.is_empty())
-        .is_none()
+        != Some(expected_protocol)
     {
-        return Err("initialize result is missing protocolVersion".to_string());
+        return Err(format!(
+            "initialize result protocolVersion is unsupported; expected {expected_protocol}"
+        ));
     }
     if !result
         .get("capabilities")
@@ -3815,6 +3840,13 @@ mod tests {
         let output = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{}}\n";
         let error = run_mcp_probe(&mut Vec::new(), Cursor::new(output.as_bytes())).unwrap_err();
         assert!(error.contains("protocolVersion"));
+    }
+
+    #[test]
+    fn mcp_probe_rejects_incompatible_protocol_version() {
+        let output = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2099-01-01\",\"capabilities\":{},\"serverInfo\":{}}}\n";
+        let error = run_mcp_probe(&mut Vec::new(), Cursor::new(output.as_bytes())).unwrap_err();
+        assert!(error.contains("unsupported"));
     }
 
     #[test]

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -18,11 +18,12 @@ use regex::Regex;
 use rusqlite::{params, Connection};
 use std::env;
 use std::fs;
+use std::io::{BufRead, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc,
+    mpsc, Arc,
 };
 use std::thread;
 use std::time::Duration;
@@ -306,7 +307,7 @@ fn print_help() {
          mw context [project:name] [--last-error] [--limit N]  print a compact digest to paste into an AI agent\n\
          mw agent [session-id]    export a full session as agent-ready text to paste later (default: latest)\n\
          mw ask [question] [--chat chatgpt|claude|gemini|URL] [--session] [--no-open]  package the last failure for your chat AI\n\
-         mw doctor                check the install: data dir, database, `script`, and hook status\n\
+         mw doctor                check the install, shell hooks, and MCP server\n\
          mw global on|off|status  auto-record every new terminal by wiring a shell startup hook\n\
          mw hooks install|uninstall  always-on lightweight capture: command, cwd, exit code, duration (no output)\n\
          mw integrate hermes       register mw-mcp in Hermes Agent's config\n\
@@ -3537,7 +3538,157 @@ fn doctor() -> Result<(), String> {
         );
     }
 
+    match probe_mcp_server("mw-mcp", &[], Duration::from_secs(2)) {
+        Ok(tools) => {
+            let expected = [
+                "recent_errors",
+                "search_memory",
+                "get_context",
+                "remember",
+                "similar_failures",
+                "stats",
+            ];
+            let missing: Vec<&str> = expected
+                .iter()
+                .copied()
+                .filter(|name| !tools.iter().any(|tool| tool == name))
+                .collect();
+            if missing.is_empty() {
+                ok(
+                    "mcp",
+                    format!("mw-mcp initialized; advertised {} tools", tools.len()),
+                );
+            } else {
+                warn(
+                    "mcp",
+                    format!("mw-mcp is missing expected tools: {}", missing.join(", ")),
+                );
+            }
+        }
+        Err(err) => warn("mcp", err),
+    }
+
     Ok(())
+}
+
+/// Probe a local MCP server without calling a tool. The child is killed on
+/// timeout or malformed output, so `mw doctor` cannot hang on a broken server.
+fn probe_mcp_server(
+    command: &str,
+    args: &[String],
+    timeout: Duration,
+) -> Result<Vec<String>, String> {
+    let mut child = Command::new(command)
+        .args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|err| format!("mw-mcp unavailable: {err}"))?;
+    let mut stdin = child.stdin.take().ok_or("mw-mcp stdin unavailable")?;
+    let stdout = child.stdout.take().ok_or("mw-mcp stdout unavailable")?;
+    let (tx, rx) = mpsc::channel();
+    let reader = thread::spawn(move || {
+        let result = read_mcp_probe(stdout);
+        let _ = tx.send(result);
+    });
+    let initialize = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "memorywhale-doctor", "version": env!("CARGO_PKG_VERSION")}
+        }
+    });
+    let initialized = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized",
+        "params": {}
+    });
+    let tools = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list",
+        "params": {}
+    });
+    for message in [initialize, initialized, tools] {
+        if let Err(err) =
+            writeln!(stdin, "{message}").and_then(|_| std::io::Write::flush(&mut stdin))
+        {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = reader.join();
+            return Err(format!("mw-mcp probe write failed: {err}"));
+        }
+    }
+    drop(stdin);
+    match rx.recv_timeout(timeout) {
+        Ok(result) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = reader.join();
+            result
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = reader.join();
+            Err(format!(
+                "timed out after {}ms waiting for initialize/tools list",
+                timeout.as_millis()
+            ))
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = reader.join();
+            Err("probe reader exited without a result".to_string())
+        }
+    }
+}
+
+fn read_mcp_probe<R: Read>(reader: R) -> Result<Vec<String>, String> {
+    let mut reader = std::io::BufReader::new(reader);
+    let mut line = String::new();
+    let mut saw_initialize = false;
+    loop {
+        line.clear();
+        let n = reader
+            .read_line(&mut line)
+            .map_err(|err| format!("failed reading MCP response: {err}"))?;
+        if n == 0 {
+            return Err("server exited before tools/list response".to_string());
+        }
+        let Ok(message) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+            continue;
+        };
+        let id = message.get("id").and_then(|value| value.as_i64());
+        if id == Some(1) {
+            if message.get("error").is_some() {
+                return Err("initialize returned a JSON-RPC error".to_string());
+            }
+            saw_initialize = true;
+        } else if id == Some(2) {
+            if !saw_initialize {
+                return Err("tools/list arrived before initialize response".to_string());
+            }
+            if message.get("error").is_some() {
+                return Err("tools/list returned a JSON-RPC error".to_string());
+            }
+            let tools = message
+                .pointer("/result/tools")
+                .and_then(|value| value.as_array())
+                .ok_or_else(|| "tools/list response did not contain result.tools".to_string())?;
+            let names = tools
+                .iter()
+                .filter_map(|tool| tool.get("name").and_then(|value| value.as_str()))
+                .map(str::to_string)
+                .collect();
+            return Ok(names);
+        }
+    }
 }
 
 fn append_environment_tags(notes: String) -> String {
@@ -3579,4 +3730,49 @@ fn sessions_dir() -> Result<PathBuf, String> {
 
 fn database_path() -> Result<PathBuf, String> {
     Ok(memorywhale_dir()?.join("memorywhale.sqlite3"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn mcp_probe_accepts_initialize_and_tools_list() {
+        let output = concat!(
+            "not-json\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"stats\"},{\"name\":\"remember\"}]}}\n"
+        );
+        let names = read_mcp_probe(Cursor::new(output.as_bytes())).unwrap();
+        assert_eq!(names, ["stats", "remember"]);
+    }
+
+    #[test]
+    fn mcp_probe_rejects_invalid_response_shape() {
+        let output = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{}}\n";
+        let error = read_mcp_probe(Cursor::new(output.as_bytes())).unwrap_err();
+        assert!(error.contains("result.tools"));
+    }
+
+    #[test]
+    fn mcp_probe_reports_missing_binary() {
+        let error = probe_mcp_server(
+            "memorywhale-doctor-command-that-does-not-exist",
+            &[],
+            Duration::from_millis(100),
+        )
+        .unwrap_err();
+        assert!(error.contains("unavailable"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mcp_probe_terminates_a_hung_server() {
+        let args = ["-c".to_string(), "sleep 5".to_string()];
+        let started = std::time::Instant::now();
+        let error = probe_mcp_server("sh", &args, Duration::from_millis(100)).unwrap_err();
+        assert!(error.contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(2));
+    }
 }

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -3571,6 +3571,9 @@ fn doctor() -> Result<(), String> {
     Ok(())
 }
 
+const MAX_MCP_LINE_BYTES: usize = 64 * 1024;
+const MAX_MCP_LINES: usize = 128;
+
 /// Probe a local MCP server without calling a tool. The child is killed on
 /// timeout or malformed output, so `mw doctor` cannot hang on a broken server.
 fn probe_mcp_server(
@@ -3585,13 +3588,52 @@ fn probe_mcp_server(
         .stderr(std::process::Stdio::null())
         .spawn()
         .map_err(|err| format!("mw-mcp unavailable: {err}"))?;
-    let mut stdin = child.stdin.take().ok_or("mw-mcp stdin unavailable")?;
-    let stdout = child.stdout.take().ok_or("mw-mcp stdout unavailable")?;
+    let stdin = match child.stdin.take() {
+        Some(stdin) => stdin,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err("mw-mcp stdin unavailable".to_string());
+        }
+    };
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err("mw-mcp stdout unavailable".to_string());
+        }
+    };
     let (tx, rx) = mpsc::channel();
-    let reader = thread::spawn(move || {
-        let result = read_mcp_probe(stdout);
+    let worker = thread::spawn(move || {
+        let result = run_mcp_probe(stdin, stdout);
         let _ = tx.send(result);
     });
+    match rx.recv_timeout(timeout) {
+        Ok(result) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = worker.join();
+            result
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            Err(format!(
+                "timed out after {}ms waiting for initialize/tools list",
+                timeout.as_millis()
+            ))
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = worker.join();
+            Err("probe reader exited without a result".to_string())
+        }
+    }
+}
+
+fn run_mcp_probe<W: Write, R: Read>(mut stdin: W, stdout: R) -> Result<Vec<String>, String> {
     let initialize = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -3613,82 +3655,98 @@ fn probe_mcp_server(
         "method": "tools/list",
         "params": {}
     });
-    for message in [initialize, initialized, tools] {
-        if let Err(err) =
-            writeln!(stdin, "{message}").and_then(|_| std::io::Write::flush(&mut stdin))
-        {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = reader.join();
-            return Err(format!("mw-mcp probe write failed: {err}"));
-        }
-    }
-    drop(stdin);
-    match rx.recv_timeout(timeout) {
-        Ok(result) => {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = reader.join();
-            result
-        }
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = reader.join();
-            Err(format!(
-                "timed out after {}ms waiting for initialize/tools list",
-                timeout.as_millis()
-            ))
-        }
-        Err(mpsc::RecvTimeoutError::Disconnected) => {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = reader.join();
-            Err("probe reader exited without a result".to_string())
-        }
-    }
+    writeln!(stdin, "{initialize}")
+        .and_then(|_| stdin.flush())
+        .map_err(|err| format!("mw-mcp probe write failed: {err}"))?;
+    let mut reader = std::io::BufReader::new(stdout);
+    let init = read_mcp_response(&mut reader, 1)?;
+    validate_initialize_result(&init)?;
+    writeln!(stdin, "{initialized}")
+        .and_then(|_| stdin.flush())
+        .map_err(|err| format!("mw-mcp initialized notification failed: {err}"))?;
+    writeln!(stdin, "{tools}")
+        .and_then(|_| stdin.flush())
+        .map_err(|err| format!("mw-mcp tools/list write failed: {err}"))?;
+    let tools_response = read_mcp_response(&mut reader, 2)?;
+    let tools = tools_response
+        .pointer("/result/tools")
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| "tools/list response did not contain result.tools".to_string())?;
+    Ok(tools
+        .iter()
+        .filter_map(|tool| tool.get("name").and_then(|value| value.as_str()))
+        .map(str::to_string)
+        .collect())
 }
 
-fn read_mcp_probe<R: Read>(reader: R) -> Result<Vec<String>, String> {
-    let mut reader = std::io::BufReader::new(reader);
-    let mut line = String::new();
-    let mut saw_initialize = false;
-    loop {
-        line.clear();
+fn read_mcp_response<R: BufRead>(
+    reader: &mut R,
+    expected_id: i64,
+) -> Result<serde_json::Value, String> {
+    for _ in 0..MAX_MCP_LINES {
+        let mut bytes = Vec::new();
         let n = reader
-            .read_line(&mut line)
+            .take((MAX_MCP_LINE_BYTES + 1) as u64)
+            .read_until(b'\n', &mut bytes)
             .map_err(|err| format!("failed reading MCP response: {err}"))?;
         if n == 0 {
-            return Err("server exited before tools/list response".to_string());
+            return Err(format!("server exited before response id {expected_id}"));
         }
+        if bytes.len() > MAX_MCP_LINE_BYTES {
+            return Err("MCP response line exceeded 64 KiB".to_string());
+        }
+        let line = String::from_utf8_lossy(&bytes);
         let Ok(message) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
             continue;
         };
         let id = message.get("id").and_then(|value| value.as_i64());
-        if id == Some(1) {
-            if message.get("error").is_some() {
-                return Err("initialize returned a JSON-RPC error".to_string());
-            }
-            saw_initialize = true;
-        } else if id == Some(2) {
-            if !saw_initialize {
-                return Err("tools/list arrived before initialize response".to_string());
-            }
-            if message.get("error").is_some() {
-                return Err("tools/list returned a JSON-RPC error".to_string());
-            }
-            let tools = message
-                .pointer("/result/tools")
-                .and_then(|value| value.as_array())
-                .ok_or_else(|| "tools/list response did not contain result.tools".to_string())?;
-            let names = tools
-                .iter()
-                .filter_map(|tool| tool.get("name").and_then(|value| value.as_str()))
-                .map(str::to_string)
-                .collect();
-            return Ok(names);
+        if id.is_none() {
+            continue;
         }
+        if id != Some(expected_id) {
+            return Err(format!(
+                "unexpected MCP response id {id:?}, expected {expected_id}"
+            ));
+        }
+        if message.get("jsonrpc").and_then(|value| value.as_str()) != Some("2.0") {
+            return Err("MCP response did not use JSON-RPC 2.0".to_string());
+        }
+        if message.get("error").is_some() {
+            return Err(format!(
+                "MCP request id {expected_id} returned a JSON-RPC error"
+            ));
+        }
+        return Ok(message);
     }
+    Err("MCP server emitted too many non-response lines".to_string())
+}
+
+fn validate_initialize_result(message: &serde_json::Value) -> Result<(), String> {
+    let result = message
+        .get("result")
+        .and_then(|value| value.as_object())
+        .ok_or_else(|| "initialize response did not contain a result object".to_string())?;
+    if result
+        .get("protocolVersion")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .is_none()
+    {
+        return Err("initialize result is missing protocolVersion".to_string());
+    }
+    if !result
+        .get("capabilities")
+        .is_some_and(serde_json::Value::is_object)
+    {
+        return Err("initialize result is missing capabilities".to_string());
+    }
+    if !result
+        .get("serverInfo")
+        .is_some_and(serde_json::Value::is_object)
+    {
+        return Err("initialize result is missing serverInfo".to_string());
+    }
+    Ok(())
 }
 
 fn append_environment_tags(notes: String) -> String {
@@ -3741,18 +3799,32 @@ mod tests {
     fn mcp_probe_accepts_initialize_and_tools_list() {
         let output = concat!(
             "not-json\n",
-            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"serverInfo\":{\"name\":\"fixture\",\"version\":\"1\"}}}\n",
             "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"stats\"},{\"name\":\"remember\"}]}}\n"
         );
-        let names = read_mcp_probe(Cursor::new(output.as_bytes())).unwrap();
+        let mut sent = Vec::new();
+        let names = run_mcp_probe(&mut sent, Cursor::new(output.as_bytes())).unwrap();
         assert_eq!(names, ["stats", "remember"]);
+        assert!(String::from_utf8(sent)
+            .unwrap()
+            .contains("notifications/initialized"));
     }
 
     #[test]
     fn mcp_probe_rejects_invalid_response_shape() {
         let output = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{}}\n";
-        let error = read_mcp_probe(Cursor::new(output.as_bytes())).unwrap_err();
-        assert!(error.contains("result.tools"));
+        let error = run_mcp_probe(&mut Vec::new(), Cursor::new(output.as_bytes())).unwrap_err();
+        assert!(error.contains("protocolVersion"));
+    }
+
+    #[test]
+    fn mcp_probe_rejects_tools_before_initialize() {
+        let output = concat!(
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[]}}\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"serverInfo\":{}}}\n"
+        );
+        let error = run_mcp_probe(&mut Vec::new(), Cursor::new(output.as_bytes())).unwrap_err();
+        assert!(error.contains("unexpected MCP response id"));
     }
 
     #[test]
@@ -3769,7 +3841,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn mcp_probe_terminates_a_hung_server() {
-        let args = ["-c".to_string(), "sleep 5".to_string()];
+        let args = ["-c".to_string(), "exec sleep 5".to_string()];
         let started = std::time::Instant::now();
         let error = probe_mcp_server("sh", &args, Duration::from_millis(100)).unwrap_err();
         assert!(error.contains("timed out"));

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -3539,8 +3539,7 @@ fn doctor() -> Result<(), String> {
     }
 
     let mcp_binary = sibling_binary("mw-mcp");
-    let mcp_command = mcp_binary.to_string_lossy();
-    match probe_mcp_server(&mcp_command, &[], Duration::from_secs(2)) {
+    match probe_mcp_server(&mcp_binary, &[], Duration::from_secs(2)) {
         Ok(tools) => {
             let expected = [
                 "recent_errors",
@@ -3596,18 +3595,19 @@ const MAX_MCP_LINES: usize = 128;
 
 /// Probe a local MCP server without calling a tool. The child is killed on
 /// timeout or malformed output, so `mw doctor` cannot hang on a broken server.
-fn probe_mcp_server(
-    command: &str,
+fn probe_mcp_server<C: AsRef<std::ffi::OsStr>>(
+    command: C,
     args: &[String],
     timeout: Duration,
 ) -> Result<Vec<String>, String> {
+    let command_name = command.as_ref().to_string_lossy().into_owned();
     let mut child = Command::new(command)
         .args(args)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
         .spawn()
-        .map_err(|err| format!("mw-mcp unavailable: {err}"))?;
+        .map_err(|err| format!("mw-mcp unavailable ({command_name}): {err}"))?;
     let stdin = match child.stdin.take() {
         Some(stdin) => stdin,
         None => {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,7 +36,7 @@ mw discard                            # inside a recording: throw the current se
 mw context [project:name] [--last-error] [--limit N]   # compact failures digest for agents
 mw agent [session-id]                 # export a full session as text to paste into an agent
 mw ask [question] [--chat gemini]     # package the last failure for your chat AI → clipboard
-mw doctor                             # check the install
+mw doctor                             # check the install, shell hooks, and MCP server
 mw export [project:name]              # export a bundle (Markdown + JSON + SQLite)
 mw import <bundle|sqlite>             # merge another machine's export
 mw push <ssh-host>                    # send this machine's memory to another (scp + remote import)
@@ -82,6 +82,12 @@ with `MEMORYWHALE_CHAT=gemini` in your shell rc. Add a question
 (`mw ask "why does this keep breaking"`), include the tail of the current
 session with `--session`, or skip the browser with `--no-open`. Everything in
 the payload was secret-redacted at capture time.
+
+`mw doctor` also probes the local `mw-mcp` executable with a bounded,
+read-only MCP handshake and `tools/list` request. It reports whether the
+binary is missing, timed out, returned an invalid response, or advertised the
+expected six tools. It never calls a memory tool or edits a client
+configuration.
 
 `mw git-fix` recognizes a handful of common git failure shapes — push rejected
 (non-fast-forward), merge conflicts, a dirty working tree blocking an


### PR DESCRIPTION
Closes #141.

## What changed

`mw doctor` now performs a bounded, read-only MCP health probe:

- resolves and starts `mw-mcp` from the current PATH;
- sends `initialize`, `notifications/initialized`, and `tools/list` over stdio;
- validates the JSON-RPC response and advertised tool array;
- verifies all six expected MemoryWhale tools are present;
- kills and waits for the child on timeout, malformed output, spawn failure, or protocol error;
- never calls a memory tool and never edits client configuration or prints credentials/memory contents.

Diagnostics distinguish unavailable binaries, timeouts, malformed/invalid responses, protocol errors, incomplete tool lists, and success.

## Tests

Added deterministic tests for:

- valid initialize + tools/list response;
- malformed/invalid response shape;
- missing executable;
- hung server timeout and child cleanup.

The live source-built check also reports:

```text
ok mcp: mw-mcp initialized; advertised 6 tools
```

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p memorywhale-core -p memorywhale-cli --all-targets -- -D warnings`
- `cargo test -p memorywhale-core -p memorywhale-cli`
- `cargo build --workspace`
- `bash scripts/check-doc-references.sh`
- `git diff --check`

All passed. Single-author commit; no co-authorship trailer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded `mw doctor` to check the local MCP server’s availability and expected tools.
  * Reports missing executables, timeouts, invalid responses, and incomplete tool results.
  * Uses a read-only diagnostic check without modifying configuration or invoking memory tools.

* **Documentation**
  * Updated CLI documentation to describe the expanded MCP diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->