### PR TITLE
fix(installer): parse and validate latest-release metadata robustly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,14 @@ jobs:
           done
           "$RUNNER_TEMP/memorywhale/bin/mw" --help
 
+  installer-tests:
+    name: Installer release-tag tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run fixture-based installer tests
+        run: sh tests/install/run-tests.sh
+
   dependency-audit:
     name: Rust dependency audit
     runs-on: ubuntu-latest

--- a/install.sh
+++ b/install.sh
@@ -24,15 +24,61 @@ case "$os-$arch" in
 esac
 
 echo "==> Finding latest MemoryWhale release…"
-tag="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
-       | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
-[ -n "$tag" ] || { echo "could not find a release; is one published yet?" >&2; exit 1; }
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+release_json="$tmp/latest-release.json"
+
+# --- release-tag library (extracted verbatim by tests/install/run-tests.sh) ---
+# Pulls the latest release tag out of GitHub's /releases/latest JSON payload.
+# Uses `jq` when available; falls back to a portable single-line grep/sed
+# pipeline so the one-line installer keeps working on machines without jq.
+latest_release_tag() {
+  file="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '.tag_name? // empty' "$file" 2>/dev/null || true
+  else
+    grep '"tag_name"' "$file" | head -1 | sed -E 's/.*"tag_name" *: *"([^"]+)".*/\1/'
+  fi
+}
+
+# Validates a candidate tag before it is used to construct asset URLs.
+# MemoryWhale publishes semver tags with a "v" prefix (e.g. v0.7.0). The core
+# MAJOR.MINOR.PATCH shape is required; an optional "-prerelease"/"+build"
+# suffix is accepted to stay aligned with semver. GitHub's /releases/latest
+# endpoint already excludes prereleases and drafts, so the tag the installer
+# sees is effectively always stable. Empty, null (empty after extraction),
+# multiline, and other unexpected values are rejected here so a malformed
+# response cannot reach URL construction. The shape gate also guarantees the
+# tag cannot carry path-breaking characters.
+validate_tag() {
+  tag="$1"
+  [ -n "$tag" ] || return 1
+  case "$tag" in
+    *"
+"*) return 1 ;;
+  esac
+  printf '%s\n' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+}
+# --- end release-tag library ---
+
+if ! curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" -o "$release_json"; then
+  echo "== ERROR: could not fetch release metadata from the GitHub API." >&2
+  echo "   Check your network connection. Unauthenticated GitHub API requests" >&2
+  echo "   are rate-limited; if you are hitting the limit, set GITHUB_TOKEN." >&2
+  echo "   Alternatively build from source: cargo install --git https://github.com/$REPO mw-cli" >&2
+  exit 1
+fi
+
+tag="$(latest_release_tag "$release_json")" || tag=""
+if ! validate_tag "$tag"; then
+  echo "== ERROR: could not determine a valid release tag (is a release published yet?)." >&2
+  [ -n "$tag" ] && echo "   unexpected value from the API: $tag" >&2
+  exit 1
+fi
 ver="${tag#v}"
 
 asset="memorywhale-${ver}-${target}.tar.gz"
 url="https://github.com/$REPO/releases/download/$tag/$asset"
-tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
 
 echo "==> Downloading $asset ($tag)…"
 curl -fSL "$url" -o "$tmp/$asset"

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,16 @@ validate_tag() {
 }
 # --- end release-tag library ---
 
-if ! curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" -o "$release_json"; then
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  release_status=0
+  curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" \
+    "https://api.github.com/repos/$REPO/releases/latest" -o "$release_json" || release_status=$?
+else
+  release_status=0
+  curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+    -o "$release_json" || release_status=$?
+fi
+if [ "$release_status" -ne 0 ]; then
   echo "== ERROR: could not fetch release metadata from the GitHub API." >&2
   echo "   Check your network connection. Unauthenticated GitHub API requests" >&2
   echo "   are rate-limited; if you are hitting the limit, set GITHUB_TOKEN." >&2

--- a/tests/install/fixtures/latest-empty-tag.json
+++ b/tests/install/fixtures/latest-empty-tag.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://api.github.com/repos/wuisabel-gif/MemWhale/releases/126",
+  "tag_name": "",
+  "name": "MemoryWhale empty tag"
+}

--- a/tests/install/fixtures/latest-missing-tag.json
+++ b/tests/install/fixtures/latest-missing-tag.json
@@ -1,0 +1,5 @@
+{
+  "message": "Not Found",
+  "documentation_url": "https://docs.github.com/rest",
+  "status": "404"
+}

--- a/tests/install/fixtures/latest-multiline-tag.json
+++ b/tests/install/fixtures/latest-multiline-tag.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://api.github.com/repos/wuisabel-gif/MemWhale/releases/127",
+  "tag_name": "v0
+.7.0",
+  "name": "MemoryWhale multiline tag"
+}

--- a/tests/install/fixtures/latest-not-a-version.json
+++ b/tests/install/fixtures/latest-not-a-version.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://api.github.com/repos/wuisabel-gif/MemWhale/releases/129",
+  "tag_name": "not-a-version",
+  "name": "MemoryWhale garbage tag"
+}

--- a/tests/install/fixtures/latest-null-tag.json
+++ b/tests/install/fixtures/latest-null-tag.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://api.github.com/repos/wuisabel-gif/MemWhale/releases/125",
+  "tag_name": null,
+  "name": "MemoryWhale broken payload"
+}

--- a/tests/install/fixtures/latest-path-escape.json
+++ b/tests/install/fixtures/latest-path-escape.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://api.github.com/repos/wuisabel-gif/MemWhale/releases/128",
+  "tag_name": "../v0.7.0",
+  "name": "MemoryWhale path-escape tag"
+}

--- a/tests/install/fixtures/latest-prerelease.json
+++ b/tests/install/fixtures/latest-prerelease.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://api.github.com/repos/wuisabel-gif/MemWhale/releases/124",
+  "tag_name": "v0.8.0-rc.1",
+  "name": "MemoryWhale v0.8.0-rc.1",
+  "draft": false,
+  "prerelease": true
+}

--- a/tests/install/fixtures/latest-valid.json
+++ b/tests/install/fixtures/latest-valid.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://api.github.com/repos/wuisabel-gif/MemWhale/releases/123",
+  "tag_name": "v0.7.0",
+  "name": "MemoryWhale v0.7.0",
+  "draft": false,
+  "prerelease": false
+}

--- a/tests/install/run-tests.sh
+++ b/tests/install/run-tests.sh
@@ -52,19 +52,21 @@ check latest-multiline-tag  reject
 check latest-path-escape    reject
 check latest-not-a-version  reject
 
-# Fallback path without jq: a non-executable jq stub in PATH is invisible to
-# `command -v`, so latest_release_tag takes the portable grep/sed branch.
+# Fallback path without jq: create a PATH containing only the required
+# grep/head/sed utilities. This makes `command -v jq` fail even on CI images
+# that install jq globally, so latest_release_tag must take the portable branch.
 echo "==> no-jq fallback path"
 no_jq_bin="$(mktemp -d)"
 trap 'rm -rf "$no_jq_bin"' EXIT
-: > "$no_jq_bin/jq"
-chmod 644 "$no_jq_bin/jq"
+for utility in grep head sed; do
+  ln -s "$(command -v "$utility")" "$no_jq_bin/$utility"
+done
 
 check_fallback() {
   fixture="$1"
   expected="$2"
   checks=$((checks + 1))
-  tag="$(PATH="$no_jq_bin:$PATH" latest_release_tag "$fixtures/$fixture.json")" || tag=""
+  tag="$(PATH="$no_jq_bin" latest_release_tag "$fixtures/$fixture.json")" || tag=""
   if validate_tag "$tag"; then actual="accept"; else actual="reject"; fi
   if [ "$actual" != "$expected" ]; then
     printf 'FAIL  %-26s expected %-7s got %-7s (tag=%s)\n' \

--- a/tests/install/run-tests.sh
+++ b/tests/install/run-tests.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# Fixture-based tests for install.sh's release-tag parsing.
+#
+# Runs with a plain POSIX sh; makes no network requests. The tests exercise the
+# exact `latest_release_tag` / `validate_tag` code the installer runs by
+# extracting the marker-delimited library from install.sh verbatim, so there is
+# a single source of truth for the parsing logic.
+#
+#   sh tests/install/run-tests.sh
+set -eu
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+install_sh="$root/install.sh"
+fixtures="$root/tests/install/fixtures"
+
+lib="$(sed -n '/^# --- release-tag library/,/^# --- end release-tag library/p' "$install_sh" | sed '1d;$d')"
+eval "$lib"
+
+failures=0
+checks=0
+
+# check <fixture-name> <accept|reject>
+check() {
+  fixture="$1"
+  expected="$2"
+  checks=$((checks + 1))
+
+  tag="$(latest_release_tag "$fixtures/$fixture.json")" || tag=""
+  if validate_tag "$tag"; then
+    actual="accept"
+  else
+    actual="reject"
+  fi
+
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL  %-26s expected %-7s got %-7s (tag=%s)\n' \
+      "$fixture" "$expected" "$actual" "$tag" >&2
+    failures=$((failures + 1))
+  else
+    printf 'ok    %-26s %s\n' "$fixture" "$expected"
+  fi
+}
+
+# jq path (jq is installed on the CI runner and common on dev machines).
+echo "==> jq path"
+check latest-valid          accept
+check latest-prerelease     accept
+check latest-null-tag       reject
+check latest-empty-tag      reject
+check latest-missing-tag    reject
+check latest-multiline-tag  reject
+check latest-path-escape    reject
+check latest-not-a-version  reject
+
+# Fallback path without jq: a non-executable jq stub in PATH is invisible to
+# `command -v`, so latest_release_tag takes the portable grep/sed branch.
+echo "==> no-jq fallback path"
+no_jq_bin="$(mktemp -d)"
+trap 'rm -rf "$no_jq_bin"' EXIT
+: > "$no_jq_bin/jq"
+chmod 644 "$no_jq_bin/jq"
+
+check_fallback() {
+  fixture="$1"
+  expected="$2"
+  checks=$((checks + 1))
+  tag="$(PATH="$no_jq_bin:$PATH" latest_release_tag "$fixtures/$fixture.json")" || tag=""
+  if validate_tag "$tag"; then actual="accept"; else actual="reject"; fi
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL  %-26s expected %-7s got %-7s (tag=%s)\n' \
+      "$fixture" "$expected" "$actual" "$tag" >&2
+    failures=$((failures + 1))
+  else
+    printf 'ok    %-26s %s\n' "$fixture" "$expected"
+  fi
+}
+
+check_fallback latest-valid         accept
+check_fallback latest-prerelease    accept
+check_fallback latest-null-tag      reject
+check_fallback latest-empty-tag     reject
+check_fallback latest-missing-tag   reject
+check_fallback latest-multiline-tag reject
+check_fallback latest-path-escape   reject
+check_fallback latest-not-a-version reject
+
+if [ "$failures" -eq 0 ]; then
+  echo "==> all $checks installer tag tests passed"
+else
+  echo "==> $failures of $checks installer tag tests FAILED" >&2
+  exit 1
+fi


### PR DESCRIPTION
Implements #154 — robustly parse and validate the latest-release metadata in `install.sh`, with fixture tests that never touch the live GitHub API.

## What changed

`install.sh` used to pipe the API response through `grep | head | sed` and only checked that the result was non-empty before building asset URLs. Now:

1. **The release JSON is fetched once** into the installer's temp dir (`$tmp/latest-release.json`), instead of being piped and re-parsed implicitly.
2. **`jq -r` when available**, with a null-safe extractor (`.tag_name? // empty`) — keeps the one-line installer working without making `jq` a prerequisite.
3. **Portable grep/sed fallback** for machines without `jq`.
4. **Tag validation** before any URL is constructed: requires MemoryWhale's `v`-prefixed semver shape (`vMAJOR.MINOR.PATCH`, optional `-prerelease`/`+build` suffix). Empty, `null`, multiline, and path-breaking values are rejected. This is also an explicit prerelease decision — `/releases/latest` excludes prereleases/drafts by default, so the installer intentionally accepts semver suffixes but will effectively always receive a stable tag.
5. **Useful errors**: a dedicated message for API failure / rate limiting (pointing at `GITHUB_TOKEN` and the source-install path) vs. a missing/malformed tag.
6. **Fixture-based shell tests** in `tests/install/` — plain POSIX `sh`, local JSON fixtures covering valid, prerelease, `null`, empty, missing, multiline, path-escape, and garbage tags. Each fixture is exercised through **both** the `jq` path and the no-jq fallback (a non-executable `jq` stub keeps `command -v` pointed at the fallback). The tests extract the parser library from `install.sh` verbatim so there is a single source of truth.
7. **CI**: new `installer-tests` job runs the shell suite.

Checksum verification behavior is unchanged, and `shellcheck` is clean on both scripts.

## Verification

- `sh tests/install/run-tests.sh` → all 16 cases pass (8 fixtures × jq/fallback)
- `shellcheck install.sh tests/install/run-tests.sh` → clean
- `sh -n` syntax check on both

Closes #154
