### PR TITLE
security(capture): sanitize split secret arguments contextually

### DIFF
--- a/crates/memorywhale-core/src/privacy.rs
+++ b/crates/memorywhale-core/src/privacy.rs
@@ -158,33 +158,75 @@ fn secret_patterns() -> &'static [Regex] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    struct EnvGuard {
+        no_redact: Option<OsString>,
+        max_bytes: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            Self {
+                no_redact: std::env::var_os("MEMORYWHALE_NO_REDACT"),
+                max_bytes: std::env::var_os("MEMORYWHALE_MAX_CAPTURE_BYTES"),
+            }
+        }
+
+        fn clear_no_redact(&self) {
+            std::env::remove_var("MEMORYWHALE_NO_REDACT");
+        }
+
+        fn clear_max_bytes(&self) {
+            std::env::remove_var("MEMORYWHALE_MAX_CAPTURE_BYTES");
+        }
+
+        fn set_no_redact(&self, value: &str) {
+            std::env::set_var("MEMORYWHALE_NO_REDACT", value);
+        }
+
+        fn set_max_bytes(&self, value: &str) {
+            std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", value);
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(value) = self.no_redact.take() {
+                std::env::set_var("MEMORYWHALE_NO_REDACT", value);
+            } else {
+                std::env::remove_var("MEMORYWHALE_NO_REDACT");
+            }
+            if let Some(value) = self.max_bytes.take() {
+                std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", value);
+            } else {
+                std::env::remove_var("MEMORYWHALE_MAX_CAPTURE_BYTES");
+            }
+        }
+    }
+
     #[test]
     fn redacts_and_truncates_before_storage() {
         let _guard = ENV_LOCK.lock().unwrap();
-        let previous = std::env::var_os("MEMORYWHALE_MAX_CAPTURE_BYTES");
-        std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", "24");
-        std::env::remove_var("MEMORYWHALE_NO_REDACT");
+        let env = EnvGuard::new();
+        env.set_max_bytes("24");
+        env.clear_no_redact();
         assert!(redact("token=abcdef1234567890").contains("token=[REDACTED]"));
         let value = sanitize_capture("token=abcdef1234567890 and a long tail");
         assert!(!value.contains("abcdef1234567890"));
         assert!(value.contains("[TRUNCATED:") || value.starts_with("[TRUNC"));
         assert!(value.len() <= 24);
-        if let Some(value) = previous {
-            std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", value);
-        } else {
-            std::env::remove_var("MEMORYWHALE_MAX_CAPTURE_BYTES");
-        }
     }
 
     #[test]
     fn sanitizes_split_and_equals_secret_arguments() {
         let _guard = ENV_LOCK.lock().unwrap();
-        let previous = std::env::var_os("MEMORYWHALE_MAX_CAPTURE_BYTES");
-        std::env::remove_var("MEMORYWHALE_MAX_CAPTURE_BYTES");
+        let env = EnvGuard::new();
+        env.clear_no_redact();
+        env.clear_max_bytes();
         let arguments = vec![
             "curl".to_string(),
             "--token".to_string(),
@@ -210,16 +252,14 @@ mod tests {
                 "--clientsecret=[REDACTED]"
             ]
         );
-        if let Some(value) = previous {
-            std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", value);
-        }
     }
 
     #[test]
     fn split_arguments_preserve_raw_capture_opt_out() {
         let _guard = ENV_LOCK.lock().unwrap();
-        let previous = std::env::var_os("MEMORYWHALE_NO_REDACT");
-        std::env::set_var("MEMORYWHALE_NO_REDACT", "1");
+        let env = EnvGuard::new();
+        env.set_no_redact("1");
+        env.clear_max_bytes();
         let arguments = vec![
             "--token".to_string(),
             "short!".to_string(),
@@ -229,40 +269,27 @@ mod tests {
             sanitize_arguments(&arguments),
             ["--token", "short!", "--password=a!"]
         );
-        if let Some(value) = previous {
-            std::env::set_var("MEMORYWHALE_NO_REDACT", value);
-        } else {
-            std::env::remove_var("MEMORYWHALE_NO_REDACT");
-        }
     }
 
     #[test]
     fn equals_arguments_respect_capture_limit() {
         let _guard = ENV_LOCK.lock().unwrap();
-        let previous = std::env::var_os("MEMORYWHALE_MAX_CAPTURE_BYTES");
-        std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", "12");
+        let env = EnvGuard::new();
+        env.clear_no_redact();
+        env.set_max_bytes("12");
         let arguments = vec!["--password=very-long-secret".to_string()];
         let sanitized = sanitize_arguments(&arguments);
         assert!(sanitized[0].len() <= 12);
-        if let Some(value) = previous {
-            std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", value);
-        } else {
-            std::env::remove_var("MEMORYWHALE_MAX_CAPTURE_BYTES");
-        }
     }
 
     #[test]
     fn raw_capture_opt_out_requires_value_one() {
         let _guard = ENV_LOCK.lock().unwrap();
-        let previous = std::env::var_os("MEMORYWHALE_NO_REDACT");
-        std::env::set_var("MEMORYWHALE_NO_REDACT", "0");
+        let env = EnvGuard::new();
+        env.clear_max_bytes();
+        env.set_no_redact("0");
         assert!(!redact("token=abcdef123456").contains("abcdef123456"));
-        std::env::set_var("MEMORYWHALE_NO_REDACT", "1");
+        env.set_no_redact("1");
         assert!(redact("token=abcdef123456").contains("abcdef123456"));
-        if let Some(value) = previous {
-            std::env::set_var("MEMORYWHALE_NO_REDACT", value);
-        } else {
-            std::env::remove_var("MEMORYWHALE_NO_REDACT");
-        }
     }
 }

--- a/crates/memorywhale-core/src/privacy.rs
+++ b/crates/memorywhale-core/src/privacy.rs
@@ -46,7 +46,7 @@ pub fn sanitize_arguments(arguments: &[String]) -> Vec<String> {
                 sanitized.push(if raw_capture_opt_out() {
                     sanitize_capture(argument)
                 } else {
-                    format!("{flag}={REDACTED}")
+                    sanitize_capture(&format!("{flag}={REDACTED}"))
                 });
                 continue;
             }
@@ -182,6 +182,9 @@ mod tests {
 
     #[test]
     fn sanitizes_split_and_equals_secret_arguments() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var_os("MEMORYWHALE_MAX_CAPTURE_BYTES");
+        std::env::remove_var("MEMORYWHALE_MAX_CAPTURE_BYTES");
         let arguments = vec![
             "curl".to_string(),
             "--token".to_string(),
@@ -207,6 +210,9 @@ mod tests {
                 "--clientsecret=[REDACTED]"
             ]
         );
+        if let Some(value) = previous {
+            std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", value);
+        }
     }
 
     #[test]
@@ -227,6 +233,21 @@ mod tests {
             std::env::set_var("MEMORYWHALE_NO_REDACT", value);
         } else {
             std::env::remove_var("MEMORYWHALE_NO_REDACT");
+        }
+    }
+
+    #[test]
+    fn equals_arguments_respect_capture_limit() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var_os("MEMORYWHALE_MAX_CAPTURE_BYTES");
+        std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", "12");
+        let arguments = vec!["--password=very-long-secret".to_string()];
+        let sanitized = sanitize_arguments(&arguments);
+        assert!(sanitized[0].len() <= 12);
+        if let Some(value) = previous {
+            std::env::set_var("MEMORYWHALE_MAX_CAPTURE_BYTES", value);
+        } else {
+            std::env::remove_var("MEMORYWHALE_MAX_CAPTURE_BYTES");
         }
     }
 

--- a/crates/memorywhale-core/src/privacy.rs
+++ b/crates/memorywhale-core/src/privacy.rs
@@ -25,6 +25,41 @@ pub fn sanitize_capture(text: &str) -> String {
     truncate_capture(&redact(text), max_capture_bytes())
 }
 
+/// Sanitize command arguments with awareness of flags whose value is the next
+/// argument, such as `--token SECRET`. Per-argument sanitization cannot see
+/// that relationship and would otherwise preserve the secret value unchanged.
+pub fn sanitize_arguments(arguments: &[String]) -> Vec<String> {
+    let mut sanitized = Vec::with_capacity(arguments.len());
+    let mut redact_next = false;
+    for argument in arguments {
+        if redact_next {
+            sanitized.push(REDACTED.to_string());
+            redact_next = false;
+            continue;
+        }
+        sanitized.push(sanitize_capture(argument));
+        redact_next = is_secret_flag(argument) && !argument.contains('=');
+    }
+    sanitized
+}
+
+fn is_secret_flag(argument: &str) -> bool {
+    matches!(
+        argument.to_ascii_lowercase().as_str(),
+        "--api-key"
+            | "--apikey"
+            | "--secret"
+            | "--token"
+            | "--password"
+            | "--passwd"
+            | "--pwd"
+            | "--access-key"
+            | "--access_key"
+            | "--client-secret"
+            | "--client_secret"
+    )
+}
+
 pub fn truncate_capture(text: &str, limit: usize) -> String {
     if text.len() <= limit {
         return text.to_string();
@@ -119,6 +154,20 @@ mod tests {
         } else {
             std::env::remove_var("MEMORYWHALE_MAX_CAPTURE_BYTES");
         }
+    }
+
+    #[test]
+    fn sanitizes_split_and_equals_secret_arguments() {
+        let arguments = vec![
+            "curl".to_string(),
+            "--token".to_string(),
+            "hunter2secret99".to_string(),
+            "--password=correct-horse-battery-staple".to_string(),
+        ];
+        assert_eq!(
+            sanitize_arguments(&arguments),
+            ["curl", "--token", "[REDACTED]", "--password=[REDACTED]"]
+        );
     }
 
     #[test]

--- a/crates/memorywhale-core/src/privacy.rs
+++ b/crates/memorywhale-core/src/privacy.rs
@@ -33,9 +33,23 @@ pub fn sanitize_arguments(arguments: &[String]) -> Vec<String> {
     let mut redact_next = false;
     for argument in arguments {
         if redact_next {
-            sanitized.push(REDACTED.to_string());
+            sanitized.push(if raw_capture_opt_out() {
+                sanitize_capture(argument)
+            } else {
+                REDACTED.to_string()
+            });
             redact_next = false;
             continue;
+        }
+        if let Some((flag, _)) = argument.split_once('=') {
+            if is_secret_flag(flag) {
+                sanitized.push(if raw_capture_opt_out() {
+                    sanitize_capture(argument)
+                } else {
+                    format!("{flag}={REDACTED}")
+                });
+                continue;
+            }
         }
         sanitized.push(sanitize_capture(argument));
         redact_next = is_secret_flag(argument) && !argument.contains('=');
@@ -44,19 +58,25 @@ pub fn sanitize_arguments(arguments: &[String]) -> Vec<String> {
 }
 
 fn is_secret_flag(argument: &str) -> bool {
+    let Some(flag) = argument.strip_prefix("--") else {
+        return false;
+    };
+    let flag = flag.split_once('=').map_or(flag, |(name, _)| name);
+    let normalized: String = flag
+        .chars()
+        .filter(|character| *character != '-' && *character != '_')
+        .flat_map(char::to_lowercase)
+        .collect();
     matches!(
-        argument.to_ascii_lowercase().as_str(),
-        "--api-key"
-            | "--apikey"
-            | "--secret"
-            | "--token"
-            | "--password"
-            | "--passwd"
-            | "--pwd"
-            | "--access-key"
-            | "--access_key"
-            | "--client-secret"
-            | "--client_secret"
+        normalized.as_str(),
+        "apikey"
+            | "secret"
+            | "token"
+            | "password"
+            | "passwd"
+            | "pwd"
+            | "accesskey"
+            | "clientsecret"
     )
 }
 
@@ -97,7 +117,7 @@ fn utf8_prefix_len(text: &str, limit: usize) -> usize {
 /// This is intentionally conservative rather than a guarantee. Set
 /// `MEMORYWHALE_NO_REDACT=1` for the explicit raw-capture opt-out.
 pub fn redact(text: &str) -> String {
-    if std::env::var("MEMORYWHALE_NO_REDACT").ok().as_deref() == Some("1") {
+    if raw_capture_opt_out() {
         return text.to_string();
     }
     let mut out = text.to_string();
@@ -110,6 +130,10 @@ pub fn redact(text: &str) -> String {
             .into_owned();
     }
     out
+}
+
+fn raw_capture_opt_out() -> bool {
+    std::env::var("MEMORYWHALE_NO_REDACT").ok().as_deref() == Some("1")
 }
 
 fn secret_patterns() -> &'static [Regex] {
@@ -162,12 +186,48 @@ mod tests {
             "curl".to_string(),
             "--token".to_string(),
             "hunter2secret99".to_string(),
-            "--password=correct-horse-battery-staple".to_string(),
+            "--password=a!".to_string(),
+            "--api_key".to_string(),
+            "short".to_string(),
+            "--accesskey".to_string(),
+            "special value!".to_string(),
+            "--clientsecret=short!".to_string(),
         ];
         assert_eq!(
             sanitize_arguments(&arguments),
-            ["curl", "--token", "[REDACTED]", "--password=[REDACTED]"]
+            [
+                "curl",
+                "--token",
+                "[REDACTED]",
+                "--password=[REDACTED]",
+                "--api_key",
+                "[REDACTED]",
+                "--accesskey",
+                "[REDACTED]",
+                "--clientsecret=[REDACTED]"
+            ]
         );
+    }
+
+    #[test]
+    fn split_arguments_preserve_raw_capture_opt_out() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var_os("MEMORYWHALE_NO_REDACT");
+        std::env::set_var("MEMORYWHALE_NO_REDACT", "1");
+        let arguments = vec![
+            "--token".to_string(),
+            "short!".to_string(),
+            "--password=a!".to_string(),
+        ];
+        assert_eq!(
+            sanitize_arguments(&arguments),
+            ["--token", "short!", "--password=a!"]
+        );
+        if let Some(value) = previous {
+            std::env::set_var("MEMORYWHALE_NO_REDACT", value);
+        } else {
+            std::env::remove_var("MEMORYWHALE_NO_REDACT");
+        }
     }
 
     #[test]

--- a/crates/mw-cli/src/bin/mw-remember.rs
+++ b/crates/mw-cli/src/bin/mw-remember.rs
@@ -64,10 +64,7 @@ fn run() -> Result<(), String> {
     }
 
     notes = append_environment_tags(notes);
-    let stored_args: Vec<String> = command_parts
-        .iter()
-        .map(|value| memorywhale_cli::sanitize_capture(value))
-        .collect();
+    let stored_args = memorywhale_cli::sanitize_arguments(&command_parts);
     let command = stored_args[0].clone();
     let argv_json = serde_json::to_string(&stored_args)
         .map_err(|err| format!("failed to encode argv: {err}"))?;

--- a/crates/mw-cli/src/bin/mw-run.rs
+++ b/crates/mw-cli/src/bin/mw-run.rs
@@ -169,10 +169,7 @@ fn remember_command(
     stderr: &str,
     notes: &str,
 ) -> Result<i64, String> {
-    let stored_args: Vec<String> = command_parts
-        .iter()
-        .map(|value| memorywhale_cli::sanitize_capture(value))
-        .collect();
+    let stored_args = memorywhale_cli::sanitize_arguments(command_parts);
     let command = stored_args[0].clone();
     let argv_json = serde_json::to_string(&stored_args)
         .map_err(|err| format!("failed to encode argv: {err}"))?;

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -1498,8 +1498,8 @@ pub fn remember_as(
 }
 
 pub use memorywhale_core::privacy::{
-    max_capture_bytes, redact, sanitize_capture, truncate_capture, DEFAULT_MAX_CAPTURE_BYTES,
-    REDACTED,
+    max_capture_bytes, redact, sanitize_arguments, sanitize_capture, truncate_capture,
+    DEFAULT_MAX_CAPTURE_BYTES, REDACTED,
 };
 
 /// Finalize the current in-progress recording the moment this process's parent

--- a/crates/mw-cli/tests/privacy.rs
+++ b/crates/mw-cli/tests/privacy.rs
@@ -69,13 +69,23 @@ fn command_capture_notes_and_arguments_are_redacted_in_db() {
     let dir = std::env::temp_dir().join(format!("mw-privacy-args-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let secret = "hunter2secret";
-    let notes = format!("password: {secret}");
-    let argument = format!("--token={secret}");
+    let split_secret = "hunter2secret";
+    let equals_secret = "equal-secret-99";
+    let notes = format!("password: {split_secret}");
+    let split_argument = "--token";
+    let equals_argument = format!("--password={equals_secret}");
 
     let out = Command::new(env!("CARGO_BIN_EXE_mw-remember"))
         .env("MEMORYWHALE_DATA_DIR", &dir)
-        .args(["--notes", &notes, "--", "deploy", &argument])
+        .args([
+            "--notes",
+            &notes,
+            "--",
+            "deploy",
+            split_argument,
+            split_secret,
+            &equals_argument,
+        ])
         .output()
         .unwrap();
     assert!(out.status.success(), "mw-remember failed: {out:?}");
@@ -88,16 +98,21 @@ fn command_capture_notes_and_arguments_are_redacted_in_db() {
             |r| Ok((r.get(0)?, r.get(1)?)),
         )
         .unwrap();
-    let stored_argument: String = conn
-        .query_row(
-            "SELECT value FROM command_arguments ORDER BY id DESC LIMIT 1",
-            [],
-            |r| r.get(0),
-        )
+    let stored_arguments: Vec<String> = conn
+        .prepare("SELECT value FROM command_arguments ORDER BY position")
+        .unwrap()
+        .query_map([], |r| r.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
         .unwrap();
 
-    for stored in [&argv_json, &stored_notes, &stored_argument] {
+    for stored in [&argv_json, &stored_notes] {
         assert!(stored.contains("[REDACTED]"), "not redacted: {stored}");
+    }
+    assert!(stored_arguments.contains(&"[REDACTED]".to_string()));
+    assert!(stored_arguments.contains(&"--password=[REDACTED]".to_string()));
+    let stored = stored_arguments.join(" ");
+    for secret in [split_secret, equals_secret] {
         assert!(
             !stored.contains(secret),
             "raw secret landed in DB: {stored}"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -701,10 +701,7 @@ fn save_command_run(
     // Keep cwd as operational metadata: changing it would make replay and
     // navigation incorrect. Command/argv are sanitized representations.
     let stored_command_line = memorywhale_core::privacy::sanitize_capture(&request.command_line);
-    let stored_argv: Vec<String> = argv
-        .iter()
-        .map(|value| memorywhale_core::privacy::sanitize_capture(value))
-        .collect();
+    let stored_argv = memorywhale_core::privacy::sanitize_arguments(&argv);
     let command = stored_argv
         .first()
         .cloned()


### PR DESCRIPTION
Closes #192.

## Problem

Per-argument sanitization redacted `--token=SECRET` but preserved a secret passed as two argv elements: `--token SECRET`. This affected command/argv values stored in `command_runs` and `command_arguments`.

## Fix

- Added shared `memorywhale_core::privacy::sanitize_arguments`.
- Recognizes secret-bearing flags (`--token`, `--password`, `--api-key`, etc.) and redacts the following argument as a value.
- Retains existing `--flag=SECRET` redaction through `sanitize_capture`.
- Wired the helper into `mw-remember`, `mw-run`, and Tauri `save_command_run`.
- Added core unit coverage and expanded SQLite-facing CLI coverage for both split and equals forms.

The helper preserves the flag name while replacing the associated value with `[REDACTED]`; normal arguments continue through the shared redaction/truncation policy.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p memorywhale-core -p memorywhale-cli --all-targets -- -D warnings`
- `cargo test -p memorywhale-core -p memorywhale-cli`
- `cargo build --workspace`
- `bash scripts/check-doc-references.sh`
- `git diff --check`

All passed. No credentials or raw test secrets are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Privacy & Security**
  - Improved protection for sensitive command-line arguments.
  - Secrets are redacted whether provided separately or inline, such as `--password=value`.
  - Applies consistently across remembered and recorded commands.
  - Respects raw-capture and capture-length settings.

- **Bug Fixes**
  - Prevented sensitive values from being stored in captured command history.
  - Added coverage to verify multiple secret-argument formats are excluded from stored history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->