### PR TITLE
feat(pullfrog): archive sanitized workflow metadata in MemoryWhale

### DIFF
--- a/.github/workflows/pullfrog-memory.yml
+++ b/.github/workflows/pullfrog-memory.yml
@@ -1,0 +1,85 @@
+name: Archive Pullfrog memory
+
+on:
+  workflow_run:
+    workflows: ["Pullfrog"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  archive:
+    name: Archive sanitized Pullfrog metadata
+    runs-on: ubuntu-latest
+    steps:
+      # workflow_run jobs use the trusted default branch. Do not check out or
+      # execute code from the Pullfrog PR that triggered the completed run.
+      - name: Check out the default branch
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build MemoryWhale capture tools
+        run: cargo build --locked --release -p memorywhale-cli --bin mw --bin mw-remember
+
+      - name: Capture an allowlisted Pullfrog event summary
+        env:
+          EVENT_PATH: ${{ github.event_path }}
+          MEMORYWHALE_DATA_DIR: ${{ runner.temp }}/memorywhale
+        run: |
+          set -euo pipefail
+          run_id="$(jq -r '.workflow_run.id // empty' "$EVENT_PATH")"
+          run_url="$(jq -r '.workflow_run.html_url // empty' "$EVENT_PATH")"
+          workflow="$(jq -r '.workflow_run.name // empty' "$EVENT_PATH")"
+          event_name="$(jq -r '.workflow_run.event // empty' "$EVENT_PATH")"
+          status="$(jq -r '.workflow_run.status // empty' "$EVENT_PATH")"
+          conclusion="$(jq -r '.workflow_run.conclusion // empty' "$EVENT_PATH")"
+          branch="$(jq -r '.workflow_run.head_branch // empty' "$EVENT_PATH")"
+          sha="$(jq -r '.workflow_run.head_sha // empty' "$EVENT_PATH")"
+          actor="$(jq -r '.workflow_run.actor.login // empty' "$EVENT_PATH")"
+          pr_number="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$EVENT_PATH")"
+
+          case "$conclusion" in
+            success|neutral|skipped) exit_code=0 ;;
+            *) exit_code=1 ;;
+          esac
+
+          # Deliberately capture metadata only. Do not include prompts, logs,
+          # diffs, comments, environment variables, or secrets.
+          summary="$(jq -cn \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg run_id "$run_id" \
+            --arg run_url "$run_url" \
+            --arg workflow "$workflow" \
+            --arg event "$event_name" \
+            --arg status "$status" \
+            --arg conclusion "$conclusion" \
+            --arg branch "$branch" \
+            --arg sha "$sha" \
+            --arg actor "$actor" \
+            --arg pr_number "$pr_number" \
+            '{repository:$repository, workflow_run_id:$run_id, workflow_url:$run_url, workflow:$workflow, event:$event, status:$status, conclusion:$conclusion, head_branch:$branch, head_sha:$sha, actor:$actor, pull_request:$pr_number}')"
+
+          MEMORYWHALE_DATA_DIR="$MEMORYWHALE_DATA_DIR" \
+            target/release/mw-remember \
+            --cwd "$GITHUB_WORKSPACE" \
+            --exit-code "$exit_code" \
+            --stdout "$summary" \
+            --notes "project:pullfrog source:github-actions workflow:Pullfrog run_id:$run_id" \
+            -- pullfrog-workflow-run "$run_id"
+
+          MEMORYWHALE_DATA_DIR="$MEMORYWHALE_DATA_DIR" \
+            target/release/mw export project:pullfrog
+
+      - name: Upload the MemoryWhale artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: pullfrog-memory-${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/memorywhale/exports
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/pullfrog-memory.yml
+++ b/.github/workflows/pullfrog-memory.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   archive:
@@ -45,12 +44,6 @@ jobs:
           sha="$(jq -r '.workflow_run.head_sha // empty' "$EVENT_PATH")"
           actor="$(jq -r '.workflow_run.actor.login // empty' "$EVENT_PATH")"
           pr_number="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$EVENT_PATH")"
-          if [[ -z "$pr_number" && -n "$sha" ]]; then
-            pr_number="$(gh api \
-              --header 'Accept: application/vnd.github+json' \
-              "/repos/$GITHUB_REPOSITORY/commits/$sha/pulls" \
-              --jq '.[0].number // empty' 2>/dev/null || true)"
-          fi
 
           case "$conclusion" in
             success|neutral|skipped) exit_code=0 ;;

--- a/.github/workflows/pullfrog-memory.yml
+++ b/.github/workflows/pullfrog-memory.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   archive:
@@ -30,6 +31,7 @@ jobs:
       - name: Capture an allowlisted Pullfrog event summary
         env:
           EVENT_PATH: ${{ github.event_path }}
+          GH_TOKEN: ${{ github.token }}
           MEMORYWHALE_DATA_DIR: ${{ runner.temp }}/memorywhale
         run: |
           set -euo pipefail
@@ -43,6 +45,12 @@ jobs:
           sha="$(jq -r '.workflow_run.head_sha // empty' "$EVENT_PATH")"
           actor="$(jq -r '.workflow_run.actor.login // empty' "$EVENT_PATH")"
           pr_number="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$EVENT_PATH")"
+          if [[ -z "$pr_number" && -n "$sha" ]]; then
+            pr_number="$(gh api \
+              --header 'Accept: application/vnd.github+json' \
+              "/repos/$GITHUB_REPOSITORY/commits/$sha/pulls" \
+              --jq '.[0].number // empty' 2>/dev/null || true)"
+          fi
 
           case "$conclusion" in
             success|neutral|skipped) exit_code=0 ;;

--- a/integrations/pullfrog/README.md
+++ b/integrations/pullfrog/README.md
@@ -191,6 +191,38 @@ For a review-only Pullfrog run, configure review instructions such as:
 
 This prompt does not grant Pullfrog access to MemoryWhale's local database.
 
+## Pullfrog event archive
+
+The repository also contains `.github/workflows/pullfrog-memory.yml`. After a
+workflow named `Pullfrog` completes, it records an allowlisted metadata summary
+in a temporary MemoryWhale store and uploads a 14-day GitHub Actions artifact.
+The captured fields are limited to repository, workflow/run ID and URL, event,
+status/conclusion, branch, commit SHA, actor, and an associated PR number.
+
+It deliberately does **not** capture Pullfrog prompts, review bodies, comments,
+diffs, logs, environment variables, or credentials. The workflow checks out the
+trusted default branch rather than executing code from the completed PR.
+
+To bring an artifact into a local MemoryWhale store:
+
+1. Download and extract the `pullfrog-memory-<run-id>` artifact from GitHub.
+2. Import the extracted bundle:
+
+   ```bash
+   mw import /path/to/downloaded/memorywhale/exports/pullfrog-*
+   ```
+
+3. Search the imported event:
+
+   ```bash
+   mw search "project:pullfrog"
+   ```
+
+Artifacts are snapshots, not synchronization. They do not automatically update
+the developer's local SQLite database, and each artifact has a 14-day retention
+period. Review GitHub artifact access and retention policies before treating the
+archive as long-term history.
+
 ## Automatic capture
 
 Pullfrog does not automatically capture local MemoryWhale terminal sessions.

--- a/integrations/pullfrog/README.md
+++ b/integrations/pullfrog/README.md
@@ -197,8 +197,8 @@ The repository also contains `.github/workflows/pullfrog-memory.yml`. After a
 workflow named `Pullfrog` completes, it records an allowlisted metadata summary
 in a temporary MemoryWhale store and uploads a 14-day GitHub Actions artifact.
 The captured event summary is limited to repository, workflow/run ID and URL,
-event, status/conclusion, branch, commit SHA, actor, and a best-effort
-associated PR number. The MemoryWhale command record also necessarily contains
+event, status/conclusion, branch, commit SHA, actor, and a PR number only when
+Pullfrog's workflow event explicitly provides one. The MemoryWhale command record also necessarily contains
 the fixed command identifier and run ID in argv, the temporary runner cwd,
 exit code, creation timestamp, and automatic `os:`/`runtime:` capture tags.
 
@@ -222,9 +222,9 @@ To bring an artifact into a local MemoryWhale store:
    ```
 
 The workflow-run event often has no direct PR association because Pullfrog
-dispatches its workflow on the default branch. The workflow therefore falls
-back to GitHub's commit-to-PR lookup when possible; the run URL and commit SHA
-remain the authoritative link when no PR number can be resolved.
+dispatches its workflow on the default branch. In that case the PR field stays
+empty rather than guessing from a default-branch commit; the run URL and commit
+SHA are the authoritative links.
 
 Artifacts are snapshots, not synchronization. They do not automatically update
 the developer's local SQLite database, and each artifact has a 14-day retention

--- a/integrations/pullfrog/README.md
+++ b/integrations/pullfrog/README.md
@@ -196,8 +196,11 @@ This prompt does not grant Pullfrog access to MemoryWhale's local database.
 The repository also contains `.github/workflows/pullfrog-memory.yml`. After a
 workflow named `Pullfrog` completes, it records an allowlisted metadata summary
 in a temporary MemoryWhale store and uploads a 14-day GitHub Actions artifact.
-The captured fields are limited to repository, workflow/run ID and URL, event,
-status/conclusion, branch, commit SHA, actor, and an associated PR number.
+The captured event summary is limited to repository, workflow/run ID and URL,
+event, status/conclusion, branch, commit SHA, actor, and a best-effort
+associated PR number. The MemoryWhale command record also necessarily contains
+the fixed command identifier and run ID in argv, the temporary runner cwd,
+exit code, creation timestamp, and automatic `os:`/`runtime:` capture tags.
 
 It deliberately does **not** capture Pullfrog prompts, review bodies, comments,
 diffs, logs, environment variables, or credentials. The workflow checks out the
@@ -206,10 +209,10 @@ trusted default branch rather than executing code from the completed PR.
 To bring an artifact into a local MemoryWhale store:
 
 1. Download and extract the `pullfrog-memory-<run-id>` artifact from GitHub.
-2. Import the extracted bundle:
+2. Import the extracted bundle directory:
 
    ```bash
-   mw import /path/to/downloaded/memorywhale/exports/pullfrog-*
+   mw import /path/to/downloaded/project-pullfrog-*
    ```
 
 3. Search the imported event:
@@ -217,6 +220,11 @@ To bring an artifact into a local MemoryWhale store:
    ```bash
    mw search "project:pullfrog"
    ```
+
+The workflow-run event often has no direct PR association because Pullfrog
+dispatches its workflow on the default branch. The workflow therefore falls
+back to GitHub's commit-to-PR lookup when possible; the run URL and commit SHA
+remain the authoritative link when no PR number can be resolved.
 
 Artifacts are snapshots, not synchronization. They do not automatically update
 the developer's local SQLite database, and each artifact has a 14-day retention


### PR DESCRIPTION
Adds the option-1 Pullfrog → MemoryWhale artifact bridge.

## Behavior

`.github/workflows/pullfrog-memory.yml` triggers after the exact `Pullfrog` workflow completes. It:

1. Checks out the trusted default branch, never the completed PR branch.
2. Builds the MemoryWhale CLI.
3. Records an allowlisted metadata summary with `mw-remember` into an isolated temporary store.
4. Exports `project:pullfrog` as a MemoryWhale bundle.
5. Uploads `pullfrog-memory-<run-id>` as a GitHub Actions artifact with 14-day retention.

Captured metadata only:

- repository
- workflow/run ID and URL
- event/status/conclusion
- head branch and commit SHA
- actor login
- associated PR number

It deliberately excludes Pullfrog prompts, review bodies, comments, diffs, logs, environment variables, and credentials. The artifact is a snapshot, not live synchronization with a developer’s local MemoryWhale database.

## Security

- Workflow uses `workflow_run` only for the exact Pullfrog workflow name.
- Default-branch checkout is pinned and uses `persist-credentials: false`.
- Upload action is pinned to a verified full-length SHA.
- Only `contents: read` permissions are declared.
- The temporary store is isolated under `$RUNNER_TEMP` and is never committed.

## Documentation

Updates `integrations/pullfrog/README.md` with artifact download/import instructions and the privacy boundary.

## Verification

- `bash scripts/check-doc-references.sh`
- `git diff --check`
- local metadata → `mw-remember` → `mw export` smoke test passed
- verified exported artifact contains the Pullfrog metadata

The unrelated local `.DS_Store` was not committed.