### PR TITLE
security: add GitHub vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest release on the default branch. Older tagged releases may not receive backports unless noted in the release notes.
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Use one of these private channels instead:
+
+1. **GitHub private vulnerability reporting** — open a security advisory from the repository **Security** tab (preferred when enabled).
+2. If private reporting is unavailable, contact the maintainers through a private channel listed on their GitHub profiles.
+
+### What to include
+
+- Affected version or commit
+- A minimal reproduction (steps or a small PoC)
+- Impact assessment (confidentiality / integrity / availability)
+
+### What not to include publicly
+
+- Captured secrets, tokens, or credentials
+- Full terminal dumps that may contain private local data
+- Unredacted user paths or environment variables that expose secrets
+
+## Coordinated disclosure
+
+We aim to acknowledge valid reports promptly and coordinate a fix before any public disclosure. Please give maintainers a reasonable window to investigate and release a fix before publishing details.
+
+## Local data threat model
+
+MemoryWhale stores sensitive development evidence on the local machine. For how local data is protected (threat model, not vulnerability reporting), see [docs/SECURITY.md](docs/SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,13 @@
 
 ## Supported versions
 
-Security fixes are applied to the latest release on the default branch. Older tagged releases may not receive backports unless noted in the release notes.
+| Version | Supported |
+| --- | --- |
+| 0.7.x (latest release on `main`) | ✅ security fixes |
+| < 0.7.0 | ❌ upgrade — fixes are not backported unless noted in release notes |
+
+(This table is updated with each release; older tags stop receiving fixes when a
+new minor ships.)
 
 ## Reporting a vulnerability
 
@@ -10,8 +16,11 @@ Please **do not** open a public issue for security vulnerabilities.
 
 Use one of these private channels instead:
 
-1. **GitHub private vulnerability reporting** — open a security advisory from the repository **Security** tab (preferred when enabled).
-2. If private reporting is unavailable, contact the maintainers through a private channel listed on their GitHub profiles.
+1. **GitHub private vulnerability reporting** — open the repository's
+   **Advisories** page (Security → Advisories) and select **Report a
+   vulnerability**. This is the preferred channel.
+2. If private reporting is unavailable, contact the maintainers through a
+   private channel listed on their GitHub profiles.
 
 ### What to include
 


### PR DESCRIPTION
Add root `SECURITY.md` so GitHub recognizes the security policy.

- Supported versions
- Private disclosure via GitHub security advisories
- Guidance on reproduction details without leaking secrets
- Link to `docs/SECURITY.md` for the local threat model

Fixes #153

Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added security guidelines covering supported versions, vulnerability reporting, required report details, disclosure restrictions, and coordinated disclosure expectations.
  * Included a reference to the local-data threat model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->