### PR TITLE
release: 0.8.0 — security & hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,78 @@
 All notable changes to MemoryWhale are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [0.8.0] — Security & hardening
+
+Product version `0.8.0`; `memorywhale-core` `0.3.0`.
+
+This release ships seven accumulated security fixes, two new commands
+(`mw doctor`, `mw --version`), the dashboard integration grid, and guides for
+eleven additional agents and model gateways.
+
+### Added
+
+- **`mw doctor`** — diagnoses the local install: data dir, database, shell
+  hooks, and the `mw-mcp` MCP server (resolve, initialize, tool-list, timeout
+  bounds), with actionable next steps per failure. (#187)
+- **`mw --version` / `mw -V`** — prints the version without opening the
+  database. (#127)
+- **Dashboard integration grid** — the local dashboard now shows which coding
+  agents, editors, and model-routing tools MemoryWhale composes with, linking
+  each cell to its setup guide. (#182, #205)
+- **Pullfrog workflow memory archive** — an opt-in GitHub Actions workflow
+  records sanitized Pullfrog run metadata (never prompts, logs, or diffs) into
+  a MemoryWhale bundle artifact. (#189)
+- **Hermes Agent integration** — `mw integrate hermes` registers `mw-mcp` in
+  Hermes' config. (#137)
+- **Integration guides** for Rho, Pi, Jan, OpenCode, CodeWhale, Pullfrog,
+  CLIProxyAPI, OpenRouter, and a full Claude Code guide (hook + skill), plus a
+  use-cases page documenting the three target users end to end.
+  (#175, #178, #179, #180, #188, #202, #203, #204, #208)
+- **MCP trust model documentation** — the local stdio trust boundary is now
+  written down. (#165)
+- CI now audits memory capture on PRs and runs repository consistency checks.
+  (#136, #184)
+
+### Fixed
+
+- **Installer release metadata** — `/releases/latest` is fetched once, parsed
+  with `jq` (portable fallback), and the tag validated as semver before any
+  URL is built; API failures get a dedicated message. (#190)
+- **`mw-serve` supports HEAD requests** — same headers as GET, no body; health
+  checks no longer get 405. (#199)
+- **Import tolerance** — malformed `argv_json` in an imported database no
+  longer aborts the merge; legacy `bookmarks` tables with missing columns
+  import with defaults. (#196 follow-up on #185)
+- Shell completions list every current `mw` / `mw-serve` command. (#183)
+- Frontend postcss path-traversal vulnerability (GHSA-r28c-9q8g-f849). (#197)
+
+### Security
+
+- **DNS-rebinding protection on the dashboard** — loopback binds reject
+  rebound Host headers; responses carry hardening headers
+  (`X-Content-Type-Options`, `Referrer-Policy`, `Cache-Control`, strict CSP);
+  the token comparison is constant-time. (#181)
+- **Bounded HTTP parsing** — request lines, headers, body size, and concurrent
+  connections are capped; malformed input gets bounded errors instead of
+  unbounded reads. (#169, #186)
+- **Cookie safety** — control characters in timezone cookie values are
+  rejected, preventing header injection. (#170)
+- **Desktop: unrestricted `import_file` removed** — the Tauri shell no longer
+  exposes a command that could read arbitrary paths. (#174)
+- **Shared capture sanitization before storage** — all write paths
+  (`mw-remember`, `mw-run`, session transcripts, recovery, import, desktop)
+  route through one `sanitize_capture` policy: secret-shape redaction and a
+  1 MiB bound per field, before SQLite. (#185)
+- **Split secret arguments redacted** — `--token SECRET` (two argv elements)
+  is now redacted like `--token=SECRET`, across CLI and desktop capture.
+  (#196)
+
+### Notes
+
+- No schema migrations this release; existing databases are unchanged.
+- Users on 0.7.0 should upgrade for the dashboard security fixes; see
+  `docs/SECURITY.md` for the disclosure policy.
+
 ## [0.7.0]
 
 Product version `0.7.0`; `memorywhale-core` `0.3.0`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 | --- | --- |
-| 0.7.x (latest release on `main`) | ✅ security fixes |
-| < 0.7.0 | ❌ upgrade — fixes are not backported unless noted in release notes |
+| 0.8.x (latest release on `main`) | ✅ security fixes |
+| < 0.8.0 | ❌ upgrade — fixes are not backported unless noted in release notes |
 
 (This table is updated with each release; older tags stop receiving fixes when a
 new minor ships.)

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale-cli"
-version = "0.7.0"
+version = "0.8.0"
 description = "MemoryWhale CLI — local-first terminal memory. Record commands, sessions, and output into local SQLite; browse them in a built-in web dashboard. Nothing is uploaded."
 authors = ["Isabel Wu <wuisabel@usc.edu>"]
 license = "MIT"

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -4108,6 +4108,14 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM command_runs", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 2, "malformed row must not abort the merge");
+        let malformed_argv: String = conn
+            .query_row(
+                "SELECT argv_json FROM command_runs WHERE command = 'broken'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(malformed_argv, "[]", "fallback must store empty argv");
         let valid_argv: String = conn
             .query_row(
                 "SELECT argv_json FROM command_runs WHERE command = 'deploy'",

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -4108,6 +4108,16 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM command_runs", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 2, "malformed row must not abort the merge");
+        let (valid_argv,): (String,) = conn
+            .query_row(
+                "SELECT argv_json FROM command_runs WHERE command = 'deploy'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        // exact form: non-secret argv preserved, secret contextually redacted
+        assert_eq!(valid_argv, r#"["deploy","--token","[REDACTED]"]"#);
+
         let all: String = conn
             .prepare("SELECT argv_json FROM command_runs ORDER BY id")
             .unwrap()

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -4038,6 +4038,29 @@ mod tests {
         fs::create_dir_all(&src_dir).unwrap();
         env::set_var("MEMORYWHALE_DATA_DIR", &dest);
 
+        // Panic-safe cleanup: restore the env and delete temp dirs even if an
+        // assertion or unwrap fails mid-test.
+        struct Cleanup {
+            previous_data_dir: Option<std::ffi::OsString>,
+            dest: std::path::PathBuf,
+            src_dir: std::path::PathBuf,
+        }
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                if let Some(value) = self.previous_data_dir.take() {
+                    env::set_var("MEMORYWHALE_DATA_DIR", value);
+                } else {
+                    env::remove_var("MEMORYWHALE_DATA_DIR");
+                }
+                let _ = fs::remove_dir_all(&self.dest);
+                let _ = fs::remove_dir_all(&self.src_dir);
+            }
+        }
+        let _cleanup = Cleanup {
+            previous_data_dir,
+            dest: dest.clone(),
+            src_dir: src_dir.clone(),
+        };
         // A legacy-shaped source DB: minimal columns, a split-secret argv, and
         // one row with argv JSON no writer should have produced.
         let src_db = src_dir.join("memorywhale.sqlite3");
@@ -4093,16 +4116,9 @@ mod tests {
             .map(Result::unwrap)
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(all.contains("[REDACTED]"), "split secret not redacted");
         assert!(!all.contains("supersecret99"), "raw secret imported");
 
         drop(conn);
-        if let Some(value) = previous_data_dir {
-            env::set_var("MEMORYWHALE_DATA_DIR", value);
-        } else {
-            env::remove_var("MEMORYWHALE_DATA_DIR");
-        }
-        let _ = fs::remove_dir_all(dest);
-        let _ = fs::remove_dir_all(src_dir);
+        // env + temp dirs are restored by the Cleanup guard on drop
     }
 }

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -1787,7 +1787,7 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
         let c = src_columns(&conn, "command_runs");
         if c.contains("command") && c.contains("argv_json") && c.contains("created_at") {
             let sql = format!(
-                "SELECT {}, {}, {}, {}, {}, {}, {}, {} FROM src.command_runs",
+                "SELECT {}, {}, {}, {}, {}, {}, {}, {} FROM src.command_runs s",
                 sel(&c, "command", "''"),
                 sel(&c, "argv_json", "'[]'"),
                 sel(&c, "cwd", "NULL"),
@@ -1831,11 +1831,16 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
             };
             for (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at) in rows {
                 let command = memorywhale_cli::sanitize_capture(&command);
-                let argv: Vec<String> = serde_json::from_str::<Vec<String>>(&argv_json)
-                    .map_err(|err| format!("invalid imported argv JSON: {err}"))?
-                    .into_iter()
-                    .map(|value: String| memorywhale_cli::sanitize_capture(&value))
-                    .collect();
+                // Tolerate malformed argv from older writers instead of
+                // aborting the whole merge; sanitize contextually so split
+                // `--token SECRET` forms are redacted like live capture.
+                let argv: Vec<String> = match serde_json::from_str::<Vec<String>>(&argv_json) {
+                    Ok(values) => memorywhale_cli::sanitize_arguments(&values),
+                    Err(err) => {
+                        eprintln!("mw import: skipping unreadable argv row: {err}");
+                        Vec::new()
+                    }
+                };
                 let argv_json = serde_json::to_string(&argv)
                     .map_err(|err| format!("failed to encode imported argv: {err}"))?;
                 let stdout = memorywhale_cli::sanitize_capture(&stdout);
@@ -1865,7 +1870,7 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
         let c = src_columns(&conn, "sessions");
         if c.contains("started_at") && c.contains("transcript_path") {
             let sql = format!(
-                "SELECT {}, {}, {}, {}, {}, {}, {}, {}, {} FROM src.sessions",
+                "SELECT {}, {}, {}, {}, {}, {}, {}, {}, {} FROM src.sessions s",
                 sel(&c, "shell", "''"),
                 sel(&c, "cwd", "NULL"),
                 sel(&c, "transcript_path", "''"),
@@ -3959,6 +3964,7 @@ fn database_path() -> Result<PathBuf, String> {
 mod tests {
     use super::*;
     use std::io::Cursor;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn mcp_probe_accepts_initialize_and_tools_list() {
@@ -4018,5 +4024,85 @@ mod tests {
         let error = probe_mcp_server("sh", &args, Duration::from_millis(100)).unwrap_err();
         assert!(error.contains("timed out"));
         assert!(started.elapsed() < Duration::from_secs(2));
+    }
+    #[test]
+    fn import_redacts_split_secret_argv_and_survives_malformed_json() {
+        let previous_data_dir = env::var_os("MEMORYWHALE_DATA_DIR");
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dest = env::temp_dir().join(format!("mw-import-argv-{unique}"));
+        let src_dir = env::temp_dir().join(format!("mw-import-argv-src-{unique}"));
+        fs::create_dir_all(&dest).unwrap();
+        fs::create_dir_all(&src_dir).unwrap();
+        env::set_var("MEMORYWHALE_DATA_DIR", &dest);
+
+        // A legacy-shaped source DB: minimal columns, a split-secret argv, and
+        // one row with argv JSON no writer should have produced.
+        let src_db = src_dir.join("memorywhale.sqlite3");
+        let src_conn = Connection::open(&src_db).unwrap();
+        src_conn
+            .execute_batch(
+                "CREATE TABLE command_runs (
+                    id INTEGER PRIMARY KEY,
+                    command TEXT NOT NULL,
+                    argv_json TEXT NOT NULL,
+                    cwd TEXT,
+                    exit_code INTEGER,
+                    stdout TEXT DEFAULT '',
+                    stderr TEXT DEFAULT '',
+                    notes TEXT DEFAULT '',
+                    created_at TEXT NOT NULL);
+                CREATE TABLE sessions (
+                    id INTEGER PRIMARY KEY,
+                    shell TEXT DEFAULT '',
+                    cwd TEXT,
+                    transcript_path TEXT DEFAULT '',
+                    transcript TEXT DEFAULT '',
+                    notes TEXT DEFAULT '',
+                    started_at TEXT NOT NULL,
+                    ended_at TEXT,
+                    byte_count INTEGER DEFAULT 0,
+                    status TEXT DEFAULT 'finished');
+                INSERT INTO command_runs
+                    (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at)
+                VALUES ('deploy',
+                        '[\"deploy\",\"--token\",\"supersecret99\"]',
+                        '/tmp', 0, '', '', '', '2026-01-01T00:00:00Z');
+                INSERT INTO command_runs
+                    (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at)
+                VALUES ('broken', '{not json', '/tmp', 1, '', '', '',
+                        '2026-01-02T00:00:00Z');",
+            )
+            .unwrap();
+        drop(src_conn);
+
+        import_sqlite(&src_db).unwrap();
+
+        let conn = Connection::open(dest.join("memorywhale.sqlite3")).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM command_runs", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 2, "malformed row must not abort the merge");
+        let all: String = conn
+            .prepare("SELECT argv_json FROM command_runs ORDER BY id")
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(all.contains("[REDACTED]"), "split secret not redacted");
+        assert!(!all.contains("supersecret99"), "raw secret imported");
+
+        drop(conn);
+        if let Some(value) = previous_data_dir {
+            env::set_var("MEMORYWHALE_DATA_DIR", value);
+        } else {
+            env::remove_var("MEMORYWHALE_DATA_DIR");
+        }
+        let _ = fs::remove_dir_all(dest);
+        let _ = fs::remove_dir_all(src_dir);
     }
 }

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -4108,7 +4108,7 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM command_runs", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 2, "malformed row must not abort the merge");
-        let (valid_argv,): (String,) = conn
+        let valid_argv: String = conn
             .query_row(
                 "SELECT argv_json FROM command_runs WHERE command = 'deploy'",
                 [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorywhale",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorywhale",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorywhale",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MemoryWhale",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "identifier": "com.memorywhale.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Prepares the v0.8.0 release. After this merges, the release is `git tag v0.8.0 && git push --tags`.

## Changelog

New `## [0.8.0]` section covering all 41 commits since v0.7.0:

**Added** — `mw doctor` (#187), `mw --version` (#127), dashboard integration grid (#182/#205), Pullfrog memory archive (#189), Hermes integration (#137), nine integration guides + Claude Code guide + use-cases page, MCP trust model docs (#165), CI audit/consistency checks (#136/#184).

**Fixed** — installer release-metadata validation (#190), HEAD requests (#199), import tolerance (argv/bookmarks), completions sync (#183), postcss CVE (#197).

**Security** (7) — DNS-rebinding protection + hardening headers + constant-time compare (#181), bounded HTTP parsing (#169/#186), cookie control-char rejection (#170), desktop `import_file` removal (#174), shared capture sanitization before storage (#185), split `--token SECRET` redaction (#196).

## Version bump

`0.7.0 → 0.8.0` in the four synced files (`crates/mw-cli/Cargo.toml`, `package.json`, `package-lock.json`, `src-tauri/tauri.conf.json`) + `Cargo.lock`. `scripts/check-release-version.sh` passes. No `memorywhale-core` bump (no public API change).

## Verification

- `cargo build --workspace` — passes
- `cargo test -p memorywhale-cli --test version` — version flags report 0.8.0 without DB init
- `bash scripts/check-release-version.sh` — consistent
- `git diff --check` — clean

## Not included (deferred to 0.9.0)

- #155 FTS5 perf (needs benchmarks)
- #156 storage loader fix (still open, can ride a patch release)
- #151 Tauri CSP, #146 module decomposition, #147 Dependabot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Released version 0.8.0 with security improvements, integrations, dashboard updates, new commands, and documentation enhancements.
  - Updated the application and package version to 0.8.0.

- **Bug Fixes**
  - Improved data imports by preventing query ambiguity and allowing processing to continue when command arguments contain invalid JSON.
  - Strengthened protection for sensitive values during import processing.

- **Documentation**
  - Updated the supported-version policy to include 0.8.x for security fixes and mark earlier versions as unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->