### PR TITLE
feat(memory): add conservative evidence compaction policy

### DIFF
--- a/crates/memorywhale-core/src/lib.rs
+++ b/crates/memorywhale-core/src/lib.rs
@@ -64,6 +64,7 @@ pub mod embed;
 pub mod engine;
 #[cfg(feature = "mempalace")]
 mod mcp;
+pub mod policy;
 pub mod privacy;
 pub mod scorer;
 pub mod sqlite;

--- a/crates/memorywhale-core/src/policy.rs
+++ b/crates/memorywhale-core/src/policy.rs
@@ -1,0 +1,336 @@
+//! Rule-of-thumb compaction policy for stored evidence.
+//!
+//! MemoryWhale keeps three bulky evidence surfaces: session transcripts,
+//! command-run output, and the lessons distilled from them. This module is the
+//! single rulebook that decides which rows to **Keep** untouched and which to
+//! **Compact** (shrink the stored text while preserving the row). It is pure:
+//! callers supply facts read from SQLite and receive a tier; all thresholds
+//! arrive as arguments so the CLI can expose flags and tests can pin every
+//! boundary.
+//!
+//! The rules of thumb, in evaluation order:
+//!
+//! 1. **Failures outrank successes.** A failed command or an errored run is
+//!    exactly what future-you will search for, so it is never auto-compacted.
+//! 2. **A distilled lesson makes bulk redundant.** When an approved lesson was
+//!    sourced from a session and enough time has passed, the transcript copy
+//!    can shrink — the reasoning lives in the lesson.
+//! 3. **Ancient bulk shrinks regardless.** Very old large sessions compact
+//!    even without a lesson; `transcript_path` still points at the raw file.
+//! 4. **Success noise is compacted first.** Huge successful outputs with no
+//!    error fingerprint are the cheapest thing to shrink.
+//! 5. **Small things stay.** Below the size thresholds, compaction costs more
+//!    than it saves.
+
+use std::fmt;
+
+/// What to do with one row of stored evidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Tier {
+    /// Leave the row exactly as it is.
+    Keep,
+    /// Shrink the stored text; the reason names which rule fired.
+    Compact(Reason),
+}
+
+/// Which rule of thumb selected the row for compaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reason {
+    /// An approved lesson distilled from this evidence already exists.
+    Distilled,
+    /// The evidence is old and large; recency no longer protects it.
+    StaleLarge,
+    /// Large output from a successful command with no error fingerprint.
+    SuccessNoise,
+}
+
+impl Reason {
+    /// Short human-readable label for reports and markers.
+    pub fn label(self) -> &'static str {
+        match self {
+            Reason::Distilled => "distilled into a saved lesson",
+            Reason::StaleLarge => "old and larger than the keep threshold",
+            Reason::SuccessNoise => "large successful output",
+        }
+    }
+}
+
+impl fmt::Display for Reason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Facts about one row of `sessions`.
+#[derive(Debug, Clone, Copy)]
+pub struct SessionFacts {
+    /// Stored inline transcript size in bytes (`sessions.byte_count`).
+    pub byte_count: i64,
+    /// True when the row is an approved (or unreviewed) lesson's source,
+    /// i.e. some bookmark row points at this session.
+    pub has_distilled_lesson: bool,
+    /// Whole days elapsed since `ended_at` (0 for today).
+    pub days_since_end: i64,
+}
+
+/// Facts about one row of `command_runs`.
+#[derive(Debug, Clone, Copy)]
+pub struct RunFacts {
+    /// The command failed (nonzero exit).
+    pub failed: bool,
+    /// An error fingerprint was recorded for this run.
+    pub has_error_fingerprint: bool,
+    /// Combined stdout + stderr bytes.
+    pub total_output_bytes: i64,
+    /// Some bookmark references this run directly.
+    pub referenced_by_bookmark: bool,
+}
+
+/// Decide the tier for one session row.
+///
+/// Rules in order: recording sessions are never touched; small transcripts
+/// stay; a distilled lesson after `stale_days`/4 makes the bulk redundant;
+/// anything older than `stale_days` and above `min_bytes` shrinks regardless.
+pub fn session_tier(facts: SessionFacts, min_bytes: i64, stale_days: i64) -> Tier {
+    if facts.byte_count <= min_bytes {
+        return Tier::Keep;
+    }
+    if facts.has_distilled_lesson && facts.days_since_end >= (stale_days / 4).max(1) {
+        return Tier::Compact(Reason::Distilled);
+    }
+    if facts.days_since_end >= stale_days {
+        return Tier::Compact(Reason::StaleLarge);
+    }
+    Tier::Keep
+}
+
+/// Decide the tier for one command-run row.
+///
+/// Failures, fingerprinted errors, bookmarked runs, and anything under
+/// `max_output_bytes` are kept. Everything else is success noise.
+pub fn run_tier(facts: RunFacts, max_output_bytes: i64) -> Tier {
+    if facts.failed || facts.has_error_fingerprint || facts.referenced_by_bookmark {
+        return Tier::Keep;
+    }
+    if facts.total_output_bytes > max_output_bytes {
+        return Tier::Compact(Reason::SuccessNoise);
+    }
+    Tier::Keep
+}
+
+/// Build the replacement text for a compacted session transcript.
+///
+/// The raw file on disk (referenced by `transcript_path`) is untouched; this
+/// only shrinks the inline SQLite copy. The marker records the original size
+/// so the shrink is auditable.
+pub fn compacted_session_transcript(original_bytes: i64) -> String {
+    format!(
+        "[COMPACTED: {original_bytes} bytes of transcript were here; \
+             the raw file is preserved on disk at sessions.transcript_path]"
+    )
+}
+
+/// Head/tail-truncate one output stream, keeping both ends around a marker.
+///
+/// Keeps `keep_each` bytes from the head and tail when truncation is needed;
+/// inputs already at or under the cap pass through unchanged.
+pub fn compact_output_stream(text: &str, max_bytes: i64) -> String {
+    let max = max_bytes.max(0) as usize;
+    if text.len() <= max {
+        return text.to_string();
+    }
+    let keep_each = (max / 2).max(1);
+    let head = take_prefix(text, keep_each);
+    let tail = take_suffix(text, keep_each);
+    let omitted = text.len() - head.len() - tail.len();
+    format!("{head}\n[COMPACTED: {omitted} bytes omitted]\n{tail}")
+}
+
+fn take_prefix(text: &str, mut limit: usize) -> &str {
+    if limit >= text.len() {
+        return text;
+    }
+    while !text.is_char_boundary(limit) {
+        limit -= 1;
+    }
+    &text[..limit]
+}
+
+fn take_suffix(text: &str, start: usize) -> &str {
+    if start >= text.len() {
+        return "";
+    }
+    let begin = text.len() - start;
+    let mut begin = begin;
+    while !text.is_char_boundary(begin) {
+        begin += 1;
+    }
+    &text[begin..]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn facts(bytes: i64, lesson: bool, days: i64) -> SessionFacts {
+        SessionFacts {
+            byte_count: bytes,
+            has_distilled_lesson: lesson,
+            days_since_end: days,
+        }
+    }
+
+    #[test]
+    fn small_sessions_stay_regardless_of_age_or_lesson() {
+        assert_eq!(
+            session_tier(facts(100, true, 365), 256 * 1024, 180),
+            Tier::Keep
+        );
+        assert_eq!(
+            session_tier(facts(0, false, 999), 256 * 1024, 180),
+            Tier::Keep
+        );
+    }
+
+    #[test]
+    fn recording_is_never_reported_because_size_gate_runs_first() {
+        // Recording sessions are filtered by the caller via byte_count/status;
+        // the policy itself only sees facts, so document that a fresh recording
+        // (tiny bytes) is Keep.
+        assert_eq!(
+            session_tier(facts(10, false, 0), 256 * 1024, 180),
+            Tier::Keep
+        );
+    }
+
+    #[test]
+    fn distilled_lesson_compacts_after_quarter_window() {
+        let tier = session_tier(facts(512 * 1024, true, 45), 256 * 1024, 180);
+        assert_eq!(tier, Tier::Compact(Reason::Distilled));
+    }
+
+    #[test]
+    fn distilled_lesson_waits_until_quarter_of_stale_days() {
+        // stale_days=180 -> quarter = 45 days; day 44 still keeps.
+        assert_eq!(
+            session_tier(facts(512 * 1024, true, 44), 256 * 1024, 180),
+            Tier::Keep
+        );
+    }
+
+    #[test]
+    fn stale_large_compacts_without_any_lesson() {
+        assert_eq!(
+            session_tier(facts(512 * 1024, false, 200), 256 * 1024, 180),
+            Tier::Compact(Reason::StaleLarge)
+        );
+    }
+
+    #[test]
+    fn large_recent_unlessoned_session_keeps() {
+        assert_eq!(
+            session_tier(facts(512 * 1024, false, 30), 256 * 1024, 180),
+            Tier::Keep
+        );
+    }
+
+    #[test]
+    fn quarter_window_floors_at_one_day() {
+        // stale_days=3 -> quarter=0 -> floor at 1: day 1 with a lesson compacts.
+        assert_eq!(
+            session_tier(facts(512 * 1024, true, 1), 256 * 1024, 3),
+            Tier::Compact(Reason::Distilled)
+        );
+    }
+
+    fn run(failed: bool, fp: bool, bytes: i64, referenced: bool) -> RunFacts {
+        RunFacts {
+            failed,
+            has_error_fingerprint: fp,
+            total_output_bytes: bytes,
+            referenced_by_bookmark: referenced,
+        }
+    }
+
+    #[test]
+    fn failures_and_fingerprints_always_keep() {
+        assert_eq!(
+            run_tier(run(true, false, 10_000_000, false), 64 * 1024),
+            Tier::Keep
+        );
+        assert_eq!(
+            run_tier(run(false, true, 10_000_000, false), 64 * 1024),
+            Tier::Keep
+        );
+    }
+
+    #[test]
+    fn bookmarked_runs_keep_even_when_huge_successes() {
+        assert_eq!(
+            run_tier(run(false, false, 10_000_000, true), 64 * 1024),
+            Tier::Keep
+        );
+    }
+
+    #[test]
+    fn big_successful_output_compacts() {
+        assert_eq!(
+            run_tier(run(false, false, 128 * 1024, false), 64 * 1024),
+            Tier::Compact(Reason::SuccessNoise)
+        );
+    }
+
+    #[test]
+    fn small_successful_output_keeps() {
+        assert_eq!(
+            run_tier(run(false, false, 1024, false), 64 * 1024),
+            Tier::Keep
+        );
+        assert_eq!(
+            run_tier(run(false, false, 64 * 1024, false), 64 * 1024),
+            Tier::Keep
+        );
+    }
+
+    #[test]
+    fn compacted_transcript_marker_records_original_size() {
+        let marker = compacted_session_transcript(912_345);
+        assert!(marker.contains("912345"));
+        assert!(marker.contains("[COMPACTED:"));
+        assert!(marker.contains("preserved on disk"));
+    }
+
+    #[test]
+    fn output_stream_passthrough_under_cap() {
+        assert_eq!(compact_output_stream("hello", 100), "hello");
+        assert_eq!(compact_output_stream("", 100), "");
+    }
+
+    #[test]
+    fn output_stream_head_tail_with_marker_over_cap() {
+        let big = format!("HEAD{}\nTAIL", "x".repeat(10_000));
+        let out = compact_output_stream(&big, 2048);
+        assert!(out.starts_with("HEAD"));
+        assert!(out.ends_with("\nTAIL"));
+        assert!(out.contains("[COMPACTED: "));
+        assert!(out.len() < big.len());
+    }
+
+    #[test]
+    fn output_stream_truncation_respects_utf8_boundaries() {
+        let emoji = "🦈".repeat(5_000); // 4 bytes each, 20_000 total
+        let out = compact_output_stream(&emoji, 1024);
+        // Must remain valid UTF-8 (String type guarantees it, but the slicing
+        // inside must not panic).
+        assert!(out.contains("[COMPACTED: "));
+        assert!(out.ends_with("🦈") || out.ends_with('\n') || out.ends_with('🦈'));
+    }
+
+    #[test]
+    fn zero_max_keeps_one_byte_each_side_and_omits_the_rest() {
+        let out = compact_output_stream("anything", 0);
+        assert!(out.starts_with('a'));
+        assert!(out.ends_with('g'));
+        assert!(out.contains("[COMPACTED: 6 bytes omitted]"));
+    }
+}

--- a/crates/memorywhale-core/src/policy.rs
+++ b/crates/memorywhale-core/src/policy.rs
@@ -139,11 +139,22 @@ pub fn compact_output_stream(text: &str, max_bytes: i64) -> String {
     if text.len() <= max {
         return text.to_string();
     }
-    let keep_each = (max / 2).max(1);
-    let head = take_prefix(text, keep_each);
-    let tail = take_suffix(text, keep_each);
-    let omitted = text.len() - head.len() - tail.len();
-    format!("{head}\n[COMPACTED: {omitted} bytes omitted]\n{tail}")
+    if max == 0 {
+        return String::new();
+    }
+    let mut keep_each = (max / 2).max(1);
+    for _ in 0..8 {
+        let head = take_prefix(text, keep_each);
+        let tail = take_suffix(text, keep_each);
+        let omitted = text.len() - head.len() - tail.len();
+        let marker = format!("\n[COMPACTED: {omitted} bytes omitted]\n");
+        if head.len() + marker.len() + tail.len() <= max {
+            return format!("{head}{marker}{tail}");
+        }
+        keep_each =
+            keep_each.saturating_sub(((head.len() + marker.len() + tail.len() - max) / 2).max(1));
+    }
+    take_prefix("[COMPACTED]", max).to_string()
 }
 
 fn take_prefix(text: &str, mut limit: usize) -> &str {
@@ -327,10 +338,17 @@ mod tests {
     }
 
     #[test]
-    fn zero_max_keeps_one_byte_each_side_and_omits_the_rest() {
+    fn zero_max_returns_empty_output() {
         let out = compact_output_stream("anything", 0);
-        assert!(out.starts_with('a'));
-        assert!(out.ends_with('g'));
-        assert!(out.contains("[COMPACTED: 6 bytes omitted]"));
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn compacted_output_is_bounded_and_idempotent() {
+        let input = "x".repeat(10_000);
+        let once = compact_output_stream(&input, 512);
+        let twice = compact_output_stream(&once, 512);
+        assert!(once.len() <= 512);
+        assert_eq!(once, twice);
     }
 }

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -914,12 +914,215 @@ fn memory_lifecycle_cmd(args: &[String]) -> Result<(), String> {
             memorywhale_cli::supersede_note(&conn, old_id, new_id)?;
             println!("mw: memory #{old_id} superseded by #{new_id}; both records were preserved.");
         }
+        [action, rest @ ..] if action == "compact" => {
+            return memory_compact_cmd(&conn, rest);
+        }
         _ => {
             return Err(
-                "usage: mw memory stale <id> | mw memory supersede <old-id> <new-id>".to_string(),
+                "usage: mw memory stale <id> | mw memory supersede <old-id> <new-id> \
+                        | mw memory compact [--apply] [--min-session-bytes N] [--stale-days N] \
+                        [--max-output-bytes N]"
+                    .to_string(),
             )
         }
     }
+    Ok(())
+}
+
+/// `mw memory compact` — apply rule-of-thumb compaction to bulky evidence.
+///
+/// Dry-run by default: prints which sessions and command runs the policy
+/// (memorywhale_core::policy) would shrink, with per-rule counts and byte
+/// savings. `--apply` performs the UPDATEs. Compaction never deletes rows:
+/// session transcripts are replaced by a marker (the raw file on disk is
+/// untouched), and command output is head/tail-truncated around a marker.
+fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> {
+    let mut apply = false;
+    let mut min_session_bytes: i64 = 256 * 1024;
+    let mut stale_days: i64 = 180;
+    let mut max_output_bytes: i64 = 64 * 1024;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--apply" => apply = true,
+            "--min-session-bytes" => {
+                min_session_bytes = iter
+                    .next()
+                    .and_then(|v| v.parse().ok())
+                    .ok_or_else(|| "--min-session-bytes requires a number".to_string())?;
+            }
+            "--stale-days" => {
+                stale_days = iter
+                    .next()
+                    .and_then(|v| v.parse().ok())
+                    .ok_or_else(|| "--stale-days requires a number".to_string())?;
+            }
+            "--max-output-bytes" => {
+                max_output_bytes = iter
+                    .next()
+                    .and_then(|v| v.parse().ok())
+                    .ok_or_else(|| "--max-output-bytes requires a number".to_string())?;
+            }
+            other => {
+                return Err(format!(
+                    "unexpected argument {other:?}; see mw memory compact --help"
+                ))
+            }
+        }
+    }
+
+    use memorywhale_core::policy::{
+        compact_output_stream, compacted_session_transcript, run_tier, session_tier, RunFacts, Tier,
+    };
+
+    // ---- sessions ----
+    let mut sessions: Vec<(i64, String)> = Vec::new(); // (id, reason)
+    {
+        let mut stmt = conn
+            .prepare(
+                "SELECT s.id, s.byte_count, s.status,
+                        COALESCE((SELECT MAX(CAST((julianday('now') - julianday(s.ended_at)) AS INTEGER))
+                                  FROM bookmarks b
+                                  WHERE b.source_session_id = s.id AND b.approved = 1),
+                                 NULL) AS lesson_age_days
+                 FROM sessions s",
+            )
+            .map_err(|e| format!("failed to scan sessions: {e}"))?;
+        let rows: Vec<(i64, i64, String, Option<i64>)> = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, i64>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, Option<i64>>(3)?,
+                ))
+            })
+            .map_err(|e| format!("failed to scan sessions: {e}"))?
+            .collect::<std::result::Result<_, _>>()
+            .map_err(|e| e.to_string())?;
+        for (id, byte_count, status, lesson_age) in rows {
+            if status == "recording" || byte_count <= min_session_bytes {
+                continue;
+            }
+            let days_since_end: i64 = conn
+                .query_row(
+                    "SELECT CAST(julianday('now') - julianday(ended_at) AS INTEGER)
+                     FROM sessions WHERE id = ?1 AND ended_at != ''",
+                    params![id],
+                    |r| r.get(0),
+                )
+                .unwrap_or(0);
+            let has_lesson = matches!(lesson_age, Some(age) if age >= 0);
+            let facts = memorywhale_core::policy::SessionFacts {
+                byte_count,
+                has_distilled_lesson: has_lesson,
+                days_since_end,
+            };
+            if let Tier::Compact(reason) = session_tier(facts, min_session_bytes, stale_days) {
+                sessions.push((id, reason.label().to_string()));
+            }
+        }
+    }
+
+    // ---- command runs ----
+    let mut runs: Vec<(i64, String)> = Vec::new();
+    {
+        let mut stmt = conn
+            .prepare(
+                "SELECT r.id, COALESCE(r.exit_code, 1), r.error_fingerprint,
+                        COALESCE(LENGTH(r.stdout), 0), COALESCE(LENGTH(r.stderr), 0),
+                        EXISTS(SELECT 1 FROM bookmarks b WHERE b.command_run_id = r.id)
+                 FROM command_runs r",
+            )
+            .map_err(|e| format!("failed to scan command runs: {e}"))?;
+        let rows: Vec<(i64, i64, Option<String>, i64, i64, bool)> = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, i64>(1)?,
+                    r.get::<_, Option<String>>(2)?,
+                    r.get::<_, i64>(3)?,
+                    r.get::<_, i64>(4)?,
+                    r.get::<_, bool>(5)?,
+                ))
+            })
+            .map_err(|e| format!("failed to scan command runs: {e}"))?
+            .collect::<std::result::Result<_, _>>()
+            .map_err(|e| e.to_string())?;
+        for (id, exit_code, fingerprint, out_len, err_len, referenced) in rows {
+            let facts = RunFacts {
+                failed: exit_code != 0,
+                has_error_fingerprint: fingerprint.is_some(),
+                total_output_bytes: out_len + err_len,
+                referenced_by_bookmark: referenced,
+            };
+            if let Tier::Compact(reason) = run_tier(facts, max_output_bytes) {
+                runs.push((id, reason.label().to_string()));
+            }
+        }
+    }
+
+    // ---- report ----
+    println!(
+        "Compaction plan ({} session(s), {} command run(s)):",
+        sessions.len(),
+        runs.len()
+    );
+    for (id, reason) in &sessions {
+        println!("  session #{id}: {reason}");
+    }
+    for (id, reason) in &runs {
+        println!("  command #{id}: {reason}");
+    }
+    if sessions.is_empty() && runs.is_empty() {
+        println!("Nothing to compact — every row is within policy.");
+    }
+    if !apply {
+        println!(
+            "Dry run only. Re-run with --apply to shrink these rows \
+             (rows are never deleted; export first if unsure)."
+        );
+        return Ok(());
+    }
+
+    // ---- apply ----
+    for (id, _) in &sessions {
+        let original: i64 = conn
+            .query_row(
+                "SELECT byte_count FROM sessions WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        let marker = compacted_session_transcript(original);
+        conn.execute(
+            "UPDATE sessions SET transcript = ?1, byte_count = ?2 WHERE id = ?3",
+            params![marker, marker.len() as i64, id],
+        )
+        .map_err(|e| format!("failed to compact session #{id}: {e}"))?;
+    }
+    for (id, _) in &runs {
+        let (stdout, stderr): (String, String) = conn
+            .query_row(
+                "SELECT stdout, stderr FROM command_runs WHERE id = ?1",
+                params![id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .map_err(|e| format!("failed to read command #{id}: {e}"))?;
+        let new_stdout = compact_output_stream(&stdout, max_output_bytes / 2);
+        let new_stderr = compact_output_stream(&stderr, max_output_bytes / 2);
+        conn.execute(
+            "UPDATE command_runs SET stdout = ?1, stderr = ?2 WHERE id = ?3",
+            params![new_stdout, new_stderr, id],
+        )
+        .map_err(|e| format!("failed to compact command #{id}: {e}"))?;
+    }
+    println!(
+        "mw: compacted {} session(s) and {} command run(s). Rows were preserved; \
+         raw session files on disk were not touched.",
+        sessions.len(),
+        runs.len()
+    );
     Ok(())
 }
 

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -946,6 +946,13 @@ fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> 
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--apply" => apply = true,
+            "--help" | "-h" => {
+                println!(
+                    "usage: mw memory compact [--apply] [--min-session-bytes N] \
+                     [--stale-days N] [--max-output-bytes N]"
+                );
+                return Ok(());
+            }
             "--min-session-bytes" => {
                 min_session_bytes = iter
                     .next()
@@ -971,6 +978,12 @@ fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> 
             }
         }
     }
+    if min_session_bytes < 0 || stale_days <= 0 || max_output_bytes <= 0 {
+        return Err(
+            "compaction thresholds must be non-negative, with stale-days and max-output-bytes positive"
+                .to_string(),
+        );
+    }
 
     use memorywhale_core::policy::{
         compact_output_stream, compacted_session_transcript, run_tier, session_tier, RunFacts, Tier,
@@ -980,21 +993,25 @@ fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> 
     let mut sessions: Vec<(i64, String)> = Vec::new(); // (id, reason)
     {
         let mut stmt = conn
-            .prepare("SELECT id, byte_count, status FROM sessions")
+            .prepare("SELECT id, byte_count, status, transcript_path FROM sessions")
             .map_err(|e| format!("failed to scan sessions: {e}"))?;
-        let rows: Vec<(i64, i64, String)> = stmt
+        let rows: Vec<(i64, i64, String, String)> = stmt
             .query_map([], |r| {
                 Ok((
                     r.get::<_, i64>(0)?,
                     r.get::<_, i64>(1)?,
                     r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
                 ))
             })
             .map_err(|e| format!("failed to scan sessions: {e}"))?
             .collect::<std::result::Result<_, _>>()
             .map_err(|e| e.to_string())?;
-        for (id, byte_count, status) in rows {
-            if status == "recording" || byte_count <= min_session_bytes {
+        for (id, byte_count, status, transcript_path) in rows {
+            if status == "recording"
+                || byte_count <= min_session_bytes
+                || !Path::new(&transcript_path).is_file()
+            {
                 continue;
             }
             let days_since_end: i64 = conn
@@ -1029,7 +1046,8 @@ fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> 
         let mut stmt = conn
             .prepare(
                 "SELECT r.id, COALESCE(r.exit_code, 1), r.error_fingerprint,
-                        COALESCE(LENGTH(r.stdout), 0), COALESCE(LENGTH(r.stderr), 0),
+                        COALESCE(LENGTH(CAST(r.stdout AS BLOB)), 0),
+                        COALESCE(LENGTH(CAST(r.stderr AS BLOB)), 0),
                         EXISTS(SELECT 1 FROM bookmarks b WHERE b.command_run_id = r.id)
                  FROM command_runs r",
             )

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -1008,9 +1008,11 @@ fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> 
             .collect::<std::result::Result<_, _>>()
             .map_err(|e| e.to_string())?;
         for (id, byte_count, status, transcript_path) in rows {
+            let transcript_path = Path::new(&transcript_path);
             if status == "recording"
                 || byte_count <= min_session_bytes
-                || !Path::new(&transcript_path).is_file()
+                || !transcript_path.is_absolute()
+                || !transcript_path.is_file()
             {
                 continue;
             }

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -938,6 +938,7 @@ fn memory_lifecycle_cmd(args: &[String]) -> Result<(), String> {
 /// session transcripts are replaced by a marker (the raw file on disk is
 /// untouched), and command output is head/tail-truncated around a marker.
 fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> {
+    const MIN_COMPACTION_STREAM_BYTES: i64 = 128;
     let mut apply = false;
     let mut min_session_bytes: i64 = 256 * 1024;
     let mut stale_days: i64 = 180;
@@ -978,11 +979,15 @@ fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> 
             }
         }
     }
-    if min_session_bytes < 0 || stale_days <= 0 || max_output_bytes <= 0 {
-        return Err(
-            "compaction thresholds must be non-negative, with stale-days and max-output-bytes positive"
-                .to_string(),
-        );
+    if min_session_bytes < 0
+        || stale_days <= 0
+        || max_output_bytes < MIN_COMPACTION_STREAM_BYTES * 2
+    {
+        return Err(format!(
+            "compaction thresholds must be non-negative, stale-days positive, and \
+                 max-output-bytes at least {}",
+            MIN_COMPACTION_STREAM_BYTES * 2
+        ));
     }
 
     use memorywhale_core::policy::{
@@ -1104,38 +1109,49 @@ fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> 
         return Ok(());
     }
 
-    // ---- apply ----
-    for (id, _) in &sessions {
-        let original: i64 = conn
-            .query_row(
-                "SELECT byte_count FROM sessions WHERE id = ?1",
-                params![id],
-                |r| r.get(0),
+    // ---- apply atomically ----
+    conn.execute_batch("BEGIN IMMEDIATE")
+        .map_err(|e| format!("failed to begin compaction transaction: {e}"))?;
+    let apply_result: Result<(), String> = (|| {
+        for (id, _) in &sessions {
+            let original: i64 = conn
+                .query_row(
+                    "SELECT byte_count FROM sessions WHERE id = ?1",
+                    params![id],
+                    |r| r.get(0),
+                )
+                .unwrap_or(0);
+            let marker = compacted_session_transcript(original);
+            conn.execute(
+                "UPDATE sessions SET transcript = ?1 WHERE id = ?2",
+                params![marker, id],
             )
-            .unwrap_or(0);
-        let marker = compacted_session_transcript(original);
-        conn.execute(
-            "UPDATE sessions SET transcript = ?1, byte_count = ?2 WHERE id = ?3",
-            params![marker, marker.len() as i64, id],
-        )
-        .map_err(|e| format!("failed to compact session #{id}: {e}"))?;
-    }
-    for (id, _) in &runs {
-        let (stdout, stderr): (String, String) = conn
-            .query_row(
-                "SELECT stdout, stderr FROM command_runs WHERE id = ?1",
-                params![id],
-                |r| Ok((r.get(0)?, r.get(1)?)),
+            .map_err(|e| format!("failed to compact session #{id}: {e}"))?;
+        }
+        for (id, _) in &runs {
+            let (stdout, stderr): (String, String) = conn
+                .query_row(
+                    "SELECT stdout, stderr FROM command_runs WHERE id = ?1",
+                    params![id],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .map_err(|e| format!("failed to read command #{id}: {e}"))?;
+            let new_stdout = compact_output_stream(&stdout, max_output_bytes / 2);
+            let new_stderr = compact_output_stream(&stderr, max_output_bytes / 2);
+            conn.execute(
+                "UPDATE command_runs SET stdout = ?1, stderr = ?2 WHERE id = ?3",
+                params![new_stdout, new_stderr, id],
             )
-            .map_err(|e| format!("failed to read command #{id}: {e}"))?;
-        let new_stdout = compact_output_stream(&stdout, max_output_bytes / 2);
-        let new_stderr = compact_output_stream(&stderr, max_output_bytes / 2);
-        conn.execute(
-            "UPDATE command_runs SET stdout = ?1, stderr = ?2 WHERE id = ?3",
-            params![new_stdout, new_stderr, id],
-        )
-        .map_err(|e| format!("failed to compact command #{id}: {e}"))?;
+            .map_err(|e| format!("failed to compact command #{id}: {e}"))?;
+        }
+        Ok(())
+    })();
+    if let Err(error) = apply_result {
+        let _ = conn.execute_batch("ROLLBACK");
+        return Err(error);
     }
+    conn.execute_batch("COMMIT")
+        .map_err(|e| format!("failed to commit compaction: {e}"))?;
     println!(
         "mw: compacted {} session(s) and {} command run(s). Rows were preserved; \
          raw session files on disk were not touched.",

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -282,6 +282,7 @@ fn print_help() {
          mw remember <text> [ttl:7d] [--force]  save a lesson/conclusion (ttl: auto-expires it; warns on a near-duplicate, --force saves anyway), e.g. \"the fix was passing --features vendored-ssl\"\n\
          mw memory stale <id>     retire an outdated lesson without deleting its evidence\n\
          mw memory supersede <old-id> <new-id>  replace an old lesson with a newer one\n\
+         mw memory compact [--apply]  preview/apply conservative evidence compaction\n\
          mw rm [session|command] <id>  delete a saved item and its transcript\n\
          mw prune [--min-bytes N] [--dry-run]  delete empty auto-recorded sessions (noise cleanup)\n\
          mw prune --older-than <7d|24h|2w> [--dry-run]  delete sessions and command runs older than a window\n\
@@ -979,28 +980,20 @@ fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> 
     let mut sessions: Vec<(i64, String)> = Vec::new(); // (id, reason)
     {
         let mut stmt = conn
-            .prepare(
-                "SELECT s.id, s.byte_count, s.status,
-                        COALESCE((SELECT MAX(CAST((julianday('now') - julianday(s.ended_at)) AS INTEGER))
-                                  FROM bookmarks b
-                                  WHERE b.source_session_id = s.id AND b.approved = 1),
-                                 NULL) AS lesson_age_days
-                 FROM sessions s",
-            )
+            .prepare("SELECT id, byte_count, status FROM sessions")
             .map_err(|e| format!("failed to scan sessions: {e}"))?;
-        let rows: Vec<(i64, i64, String, Option<i64>)> = stmt
+        let rows: Vec<(i64, i64, String)> = stmt
             .query_map([], |r| {
                 Ok((
                     r.get::<_, i64>(0)?,
                     r.get::<_, i64>(1)?,
                     r.get::<_, String>(2)?,
-                    r.get::<_, Option<i64>>(3)?,
                 ))
             })
             .map_err(|e| format!("failed to scan sessions: {e}"))?
             .collect::<std::result::Result<_, _>>()
             .map_err(|e| e.to_string())?;
-        for (id, byte_count, status, lesson_age) in rows {
+        for (id, byte_count, status) in rows {
             if status == "recording" || byte_count <= min_session_bytes {
                 continue;
             }
@@ -1012,7 +1005,13 @@ fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> 
                     |r| r.get(0),
                 )
                 .unwrap_or(0);
-            let has_lesson = matches!(lesson_age, Some(age) if age >= 0);
+            let has_lesson: bool = conn
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM bookmarks WHERE source_session_id = ?1 AND approved = 1)",
+                    params![id],
+                    |r| r.get(0),
+                )
+                .unwrap_or(false);
             let facts = memorywhale_core::policy::SessionFacts {
                 byte_count,
                 has_distilled_lesson: has_lesson,
@@ -1038,7 +1037,7 @@ fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> 
         let rows: Vec<(i64, i64, Option<String>, i64, i64, bool)> = stmt
             .query_map([], |r| {
                 Ok((
-                    r.get::<_, i64>(0)?,
+                    r.get::<_, Option<i64>>(0)?.unwrap_or(0),
                     r.get::<_, i64>(1)?,
                     r.get::<_, Option<String>>(2)?,
                     r.get::<_, i64>(3)?,

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -998,23 +998,25 @@ fn memory_compact_cmd(conn: &Connection, args: &[String]) -> Result<(), String> 
     let mut sessions: Vec<(i64, String)> = Vec::new(); // (id, reason)
     {
         let mut stmt = conn
-            .prepare("SELECT id, byte_count, status, transcript_path FROM sessions")
+            .prepare("SELECT id, byte_count, status, transcript_path, transcript FROM sessions")
             .map_err(|e| format!("failed to scan sessions: {e}"))?;
-        let rows: Vec<(i64, i64, String, String)> = stmt
+        let rows: Vec<(i64, i64, String, String, String)> = stmt
             .query_map([], |r| {
                 Ok((
                     r.get::<_, i64>(0)?,
                     r.get::<_, i64>(1)?,
                     r.get::<_, String>(2)?,
                     r.get::<_, String>(3)?,
+                    r.get::<_, String>(4)?,
                 ))
             })
             .map_err(|e| format!("failed to scan sessions: {e}"))?
             .collect::<std::result::Result<_, _>>()
             .map_err(|e| e.to_string())?;
-        for (id, byte_count, status, transcript_path) in rows {
+        for (id, byte_count, status, transcript_path, transcript) in rows {
             let transcript_path = Path::new(&transcript_path);
-            if status == "recording"
+            if transcript == compacted_session_transcript(byte_count)
+                || status == "recording"
                 || byte_count <= min_session_bytes
                 || !transcript_path.is_absolute()
                 || !transcript_path.is_file()

--- a/crates/mw-cli/tests/compaction.rs
+++ b/crates/mw-cli/tests/compaction.rs
@@ -1,0 +1,74 @@
+use rusqlite::Connection;
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn imported_relative_transcript_path_cannot_authorize_compaction() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("mw-compaction-{unique}"));
+    let source_dir = root.join("source");
+    let data_dir = root.join("data");
+    let work_dir = root.join("work");
+    fs::create_dir_all(&source_dir).unwrap();
+    fs::create_dir_all(&work_dir).unwrap();
+
+    let source_db = source_dir.join("memorywhale.sqlite3");
+    let source = Connection::open(&source_db).unwrap();
+    source
+        .execute_batch(
+            "CREATE TABLE sessions (
+                id INTEGER PRIMARY KEY,
+                transcript_path TEXT NOT NULL,
+                transcript TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                ended_at TEXT NOT NULL,
+                byte_count INTEGER NOT NULL,
+                status TEXT NOT NULL);
+             INSERT INTO sessions
+                (transcript_path, transcript, started_at, ended_at, byte_count, status)
+             VALUES
+                ('backing.log', 'recoverable imported transcript',
+                 '2020-01-01T00:00:00Z', '2020-01-01T01:00:00Z', 31, 'finished');",
+        )
+        .unwrap();
+    drop(source);
+
+    fs::write(work_dir.join("backing.log"), "unrelated local file").unwrap();
+
+    let import = Command::new(env!("CARGO_BIN_EXE_mw"))
+        .args(["import", source_db.to_str().unwrap()])
+        .env("MEMORYWHALE_DATA_DIR", &data_dir)
+        .current_dir(&work_dir)
+        .output()
+        .unwrap();
+    assert!(import.status.success(), "mw import failed: {import:?}");
+
+    let compact = Command::new(env!("CARGO_BIN_EXE_mw"))
+        .args([
+            "memory",
+            "compact",
+            "--apply",
+            "--min-session-bytes",
+            "0",
+            "--stale-days",
+            "1",
+        ])
+        .env("MEMORYWHALE_DATA_DIR", &data_dir)
+        .current_dir(&work_dir)
+        .output()
+        .unwrap();
+    assert!(compact.status.success(), "mw compact failed: {compact:?}");
+
+    let destination = Connection::open(data_dir.join("memorywhale.sqlite3")).unwrap();
+    let transcript: String = destination
+        .query_row("SELECT transcript FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(transcript, "recoverable imported transcript");
+
+    drop(destination);
+    fs::remove_dir_all(root).unwrap();
+}

--- a/crates/mw-cli/tests/compaction.rs
+++ b/crates/mw-cli/tests/compaction.rs
@@ -64,3 +64,95 @@ fn command_compaction_converges_on_second_apply() {
     assert!(stdout.len() + stderr.len() <= 256);
     let _ = std::fs::remove_dir_all(data_dir);
 }
+
+#[test]
+fn session_compaction_converges_and_preserves_raw_byte_count() {
+    let data_dir =
+        std::env::temp_dir().join(format!("mw-compaction-session-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&data_dir);
+    std::fs::create_dir_all(&data_dir).unwrap();
+    let raw_path = data_dir.join("session.log");
+    let raw = "transcript\n".repeat(30_000);
+    std::fs::write(&raw_path, &raw).unwrap();
+
+    let remembered = Command::new(env!("CARGO_BIN_EXE_mw-remember"))
+        .args(["--", "seed-session"])
+        .env("MEMORYWHALE_DATA_DIR", &data_dir)
+        .output()
+        .unwrap();
+    assert!(
+        remembered.status.success(),
+        "database setup failed: {remembered:?}"
+    );
+    let conn = Connection::open(data_dir.join("memorywhale.sqlite3")).unwrap();
+    conn.execute(
+        "INSERT INTO sessions
+            (shell, cwd, transcript_path, transcript, notes, started_at, ended_at, byte_count, status)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        rusqlite::params![
+            "/bin/sh",
+            data_dir.to_str().unwrap(),
+            raw_path.to_str().unwrap(),
+            raw,
+            "",
+            "2020-01-01T00:00:00Z",
+            "2020-01-01T01:00:00Z",
+            raw.len() as i64,
+            "finished"
+        ],
+    )
+    .unwrap();
+    drop(conn);
+
+    let first = run_mw(
+        &data_dir,
+        &[
+            "memory",
+            "compact",
+            "--apply",
+            "--min-session-bytes",
+            "1",
+            "--stale-days",
+            "1",
+            "--max-output-bytes",
+            "256",
+        ],
+    );
+    assert!(
+        first.status.success(),
+        "session compaction failed: {first:?}"
+    );
+    assert!(String::from_utf8_lossy(&first.stdout).contains("1 session(s)"));
+
+    let second = run_mw(
+        &data_dir,
+        &[
+            "memory",
+            "compact",
+            "--min-session-bytes",
+            "1",
+            "--stale-days",
+            "1",
+        ],
+    );
+    assert!(
+        second.status.success(),
+        "second session plan failed: {second:?}"
+    );
+    assert!(
+        String::from_utf8_lossy(&second.stdout).contains("0 session(s), 0 command run(s)"),
+        "session compaction is not convergent: {}",
+        String::from_utf8_lossy(&second.stdout)
+    );
+
+    let conn = Connection::open(data_dir.join("memorywhale.sqlite3")).unwrap();
+    let (transcript, byte_count): (String, i64) = conn
+        .query_row("SELECT transcript, byte_count FROM sessions", [], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .unwrap();
+    assert!(transcript.starts_with("[COMPACTED:"));
+    assert_eq!(byte_count, raw.len() as i64);
+    assert_eq!(std::fs::read_to_string(raw_path).unwrap(), raw);
+    let _ = std::fs::remove_dir_all(data_dir);
+}

--- a/crates/mw-cli/tests/compaction.rs
+++ b/crates/mw-cli/tests/compaction.rs
@@ -1,74 +1,66 @@
 use rusqlite::Connection;
-use std::fs;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
+
+fn run_mw(data_dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_mw"))
+        .args(args)
+        .env("MEMORYWHALE_DATA_DIR", data_dir)
+        .output()
+        .unwrap()
+}
 
 #[test]
-fn imported_relative_transcript_path_cannot_authorize_compaction() {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let root = std::env::temp_dir().join(format!("mw-compaction-{unique}"));
-    let source_dir = root.join("source");
-    let data_dir = root.join("data");
-    let work_dir = root.join("work");
-    fs::create_dir_all(&source_dir).unwrap();
-    fs::create_dir_all(&work_dir).unwrap();
-
-    let source_db = source_dir.join("memorywhale.sqlite3");
-    let source = Connection::open(&source_db).unwrap();
-    source
-        .execute_batch(
-            "CREATE TABLE sessions (
-                id INTEGER PRIMARY KEY,
-                transcript_path TEXT NOT NULL,
-                transcript TEXT NOT NULL,
-                started_at TEXT NOT NULL,
-                ended_at TEXT NOT NULL,
-                byte_count INTEGER NOT NULL,
-                status TEXT NOT NULL);
-             INSERT INTO sessions
-                (transcript_path, transcript, started_at, ended_at, byte_count, status)
-             VALUES
-                ('backing.log', 'recoverable imported transcript',
-                 '2020-01-01T00:00:00Z', '2020-01-01T01:00:00Z', 31, 'finished');",
-        )
-        .unwrap();
-    drop(source);
-
-    fs::write(work_dir.join("backing.log"), "unrelated local file").unwrap();
-
-    let import = Command::new(env!("CARGO_BIN_EXE_mw"))
-        .args(["import", source_db.to_str().unwrap()])
-        .env("MEMORYWHALE_DATA_DIR", &data_dir)
-        .current_dir(&work_dir)
-        .output()
-        .unwrap();
-    assert!(import.status.success(), "mw import failed: {import:?}");
-
-    let compact = Command::new(env!("CARGO_BIN_EXE_mw"))
+fn command_compaction_converges_on_second_apply() {
+    let data_dir = std::env::temp_dir().join(format!("mw-compaction-run-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&data_dir);
+    std::fs::create_dir_all(&data_dir).unwrap();
+    let large_output = "x".repeat(4096);
+    let remembered = Command::new(env!("CARGO_BIN_EXE_mw-remember"))
         .args([
-            "memory",
-            "compact",
-            "--apply",
-            "--min-session-bytes",
+            "--stdout",
+            &large_output,
+            "--exit-code",
             "0",
-            "--stale-days",
-            "1",
+            "--",
+            "successful-build",
         ])
         .env("MEMORYWHALE_DATA_DIR", &data_dir)
-        .current_dir(&work_dir)
         .output()
         .unwrap();
-    assert!(compact.status.success(), "mw compact failed: {compact:?}");
+    assert!(
+        remembered.status.success(),
+        "capture failed: {remembered:?}"
+    );
 
-    let destination = Connection::open(data_dir.join("memorywhale.sqlite3")).unwrap();
-    let transcript: String = destination
-        .query_row("SELECT transcript FROM sessions", [], |row| row.get(0))
+    let first = run_mw(
+        &data_dir,
+        &["memory", "compact", "--apply", "--max-output-bytes", "256"],
+    );
+    assert!(first.status.success(), "first compaction failed: {first:?}");
+    let first_text = String::from_utf8_lossy(&first.stdout);
+    assert!(
+        first_text.contains("1 command run(s)"),
+        "nothing compacted: {first_text}"
+    );
+
+    let second = run_mw(
+        &data_dir,
+        &["memory", "compact", "--max-output-bytes", "256"],
+    );
+    assert!(second.status.success(), "second plan failed: {second:?}");
+    let second_text = String::from_utf8_lossy(&second.stdout);
+    assert!(
+        second_text.contains("0 session(s), 0 command run(s)"),
+        "compaction is not convergent: {second_text}"
+    );
+
+    let conn = Connection::open(data_dir.join("memorywhale.sqlite3")).unwrap();
+    let (stdout, stderr): (String, String) = conn
+        .query_row("SELECT stdout, stderr FROM command_runs", [], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
         .unwrap();
-    assert_eq!(transcript, "recoverable imported transcript");
-
-    drop(destination);
-    fs::remove_dir_all(root).unwrap();
+    assert!(stdout.contains("[COMPACTED:"));
+    assert!(stdout.len() + stderr.len() <= 256);
+    let _ = std::fs::remove_dir_all(data_dir);
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ The repository documentation is organized by the question a reader is asking.
 ## Reference: what is the exact interface?
 
 - [CLI and helper binaries](reference/cli.md)
+- [Memory compaction](reference/compaction.md)
 - [Memory pet](reference/pet.md)
 - [MCP tools](reference/mcp.md)
 - [Configuration](reference/configuration.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,6 +29,7 @@ mw rm 5                               # delete a session (+ its transcript); mw 
 mw prune [--min-bytes N] [--dry-run]  # delete empty auto-recorded sessions (noise cleanup)
 mw memory stale <id>                  # retire an outdated lesson, preserving its row
 mw memory supersede <old> <new>       # replace an old lesson with a newer one
+mw memory compact [--apply]           # preview/apply conservative evidence compaction
 mw audit                              # inspect capture policy and retained volume
 mw integrate hermes                   # register mw-mcp in Hermes Agent's config
 mw share 5 [-o file.html]             # write a self-contained HTML page of one item to send someone
@@ -61,6 +62,9 @@ Use `mw memory stale <id>` when advice is no longer current, or
 `mw memory supersede <old-id> <new-id>` when a newer lesson replaces it. Both
 commands preserve the original rows and provenance while excluding retired
 memories from normal retrieval.
+
+See the [memory compaction reference](compaction.md) for the dry-run-first
+policy, protected evidence rules, thresholds, and `--apply` behavior.
 
 `mw context` gives an agent a short digest of recent *failures*; `mw agent`
 dumps a whole *session transcript* as Markdown to hand over later — e.g.

--- a/docs/reference/compaction.md
+++ b/docs/reference/compaction.md
@@ -1,0 +1,64 @@
+# Memory compaction
+
+MemoryWhale's compaction policy shrinks bulky evidence without deleting its
+row. It is intentionally conservative: failures, error-fingerprinted runs,
+and bookmarked runs are protected; large successful output is the first thing
+that becomes compactable.
+
+## Preview a plan
+
+`mw memory compact` is a dry run by default:
+
+```bash
+mw memory compact
+```
+
+It reports sessions and command runs selected by the policy, including the
+rule that selected each one. Nothing changes during a dry run.
+
+## Apply a plan
+
+```bash
+mw memory compact --apply
+```
+
+The default thresholds are:
+
+| Evidence | Default rule |
+| --- | --- |
+| Session transcript | at least 256 KiB and at least 180 elapsed days old, unless an approved lesson makes it eligible after 45 days |
+| Successful command output | combined stdout/stderr over 64 KiB, with no error fingerprint and no bookmark |
+| Failed/error-fingerprinted/bookmarked command | always keep |
+
+Tune the thresholds for a preview or apply:
+
+```bash
+mw memory compact \
+  --min-session-bytes 1048576 \
+  --stale-days 365 \
+  --max-output-bytes 131072
+```
+
+## What compaction preserves
+
+- **Rows are never deleted.** IDs, timestamps, commands, statuses, links, and
+  provenance remain searchable.
+- **Raw session files are not touched.** A compacted session keeps its
+  `transcript_path`; only the inline SQLite transcript becomes a marker.
+- **Command output keeps both ends.** Compacted stdout/stderr retain a head and
+  tail around a `[COMPACTED: … bytes omitted]` marker.
+- **Lessons are not compacted by this command.** A saved lesson is the reason
+  evidence may become compactable; it is the durable summary.
+
+Always run the dry-run first. Export or back up the database before applying a
+large policy change:
+
+```bash
+mw export
+mw memory compact
+mw memory compact --apply
+```
+
+Compaction is local and does not upload data. It is separate from TTL expiry:
+TTL can remove lessons from normal retrieval while preserving their rows;
+compaction reduces bulky evidence while preserving its rows.

--- a/docs/reference/compaction.md
+++ b/docs/reference/compaction.md
@@ -27,7 +27,7 @@ The default thresholds are:
 | Evidence | Default rule |
 | --- | --- |
 | Session transcript | at least 256 KiB and at least 180 elapsed days old, unless an approved lesson makes it eligible after 45 days |
-| Successful command output | combined stdout/stderr over 64 KiB, with no error fingerprint and no bookmark |
+| Successful command output | combined stdout/stderr over 64 KiB, with no error fingerprint and no bookmark; `--max-output-bytes` must be at least 256 |
 | Failed/error-fingerprinted/bookmarked command | always keep |
 
 Tune the thresholds for a preview or apply:
@@ -44,7 +44,11 @@ mw memory compact \
 - **Rows are never deleted.** IDs, timestamps, commands, statuses, links, and
   provenance remain searchable.
 - **Raw session files are not touched.** A compacted session keeps its
-  `transcript_path`; only the inline SQLite transcript becomes a marker.
+  existing absolute `transcript_path`; only the inline SQLite transcript becomes
+  a marker. Sessions whose backing file is unavailable are not selected.
+- **Original byte counts remain.** `sessions.byte_count` continues to describe
+  the raw transcript, so `mw list` and `mw audit` do not underreport retained
+  evidence after compaction.
 - **Command output keeps both ends.** Compacted stdout/stderr retain a head and
   tail around a `[COMPACTED: … bytes omitted]` marker.
 - **Lessons are not compacted by this command.** A saved lesson is the reason


### PR DESCRIPTION
Introduces the first implementation of issue #155 direction: explicit, rule-based evidence compaction.

## Rules of thumb

- Failed commands, error-fingerprinted runs, and bookmarked runs are always kept.
- Large sessions with an approved lesson can compact after one-quarter of the stale window (default 45 days).
- Large sessions older than the stale window compact even without a lesson (default 180 days).
- Large successful output without an error fingerprint or bookmark is compacted first (default 64 KiB).
- Small evidence remains untouched.

## Safety model

`mw memory compact` is dry-run by default. `--apply` is explicit. Rows are never deleted; session raw transcript files are never touched; command output retains head/tail markers; lessons remain intact.

## CLI

```bash
mw memory compact
mw memory compact --apply
mw memory compact --min-session-bytes 1048576 --stale-days 365 --max-output-bytes 131072
```

Added `memorywhale_core::policy` as a pure, unit-tested rulebook plus `docs/reference/compaction.md`.

## Verification

- full core/CLI tests pass (44 core tests, including 16 policy tests)
- clippy `-D warnings` passes
- workspace builds
- docs consistency checks pass
- dry-run smoke test against `mw demo` passes

Closes #155.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `mw memory compact` to preview or apply memory evidence compaction.
  - Compacts eligible session transcripts and large command outputs while preserving records, raw files, and lessons.
  - Supports configurable size, age, and output thresholds with decision reasons.
  - Provides safe UTF-8 head-and-tail truncation and defaults to a no-write preview; use `--apply` to make changes.
  - Excludes unavailable transcript files and enforces a minimum output limit.

- **Bug Fixes**
  - Prevented relative transcript paths from authorizing compaction of unrelated local files.

- **Documentation**
  - Added CLI documentation and a dedicated memory compaction reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->