### PR TITLE
docs(cli): document the memory pet

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ is especially useful when you:
 
 - [Documentation map](docs/README.md)
 - [Getting started](docs/guides/getting-started.md)
+- [`mw pet` reference](docs/reference/pet.md)
 - [Terminal capture](docs/guides/terminal-capture.md)
 - [Agent memory](docs/guides/agent-memory.md)
 - [CLI reference](docs/reference/cli.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ The repository documentation is organized by the question a reader is asking.
 ## Reference: what is the exact interface?
 
 - [CLI and helper binaries](reference/cli.md)
+- [Memory pet](reference/pet.md)
 - [MCP tools](reference/mcp.md)
 - [Configuration](reference/configuration.md)
 - [Storage](reference/storage.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,6 +36,7 @@ mw discard                            # inside a recording: throw the current se
 mw context [project:name] [--last-error] [--limit N]   # compact failures digest for agents
 mw agent [session-id]                 # export a full session as text to paste into an agent
 mw ask [question] [--chat gemini]     # package the last failure for your chat AI → clipboard
+mw pet [--watch]                      # show the whale whose mood reflects the memory store
 mw doctor                             # check the install, shell hooks, and MCP server
 mw export [project:name]              # export a bundle (Markdown + JSON + SQLite)
 mw import <bundle|sqlite>             # merge another machine's export

--- a/docs/reference/pet.md
+++ b/docs/reference/pet.md
@@ -1,0 +1,52 @@
+# `mw pet` — the MemoryWhale companion
+
+`mw pet` is a small, read-only terminal view of the local MemoryWhale store.
+It renders an ASCII whale whose mood reflects how recently the store was used.
+It does not call a model, contact a network service, or write memory.
+
+## Usage
+
+```bash
+mw pet              # print one snapshot
+mw pet --watch      # refresh and animate until Ctrl-C
+NO_COLOR=1 mw pet   # disable ANSI colors
+```
+
+`--watch` refreshes the store approximately every 2.5 seconds and redraws the
+whale four times per second. Press `Ctrl-C` to stop it.
+
+## Mood rules
+
+| Mood | Condition |
+| --- | --- |
+| `hungry` | The store has no memories. |
+| `well-fed` | The most recently used memory was used today or yesterday. |
+| `content` | The most recently used memory was used within the last seven days. |
+| `sleepy` | The most recently used memory is older than seven days. |
+
+The snapshot also shows:
+
+- the number of loaded memories;
+- the number of links in `memory_links`;
+- the age of the most recently used memory;
+- the number of expired memories, which can trigger a small spout animation.
+
+The pet reads the same SQLite database as the other CLI commands. It follows
+`MEMORYWHALE_DATA_DIR` when set, so it can inspect a selected local store:
+
+```bash
+MEMORYWHALE_DATA_DIR=/path/to/MemoryWhale mw pet
+```
+
+## What it does not do
+
+The pet is intentionally presentation-only. It does not:
+
+- create, update, expire, or delete memories;
+- record terminal commands or sessions;
+- start an MCP server;
+- require an API key or an AI provider;
+- upload store contents.
+
+For a searchable view, use `mw search`, `mw tui`, or `mw-serve`. To provide
+memory to a coding agent, configure the local `mw-mcp` server instead.

--- a/docs/reference/pet.md
+++ b/docs/reference/pet.md
@@ -1,8 +1,13 @@
 # `mw pet` — the MemoryWhale companion
 
-`mw pet` is a small, read-only terminal view of the local MemoryWhale store.
-It renders an ASCII whale whose mood reflects how recently the store was used.
-It does not call a model, contact a network service, or write memory.
+`mw pet` is a memory-record read-only terminal view of the local MemoryWhale
+store. It renders an ASCII whale whose mood reflects how recently the store was
+used. It does not call a model or contact a network service.
+
+It uses the normal MemoryWhale database initializer. The first run can create
+the configured data directory and database schema, migrations can run, and
+opening the store can apply due-note expiry housekeeping. It does not
+intentionally add commands, sessions, lessons, or links.
 
 ## Usage
 
@@ -20,16 +25,16 @@ whale four times per second. Press `Ctrl-C` to stop it.
 | Mood | Condition |
 | --- | --- |
 | `hungry` | The store has no memories. |
-| `well-fed` | The most recently used memory was used today or yesterday. |
-| `content` | The most recently used memory was used within the last seven days. |
-| `sleepy` | The most recently used memory is older than seven days. |
+| `well-fed` | Fewer than two whole elapsed UTC days since the most recently used memory. |
+| `content` | At least two and fewer than eight whole elapsed UTC days since the most recently used memory. |
+| `sleepy` | At least eight whole elapsed UTC days since the most recently used memory. |
 
 The snapshot also shows:
 
 - the number of loaded memories;
 - the number of links in `memory_links`;
 - the age of the most recently used memory;
-- the number of expired memories, which can trigger a small spout animation.
+- a small spout animation when recent activity or expired memories warrant it.
 
 The pet reads the same SQLite database as the other CLI commands. It follows
 `MEMORYWHALE_DATA_DIR` when set, so it can inspect a selected local store:
@@ -40,13 +45,17 @@ MEMORYWHALE_DATA_DIR=/path/to/MemoryWhale mw pet
 
 ## What it does not do
 
-The pet is intentionally presentation-only. It does not:
+The pet is intentionally presentation-only with respect to user-created
+memory content. It does not:
 
-- create, update, expire, or delete memories;
+- add or delete memories, sessions, lessons, or links;
 - record terminal commands or sessions;
 - start an MCP server;
 - require an API key or an AI provider;
 - upload store contents.
+
+Opening the store may still perform the initialization and due-note expiry
+housekeeping described above.
 
 For a searchable view, use `mw search`, `mw tui`, or `mw-serve`. To provide
 memory to a coding agent, configure the local `mw-mcp` server instead.


### PR DESCRIPTION
Adds complete documentation for `mw pet` and `mw pet --watch`.

## Included

- usage examples and `NO_COLOR` behavior;
- mood rules for hungry, well-fed, content, and sleepy;
- displayed store metrics and refresh cadence;
- `MEMORYWHALE_DATA_DIR` usage;
- explicit read-only/local limitations;
- links from the README, docs map, and CLI reference.

Verification: `bash scripts/check-doc-references.sh` and `git diff --check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the read-only `mw pet` command, which displays a whale reflecting the memory store’s mood and statistics.
  * Added optional watch mode and color controls.
* **Documentation**
  * Documented command usage, mood rules, database selection, displayed statistics, initialization housekeeping, and read-only behavior.
  * Added links to the new `mw pet` reference from the documentation indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->