### PR TITLE
security(desktop): configure restrictive Tauri CSP

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -36,11 +36,13 @@ The Tauri desktop shell uses a restrictive CSP in
 `src-tauri/tauri.conf.json`:
 
 - scripts and default resources are same-origin only;
-- `asset:` and `https://asset.localhost` are allowed for Tauri-bundled assets;
-- `blob:` and `data:` images support locally rendered graph/file content;
+- images and fonts are same-origin only; the current frontend uses inline SVG
+  and `File.text()` rather than Tauri's asset protocol or blob/data URLs;
 - `ipc:` and `http://ipc.localhost` are required for Tauri IPC;
 - inline styles are allowed because the React frontend currently uses inline
   style attributes for dynamic widths and layout values.
+- `base-uri 'none'` prevents injected markup from changing the document base;
+  `form-action 'none'` prevents injected forms from submitting data.
 
 There is no wildcard script source, `unsafe-eval`, or remote script/style
 source. If inline styles are migrated to CSS classes, remove `unsafe-inline`

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -30,6 +30,22 @@ need the same protection as shell history or an unencrypted developer backup.
 - Use `mw rm` for individual deletion and `mw prune --older-than <window>` for
   retention cleanup. Preview bulk cleanup with `--dry-run`.
 
+## Desktop Content Security Policy
+
+The Tauri desktop shell uses a restrictive CSP in
+`src-tauri/tauri.conf.json`:
+
+- scripts and default resources are same-origin only;
+- `asset:` and `https://asset.localhost` are allowed for Tauri-bundled assets;
+- `blob:` and `data:` images support locally rendered graph/file content;
+- `ipc:` and `http://ipc.localhost` are required for Tauri IPC;
+- inline styles are allowed because the React frontend currently uses inline
+  style attributes for dynamic widths and layout values.
+
+There is no wildcard script source, `unsafe-eval`, or remote script/style
+source. If inline styles are migrated to CSS classes, remove `unsafe-inline`
+from `style-src` as a further hardening step.
+
 For a sensitive repository, prefer preventing capture over relying on
 redaction or later deletion.
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https://asset.localhost blob: data:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost"
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https://asset.localhost blob: data:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost"
+      "csp": "default-src 'self'; base-uri 'none'; form-action 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self'; connect-src 'self' ipc: http://ipc.localhost"
     }
   },
   "bundle": {


### PR DESCRIPTION
Closes #151.

## CSP

Replaces `app.security.csp: null` with a narrow policy:

- `default-src` and scripts are same-origin only;
- Tauri bundled assets use `asset:` / `https://asset.localhost`;
- local graph/file rendering may use `blob:` / `data:` images;
- Tauri IPC uses `ipc:` / `http://ipc.localhost`;
- `style-src unsafe-inline` is retained only because the React UI currently uses inline style attributes for dynamic layout values.

No wildcard scripts, `unsafe-eval`, or remote script/style sources are permitted. The security docs explain each non-obvious allowance and note the future hardening step of moving inline styles into CSS classes.

## Verification

- CSP JSON validation rejects null, wildcard, and unsafe-eval
- `npm run build`
- `cargo build --workspace`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened the desktop app’s Content Security Policy by restricting images and fonts to same-origin resources.
  * Disabled unauthorized base URI changes and form submissions.
  * Updated security documentation to reflect permitted resource sources and current inline content usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->