### PR TITLE
fix(storage): surface present-table retrieval failures

### DIFF
--- a/crates/memorywhale-core/src/lib.rs
+++ b/crates/memorywhale-core/src/lib.rs
@@ -6,8 +6,8 @@
 //!
 //! # The core flow
 //!
-//! 1. Build [`Memory`] items — in code, or via [`sqlite::load_memories`] from a
-//!    MemoryWhale database.
+//! 1. Build [`Memory`] items — in code, or via the fallible
+//!    [`sqlite::load_memories`] loader from a MemoryWhale database.
 //! 2. Wrap them in an [`engine::BuiltinEngine`] (the default, zero-setup engine).
 //! 3. Run a [`Query`] through [`engine::MemoryEngine::retrieve`].
 //! 4. Read back [`ScoredMemory`] values: a blended `score`, plus the per-signal

--- a/crates/memorywhale-core/src/sqlite.rs
+++ b/crates/memorywhale-core/src/sqlite.rs
@@ -81,6 +81,8 @@ fn parse_ts(ts: &str) -> DateTime<Utc> {
 pub enum LoadErrorKind {
     /// Reading SQLite schema metadata failed.
     Schema { source: rusqlite::Error },
+    /// A present table has a shape outside the supported compatibility set.
+    UnsupportedSchema { details: String },
     /// Preparing the source query failed. This includes an incompatible
     /// present-table schema (for example, a missing required column).
     Prepare { source: rusqlite::Error },
@@ -117,6 +119,15 @@ impl LoadError {
         }
     }
 
+    fn unsupported_schema(table: &'static str, details: impl Into<String>) -> Self {
+        Self {
+            table,
+            kind: LoadErrorKind::UnsupportedSchema {
+                details: details.into(),
+            },
+        }
+    }
+
     fn query(table: &'static str, source: rusqlite::Error) -> Self {
         Self {
             table,
@@ -137,6 +148,9 @@ impl fmt::Display for LoadError {
         match &self.kind {
             LoadErrorKind::Schema { source } => {
                 write!(f, "failed to inspect {} schema: {source}", self.table)
+            }
+            LoadErrorKind::UnsupportedSchema { details } => {
+                write!(f, "unsupported {} schema: {details}", self.table)
             }
             LoadErrorKind::Prepare { source } => {
                 write!(
@@ -165,6 +179,7 @@ impl Error for LoadError {
             | LoadErrorKind::Prepare { source }
             | LoadErrorKind::Query { source } => Some(source),
             LoadErrorKind::RowDecode { source, .. } => Some(source),
+            LoadErrorKind::UnsupportedSchema { .. } => None,
         }
     }
 }
@@ -208,15 +223,12 @@ fn table_columns(conn: &Connection, table: &'static str) -> Result<Option<Vec<St
         return Ok(None);
     }
 
-    let pragma = match table {
-        "bookmarks" => "PRAGMA table_info(bookmarks)",
-        _ => unreachable!("column metadata is currently only needed for bookmarks"),
-    };
+    let pragma = "SELECT name FROM pragma_table_info(?1)";
     let mut stmt = conn
         .prepare(pragma)
         .map_err(|source| LoadError::schema(table, source))?;
     let mut rows = stmt
-        .query([])
+        .query([table])
         .map_err(|source| LoadError::schema(table, source))?;
     let mut columns = Vec::new();
     while let Some(row) = rows
@@ -224,7 +236,7 @@ fn table_columns(conn: &Connection, table: &'static str) -> Result<Option<Vec<St
         .map_err(|source| LoadError::schema(table, source))?
     {
         columns.push(
-            row.get::<_, String>(1)
+            row.get::<_, String>(0)
                 .map_err(|source| LoadError::schema(table, source))?,
         );
     }
@@ -426,20 +438,21 @@ fn bookmarks(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
             .iter()
             .any(|column| column.eq_ignore_ascii_case(name))
     };
-    let mut predicates = Vec::new();
-    if has_column("approved") {
-        predicates.push("approved = 1");
+    let has_approved = has_column("approved");
+    let has_status = has_column("status");
+    if has_status && !has_approved {
+        return Err(LoadError::unsupported_schema(
+            "bookmarks",
+            "status exists without approved; review filtering cannot be enforced",
+        ));
     }
-    if has_column("status") {
-        predicates.push("status = 'active'");
-    }
-    let sql = if predicates.is_empty() {
-        "SELECT id, label, created_at FROM bookmarks".to_string()
+    let sql = if has_approved && has_status {
+        "SELECT id, label, created_at FROM bookmarks WHERE approved = 1 AND status = 'active'"
+            .to_string()
+    } else if has_approved {
+        "SELECT id, label, created_at FROM bookmarks WHERE approved = 1".to_string()
     } else {
-        format!(
-            "SELECT id, label, created_at FROM bookmarks WHERE {}",
-            predicates.join(" AND ")
-        )
+        "SELECT id, label, created_at FROM bookmarks".to_string()
     };
     let rows = load_rows_existing(conn, "bookmarks", &sql, |r| {
         Ok((
@@ -594,8 +607,8 @@ mod tests {
         assert_eq!(approved_mems.len(), 1);
         assert_eq!(approved_mems[0].text, "approved lesson");
 
-        // A status-only variant still excludes lifecycle-hidden rows while it
-        // has no review column to apply.
+        // A status-only variant is unsupported: it could silently bypass
+        // review-mode filtering, because no released migration creates it.
         let status_only = Connection::open_in_memory().unwrap();
         status_only
             .execute_batch(
@@ -607,9 +620,11 @@ mod tests {
                    (2, 'stale lesson', '2026-01-02T00:00:00Z', 'stale');",
             )
             .unwrap();
-        let status_mems = load_memories(&status_only).unwrap();
-        assert_eq!(status_mems.len(), 1);
-        assert_eq!(status_mems[0].text, "active lesson");
+        let status_error = load_memories(&status_only).unwrap_err();
+        assert!(matches!(
+            status_error.kind,
+            LoadErrorKind::UnsupportedSchema { .. }
+        ));
 
         // A current schema applies both review and lifecycle predicates.
         let current = Connection::open_in_memory().unwrap();

--- a/crates/memorywhale-core/src/sqlite.rs
+++ b/crates/memorywhale-core/src/sqlite.rs
@@ -3,15 +3,17 @@
 //! Both surfaces call this — the desktop app (`documents` + `command_runs` +
 //! `agent_turns`) and the CLI (`sessions` + `command_runs` + `bookmarks`). The
 //! two databases have different tables, so every source is queried
-//! independently and a missing table is treated as zero rows (not an error).
-//! That keeps a single loader honest across both schemas instead of two copies
-//! drifting apart.
+//! independently and an absent optional table is treated as zero rows. Once a
+//! source table is present, however, schema, query, and row errors are returned
+//! to the caller instead of being mistaken for an empty source.
 //!
 //! Ids are namespaced per source so `explain(id)` stays stable and unique
 //! across sources; [`decode_id`] recovers the source + original row id for
 //! display (e.g. `mw replay <id>` / `mw show <id>`).
 
 use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
 
 use chrono::{DateTime, Utc};
 use rusqlite::Connection;
@@ -74,36 +76,227 @@ fn parse_ts(ts: &str) -> DateTime<Utc> {
     }
 }
 
-/// Load everything MemoryWhale remembers as scorable memories, tolerant of any
-/// source table being absent (so it serves both the desktop and CLI schemas).
-pub fn load_memories(conn: &Connection) -> Vec<Memory> {
+/// The stage at which loading a present source failed.
+#[derive(Debug)]
+pub enum LoadErrorKind {
+    /// Reading SQLite schema metadata failed.
+    Schema { source: rusqlite::Error },
+    /// Preparing the source query failed. This includes an incompatible
+    /// present-table schema (for example, a missing required column).
+    Prepare { source: rusqlite::Error },
+    /// Executing or advancing a source query failed.
+    Query { source: rusqlite::Error },
+    /// A row could not be decoded into the source's canonical memory shape.
+    RowDecode { row: usize, source: rusqlite::Error },
+}
+
+/// A structured retrieval-loading failure.
+///
+/// `table` identifies the source whose evidence could not be read. Optional
+/// source tables that are genuinely absent do not produce an error; this type
+/// is reserved for failures after schema inspection finds a source, or for a
+/// failure to inspect that schema.
+#[derive(Debug)]
+pub struct LoadError {
+    pub table: &'static str,
+    pub kind: LoadErrorKind,
+}
+
+impl LoadError {
+    fn schema(table: &'static str, source: rusqlite::Error) -> Self {
+        Self {
+            table,
+            kind: LoadErrorKind::Schema { source },
+        }
+    }
+
+    fn prepare(table: &'static str, source: rusqlite::Error) -> Self {
+        Self {
+            table,
+            kind: LoadErrorKind::Prepare { source },
+        }
+    }
+
+    fn query(table: &'static str, source: rusqlite::Error) -> Self {
+        Self {
+            table,
+            kind: LoadErrorKind::Query { source },
+        }
+    }
+
+    fn row_decode(table: &'static str, row: usize, source: rusqlite::Error) -> Self {
+        Self {
+            table,
+            kind: LoadErrorKind::RowDecode { row, source },
+        }
+    }
+}
+
+impl fmt::Display for LoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            LoadErrorKind::Schema { source } => {
+                write!(f, "failed to inspect {} schema: {source}", self.table)
+            }
+            LoadErrorKind::Prepare { source } => {
+                write!(
+                    f,
+                    "failed to prepare {} retrieval query: {source}",
+                    self.table
+                )
+            }
+            LoadErrorKind::Query { source } => {
+                write!(f, "failed to query {}: {source}", self.table)
+            }
+            LoadErrorKind::RowDecode { row, source } => write!(
+                f,
+                "failed to decode row {} from {}: {source}",
+                row + 1,
+                self.table
+            ),
+        }
+    }
+}
+
+impl Error for LoadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match &self.kind {
+            LoadErrorKind::Schema { source }
+            | LoadErrorKind::Prepare { source }
+            | LoadErrorKind::Query { source } => Some(source),
+            LoadErrorKind::RowDecode { source, .. } => Some(source),
+        }
+    }
+}
+
+/// Load everything MemoryWhale remembers as scorable memories, tolerant of
+/// optional source tables being absent (so it serves both desktop and CLI
+/// schemas). A present source that cannot be read is an error.
+pub fn load_memories(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
     let mut mems = Vec::new();
-    mems.extend(documents(conn));
-    mems.extend(command_runs(conn));
-    mems.extend(agent_turns(conn));
-    mems.extend(bookmarks(conn));
-    mems.extend(sessions(conn));
-    mems
+    mems.extend(documents(conn)?);
+    mems.extend(command_runs(conn)?);
+    mems.extend(agent_turns(conn)?);
+    mems.extend(bookmarks(conn)?);
+    mems.extend(sessions(conn)?);
+    Ok(mems)
+}
+
+/// Check SQLite's schema catalogs rather than using a failed source prepare as
+/// the missing-table signal. Include temporary tables because callers/tests may
+/// use a temporary source on an otherwise ordinary connection.
+fn table_exists(conn: &Connection, table: &'static str) -> Result<bool, LoadError> {
+    conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM sqlite_master
+              WHERE type IN ('table', 'view') AND name COLLATE NOCASE = ?1
+             UNION ALL
+             SELECT 1 FROM sqlite_temp_master
+              WHERE type IN ('table', 'view') AND name COLLATE NOCASE = ?1
+         )",
+        [table],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|present| present != 0)
+    .map_err(|source| LoadError::schema(table, source))
+}
+
+/// Read a present table's column names. The bookmark loader uses this metadata
+/// to choose the supported legacy filtering shape before preparing SQL.
+fn table_columns(conn: &Connection, table: &'static str) -> Result<Option<Vec<String>>, LoadError> {
+    if !table_exists(conn, table)? {
+        return Ok(None);
+    }
+
+    let pragma = match table {
+        "bookmarks" => "PRAGMA table_info(bookmarks)",
+        _ => unreachable!("column metadata is currently only needed for bookmarks"),
+    };
+    let mut stmt = conn
+        .prepare(pragma)
+        .map_err(|source| LoadError::schema(table, source))?;
+    let mut rows = stmt
+        .query([])
+        .map_err(|source| LoadError::schema(table, source))?;
+    let mut columns = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .map_err(|source| LoadError::schema(table, source))?
+    {
+        columns.push(
+            row.get::<_, String>(1)
+                .map_err(|source| LoadError::schema(table, source))?,
+        );
+    }
+    Ok(Some(columns))
+}
+
+/// Read a present source table. Keeping query execution and row decoding
+/// separate means a database/locking failure while stepping the query is not
+/// reported as a bad row.
+fn load_rows_existing<T, F>(
+    conn: &Connection,
+    table: &'static str,
+    sql: &str,
+    mut decode: F,
+) -> Result<Vec<T>, LoadError>
+where
+    F: FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
+{
+    let mut stmt = conn
+        .prepare(sql)
+        .map_err(|source| LoadError::prepare(table, source))?;
+    let mut rows = stmt
+        .query([])
+        .map_err(|source| LoadError::query(table, source))?;
+    let mut decoded = Vec::new();
+    let mut row_number = 0;
+    while let Some(row) = rows
+        .next()
+        .map_err(|source| LoadError::query(table, source))?
+    {
+        decoded
+            .push(decode(row).map_err(|source| LoadError::row_decode(table, row_number, source))?);
+        row_number += 1;
+    }
+    Ok(decoded)
+}
+
+/// Read an optional source table after its existence has been established from
+/// schema metadata.
+fn load_rows<T, F>(
+    conn: &Connection,
+    table: &'static str,
+    sql: &str,
+    decode: F,
+) -> Result<Vec<T>, LoadError>
+where
+    F: FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
+{
+    if !table_exists(conn, table)? {
+        return Ok(Vec::new());
+    }
+    load_rows_existing(conn, table, sql, decode)
 }
 
 /// Documents / notes (desktop). `text` = title + content.
-fn documents(conn: &Connection) -> Vec<Memory> {
-    let Ok(mut stmt) =
-        conn.prepare("SELECT id, title, content, source_type, created_at FROM documents")
-    else {
-        return Vec::new();
-    };
-    let rows = stmt.query_map([], |r| {
-        Ok((
-            r.get::<_, i64>(0)?,
-            r.get::<_, String>(1)?,
-            r.get::<_, String>(2)?,
-            r.get::<_, String>(3)?,
-            r.get::<_, String>(4)?,
-        ))
-    });
-    let Ok(rows) = rows else { return Vec::new() };
-    rows.flatten()
+fn documents(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
+    let rows = load_rows(
+        conn,
+        "documents",
+        "SELECT id, title, content, source_type, created_at FROM documents",
+        |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, String>(3)?,
+                r.get::<_, String>(4)?,
+            ))
+        },
+    )?;
+    Ok(rows
+        .into_iter()
         .map(|(id, title, content, source_type, created)| {
             let when = parse_ts(&created);
             Memory {
@@ -117,35 +310,34 @@ fn documents(conn: &Connection) -> Vec<Memory> {
                 embedding: None,
             }
         })
-        .collect()
+        .collect())
 }
 
 /// Command runs (both). Reinforcement = how often the same command recurs;
 /// failures are more important than successes.
-fn command_runs(conn: &Connection) -> Vec<Memory> {
-    let Ok(mut stmt) = conn.prepare(
+fn command_runs(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
+    let rows = load_rows(
+        conn,
+        "command_runs",
         "SELECT id, command, argv_json, notes, stderr, exit_code, created_at FROM command_runs",
-    ) else {
-        return Vec::new();
-    };
-    let rows = stmt.query_map([], |r| {
-        Ok((
-            r.get::<_, i64>(0)?,
-            r.get::<_, String>(1)?,
-            r.get::<_, String>(2)?,
-            r.get::<_, String>(3)?,
-            r.get::<_, String>(4)?,
-            r.get::<_, Option<i64>>(5)?,
-            r.get::<_, String>(6)?,
-        ))
-    });
-    let Ok(rows) = rows else { return Vec::new() };
-    let runs: Vec<_> = rows.flatten().collect();
+        |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, String>(3)?,
+                r.get::<_, String>(4)?,
+                r.get::<_, Option<i64>>(5)?,
+                r.get::<_, String>(6)?,
+            ))
+        },
+    )?;
     let mut counts: HashMap<String, u32> = HashMap::new();
-    for (_, cmd, ..) in &runs {
+    for (_, cmd, ..) in &rows {
         *counts.entry(cmd.to_lowercase()).or_insert(0) += 1;
     }
-    runs.into_iter()
+    Ok(rows
+        .into_iter()
         .map(
             |(id, command, argv_json, notes, stderr, exit_code, created)| {
                 let when = parse_ts(&created);
@@ -169,32 +361,33 @@ fn command_runs(conn: &Connection) -> Vec<Memory> {
                 }
             },
         )
-        .collect()
+        .collect())
 }
 
 /// Agent conversation turns (desktop; written by Delphin / hooks).
-fn agent_turns(conn: &Connection) -> Vec<Memory> {
-    let Ok(mut stmt) = conn.prepare("SELECT id, ts, direction, text FROM agent_turns") else {
-        return Vec::new();
-    };
-    let rows = stmt.query_map([], |r| {
-        Ok((
-            r.get::<_, i64>(0)?,
-            r.get::<_, String>(1)?,
-            r.get::<_, String>(2)?,
-            r.get::<_, String>(3)?,
-        ))
-    });
-    let Ok(rows) = rows else { return Vec::new() };
+fn agent_turns(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
+    let rows = load_rows(
+        conn,
+        "agent_turns",
+        "SELECT id, ts, direction, text FROM agent_turns",
+        |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, String>(3)?,
+            ))
+        },
+    )?;
     let turns: Vec<_> = rows
-        .flatten()
+        .into_iter()
         .filter(|(_, _, _, t)| !t.trim().is_empty())
         .collect();
     let mut counts: HashMap<String, u32> = HashMap::new();
     for (_, _, _, t) in &turns {
         *counts.entry(t.trim().to_lowercase()).or_insert(0) += 1;
     }
-    turns
+    Ok(turns
         .into_iter()
         .map(|(id, ts, direction, text)| {
             let when = parse_ts(&ts);
@@ -215,38 +408,48 @@ fn agent_turns(conn: &Connection) -> Vec<Memory> {
                 embedding: None,
             }
         })
-        .collect()
+        .collect())
 }
 
 /// Remembered lessons / bookmarks (CLI `mw mark` / `mw remember`).
-fn bookmarks(conn: &Connection) -> Vec<Memory> {
+fn bookmarks(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
     // Review mode is enforced at write time (agent notes land with approved=0),
-    // so every reader just filters approved=1 — one rule, no config lookup here.
-    // Older DBs predating the provenance migration have no `approved` column;
-    // there the prepare fails and we fall back to loading everything.
-    let mut stmt = match conn.prepare(
-        "SELECT id, label, created_at FROM bookmarks WHERE approved = 1 AND status = 'active'",
-    ) {
-        Ok(stmt) => stmt,
-        Err(_) => {
-            match conn.prepare("SELECT id, label, created_at FROM bookmarks WHERE approved = 1") {
-                Ok(stmt) => stmt,
-                Err(_) => match conn.prepare("SELECT id, label, created_at FROM bookmarks") {
-                    Ok(stmt) => stmt,
-                    Err(_) => return Vec::new(),
-                },
-            }
-        }
+    // so every reader filters approved=1 when that column exists. Lifecycle
+    // filtering is likewise applied only when the status column exists. Older
+    // databases are selected from schema metadata, not by treating an
+    // arbitrary prepare error as a legacy-schema signal.
+    let Some(columns) = table_columns(conn, "bookmarks")? else {
+        return Ok(Vec::new());
     };
-    let rows = stmt.query_map([], |r| {
+    let has_column = |name: &str| {
+        columns
+            .iter()
+            .any(|column| column.eq_ignore_ascii_case(name))
+    };
+    let mut predicates = Vec::new();
+    if has_column("approved") {
+        predicates.push("approved = 1");
+    }
+    if has_column("status") {
+        predicates.push("status = 'active'");
+    }
+    let sql = if predicates.is_empty() {
+        "SELECT id, label, created_at FROM bookmarks".to_string()
+    } else {
+        format!(
+            "SELECT id, label, created_at FROM bookmarks WHERE {}",
+            predicates.join(" AND ")
+        )
+    };
+    let rows = load_rows_existing(conn, "bookmarks", &sql, |r| {
         Ok((
             r.get::<_, i64>(0)?,
             r.get::<_, String>(1)?,
             r.get::<_, String>(2)?,
         ))
-    });
-    let Ok(rows) = rows else { return Vec::new() };
-    rows.flatten()
+    })?;
+    Ok(rows
+        .into_iter()
         .filter(|(_, label, _)| !label.trim().is_empty())
         .map(|(id, label, created)| {
             let when = parse_ts(&created);
@@ -261,26 +464,27 @@ fn bookmarks(conn: &Connection) -> Vec<Memory> {
                 embedding: None,
             }
         })
-        .collect()
+        .collect())
 }
 
 /// Recorded terminal sessions (CLI). `text` = notes + cleaned transcript, so
 /// the same content `mw search` used to LIKE-match still drives similarity.
-fn sessions(conn: &Connection) -> Vec<Memory> {
-    let Ok(mut stmt) = conn.prepare("SELECT id, notes, transcript, started_at FROM sessions")
-    else {
-        return Vec::new();
-    };
-    let rows = stmt.query_map([], |r| {
-        Ok((
-            r.get::<_, i64>(0)?,
-            r.get::<_, String>(1)?,
-            r.get::<_, String>(2)?,
-            r.get::<_, String>(3)?,
-        ))
-    });
-    let Ok(rows) = rows else { return Vec::new() };
-    rows.flatten()
+fn sessions(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
+    let rows = load_rows(
+        conn,
+        "sessions",
+        "SELECT id, notes, transcript, started_at FROM sessions",
+        |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, String>(3)?,
+            ))
+        },
+    )?;
+    Ok(rows
+        .into_iter()
         .filter_map(|(id, notes, transcript, started)| {
             let text = format!("{notes}\n{transcript}").trim().to_string();
             if text.is_empty() {
@@ -298,7 +502,7 @@ fn sessions(conn: &Connection) -> Vec<Memory> {
                 embedding: None,
             })
         })
-        .collect()
+        .collect())
 }
 
 #[cfg(test)]
@@ -339,7 +543,7 @@ mod tests {
 
     #[test]
     fn tolerates_missing_tables_and_namespaces_ids() {
-        let mems = load_memories(&fixture());
+        let mems = load_memories(&fixture()).unwrap();
         // 2 command_runs + 1 bookmark; documents/agent_turns/sessions absent.
         assert_eq!(mems.len(), 3);
         assert!(mems.iter().any(|m| decode_id(m.id) == (Source::Command, 1)));
@@ -350,6 +554,116 @@ mod tests {
             .find(|m| decode_id(m.id) == (Source::Command, 1))
             .unwrap();
         assert_eq!(cmd.mentions, 2);
+    }
+
+    #[test]
+    fn empty_database_has_no_optional_sources_and_no_error() {
+        let conn = Connection::open_in_memory().unwrap();
+        assert!(load_memories(&conn).unwrap().is_empty());
+    }
+
+    #[test]
+    fn bookmarks_preserve_legacy_variants_and_current_filters() {
+        // Pre-provenance bookmarks have neither filtering column and remain
+        // readable as long as their canonical columns are present.
+        let legacy = Connection::open_in_memory().unwrap();
+        legacy
+            .execute_batch(
+                "CREATE TABLE bookmarks (id INTEGER PRIMARY KEY, label TEXT, created_at TEXT);
+                 INSERT INTO bookmarks VALUES
+                   (1, 'legacy lesson', '2026-01-01T00:00:00Z');",
+            )
+            .unwrap();
+        let legacy_mems = load_memories(&legacy).unwrap();
+        assert_eq!(legacy_mems.len(), 1);
+        assert_eq!(legacy_mems[0].text, "legacy lesson");
+
+        // The intermediate schema had approval but not lifecycle status.
+        let approved_only = Connection::open_in_memory().unwrap();
+        approved_only
+            .execute_batch(
+                "CREATE TABLE bookmarks (
+                     id INTEGER PRIMARY KEY, label TEXT, created_at TEXT, approved INTEGER
+                 );
+                 INSERT INTO bookmarks VALUES
+                   (1, 'approved lesson', '2026-01-01T00:00:00Z', 1),
+                   (2, 'pending lesson', '2026-01-02T00:00:00Z', 0);",
+            )
+            .unwrap();
+        let approved_mems = load_memories(&approved_only).unwrap();
+        assert_eq!(approved_mems.len(), 1);
+        assert_eq!(approved_mems[0].text, "approved lesson");
+
+        // A status-only variant still excludes lifecycle-hidden rows while it
+        // has no review column to apply.
+        let status_only = Connection::open_in_memory().unwrap();
+        status_only
+            .execute_batch(
+                "CREATE TABLE bookmarks (
+                     id INTEGER PRIMARY KEY, label TEXT, created_at TEXT, status TEXT
+                 );
+                 INSERT INTO bookmarks VALUES
+                   (1, 'active lesson', '2026-01-01T00:00:00Z', 'active'),
+                   (2, 'stale lesson', '2026-01-02T00:00:00Z', 'stale');",
+            )
+            .unwrap();
+        let status_mems = load_memories(&status_only).unwrap();
+        assert_eq!(status_mems.len(), 1);
+        assert_eq!(status_mems[0].text, "active lesson");
+
+        // A current schema applies both review and lifecycle predicates.
+        let current = Connection::open_in_memory().unwrap();
+        current
+            .execute_batch(
+                "CREATE TABLE bookmarks (
+                     id INTEGER PRIMARY KEY, label TEXT, created_at TEXT,
+                     approved INTEGER, status TEXT
+                 );
+                 INSERT INTO bookmarks VALUES
+                   (1, 'active approved', '2026-01-01T00:00:00Z', 1, 'active'),
+                   (2, 'pending active', '2026-01-02T00:00:00Z', 0, 'active'),
+                   (3, 'released stale', '2026-01-03T00:00:00Z', 1, 'stale');",
+            )
+            .unwrap();
+        let current_mems = load_memories(&current).unwrap();
+        assert_eq!(current_mems.len(), 1);
+        assert_eq!(current_mems[0].text, "active approved");
+    }
+
+    #[test]
+    fn malformed_present_rows_return_a_structured_decode_error() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE command_runs (
+                 id INTEGER PRIMARY KEY, command TEXT, argv_json TEXT,
+                 notes TEXT, stderr TEXT, exit_code INTEGER, created_at TEXT
+             );
+             INSERT INTO command_runs VALUES
+                 (1, NULL, '[]', '', '', 1, '2026-01-01T00:00:00Z');",
+        )
+        .unwrap();
+
+        let error = load_memories(&conn).unwrap_err();
+        assert_eq!(error.table, "command_runs");
+        assert!(matches!(
+            error.kind,
+            LoadErrorKind::RowDecode { row: 0, .. }
+        ));
+        assert!(error.to_string().contains("command_runs"));
+    }
+
+    #[test]
+    fn invalid_present_schema_returns_a_structured_prepare_error() {
+        let conn = Connection::open_in_memory().unwrap();
+        // `documents` is present, so its incompatible shape must not be
+        // mistaken for the desktop source being absent.
+        conn.execute_batch("CREATE TABLE documents (id INTEGER PRIMARY KEY, title TEXT);")
+            .unwrap();
+
+        let error = load_memories(&conn).unwrap_err();
+        assert_eq!(error.table, "documents");
+        assert!(matches!(error.kind, LoadErrorKind::Prepare { .. }));
+        assert!(error.to_string().contains("documents"));
     }
 
     #[test]
@@ -376,8 +690,8 @@ mod tests {
 
         // Two independently constructed engines standing in for the two
         // surfaces; both go through the shared loader with the same `now`.
-        let cli = BuiltinEngine::new(load_memories(&conn));
-        let desktop = BuiltinEngine::new(load_memories(&conn));
+        let cli = BuiltinEngine::new(load_memories(&conn).unwrap());
+        let desktop = BuiltinEngine::new(load_memories(&conn).unwrap());
         let q = Query::new("linker failure", now);
 
         let cli_rank: Vec<(i64, u32)> = cli

--- a/crates/mw-cli/examples/shortcut_eval.rs
+++ b/crates/mw-cli/examples/shortcut_eval.rs
@@ -121,16 +121,20 @@ fn seed_failure(conn: &Connection, task: &Task, now: DateTime<Utc>) {
 
 /// Rank a query through the same loader + engine the CLI and MCP use, returning
 /// the retrieved *note* ids (decoded) in engine order.
-fn ranked_notes(conn: &Connection, query: &str, now: DateTime<Utc>) -> Vec<i64> {
-    let engine = BuiltinEngine::new(load_memories(conn));
-    engine
+fn ranked_notes(
+    conn: &Connection,
+    query: &str,
+    now: DateTime<Utc>,
+) -> Result<Vec<i64>, memorywhale_core::sqlite::LoadError> {
+    let engine = BuiltinEngine::new(load_memories(conn)?);
+    Ok(engine
         .retrieve(&Query::new(query, now), 20)
         .into_iter()
         .filter_map(|s| match decode_id(s.memory.id) {
             (Source::Note, real) => Some(real),
             _ => None,
         })
-        .collect()
+        .collect())
 }
 
 #[derive(Serialize)]
@@ -190,7 +194,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let sf_shortcut = recognized && insight.resolutions > 0;
 
         // search_memory path.
-        let ranked = ranked_notes(&conn, &task.query, now);
+        let ranked = ranked_notes(&conn, &task.query, now)?;
         let sm_at_1 = mw::fix_surfaced(&ranked, &task.fix_ids, 1);
         let sm_at_5 = mw::fix_surfaced(&ranked, &task.fix_ids, 5);
 

--- a/crates/mw-cli/src/bin/mw-mcp.rs
+++ b/crates/mw-cli/src/bin/mw-mcp.rs
@@ -179,7 +179,8 @@ fn recent_errors(limit: i64) -> Result<String, String> {
     let conn = open()?;
     // A brand-new store has only the bookmarks table; `command_runs` appears
     // once something is recorded. Treat its absence as "no failures yet" (same
-    // graceful-read convention as `load_memories`) rather than erroring.
+    // graceful-read convention for absent optional source tables rather than
+    // erroring. Present-table loader failures are surfaced to the MCP caller.
     let Ok(mut stmt) = conn.prepare(
         "SELECT argv_json, cwd, exit_code, stderr, notes, created_at
              FROM command_runs
@@ -293,7 +294,8 @@ fn search_memory(
     // Unscoped (no project/machine) leaves the memory set untouched.
     let mems = memorywhale_cli::scope_memories(
         &conn,
-        memorywhale_core::sqlite::load_memories(&conn),
+        memorywhale_core::sqlite::load_memories(&conn)
+            .map_err(|e| format!("failed to load memories: {e}"))?,
         project,
         machine,
         None,
@@ -336,7 +338,8 @@ fn get_context(project: Option<&str>, machine: Option<&str>) -> Result<String, S
     let scope = project.map(|p| p.trim_start_matches("project:"));
     let mems = memorywhale_cli::scope_memories(
         &conn,
-        memorywhale_core::sqlite::load_memories(&conn),
+        memorywhale_core::sqlite::load_memories(&conn)
+            .map_err(|e| format!("failed to load memories: {e}"))?,
         scope.filter(|s| !s.is_empty()),
         machine,
         None,

--- a/crates/mw-cli/src/bin/mw-mcp.rs
+++ b/crates/mw-cli/src/bin/mw-mcp.rs
@@ -177,18 +177,27 @@ fn call_tool(name: &str, args: &Value, client_name: Option<&str>) -> Result<Stri
 
 fn recent_errors(limit: i64) -> Result<String, String> {
     let conn = open()?;
+    let has_command_runs: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'command_runs')",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(|e| e.to_string())?;
     // A brand-new store has only the bookmarks table; `command_runs` appears
-    // once something is recorded. Treat its absence as "no failures yet" (same
-    // graceful-read convention for absent optional source tables rather than
-    // erroring. Present-table loader failures are surfaced to the MCP caller.
-    let Ok(mut stmt) = conn.prepare(
-        "SELECT argv_json, cwd, exit_code, stderr, notes, created_at
+    // once something is recorded. Treat only its absence as "no failures yet";
+    // present-table preparation/query/row errors remain visible to MCP callers.
+    if !has_command_runs {
+        return Ok("(no failed commands recorded)".to_string());
+    }
+    let mut stmt = conn
+        .prepare(
+            "SELECT argv_json, cwd, exit_code, stderr, notes, created_at
              FROM command_runs
              WHERE exit_code IS NOT NULL AND exit_code != 0
              ORDER BY id DESC LIMIT ?1",
-    ) else {
-        return Ok("(no failed commands recorded)".to_string());
-    };
+        )
+        .map_err(|e| e.to_string())?;
     let rows = stmt
         .query_map(params![limit], |r| {
             Ok((

--- a/crates/mw-cli/src/bin/mw-mcp.rs
+++ b/crates/mw-cli/src/bin/mw-mcp.rs
@@ -179,8 +179,11 @@ fn recent_errors(limit: i64) -> Result<String, String> {
     let conn = open()?;
     let has_command_runs: bool = conn
         .query_row(
-            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'command_runs')",
-            [],
+            "SELECT EXISTS(
+                 SELECT 1 FROM sqlite_master
+                  WHERE type IN ('table', 'view') AND name COLLATE NOCASE = ?1
+             )",
+            ["command_runs"],
             |r| r.get(0),
         )
         .map_err(|e| e.to_string())?;

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -1193,16 +1193,22 @@ fn remember_cmd(args: &[String]) -> Result<(), String> {
     // be opened here, skip the check and let `remember` surface the real error.
     if !force {
         if let Ok(conn) = open_session_db() {
-            let mems = memorywhale_core::sqlite::load_memories(&conn);
-            if let Some((sim, existing)) = memorywhale_cli::nearest_similar(&mems, &text) {
-                if sim >= memorywhale_cli::DEDUP_SIMILARITY {
-                    let snippet: String = existing.text.chars().take(100).collect();
-                    return Err(format!(
-                        "a similar memory already exists (#{} · {:.0}% overlap):\n  \"{}\"\nnot saved (near-duplicate). Re-run with `mw remember --force` to save it anyway.",
-                        existing.id,
-                        sim * 100.0,
-                        memorywhale_cli::redact(&snippet),
-                    ));
+            match memorywhale_core::sqlite::load_memories(&conn) {
+                Ok(mems) => {
+                    if let Some((sim, existing)) = memorywhale_cli::nearest_similar(&mems, &text) {
+                        if sim >= memorywhale_cli::DEDUP_SIMILARITY {
+                            let snippet: String = existing.text.chars().take(100).collect();
+                            return Err(format!(
+                                "a similar memory already exists (#{} · {:.0}% overlap):\n  \"{}\"\nnot saved (near-duplicate). Re-run with `mw remember --force` to save it anyway.",
+                                existing.id,
+                                sim * 100.0,
+                                memorywhale_cli::redact(&snippet),
+                            ));
+                        }
+                    }
+                }
+                Err(error) => {
+                    eprintln!("mw: could not check for duplicate memories; continuing: {error}")
                 }
             }
         }
@@ -2424,7 +2430,8 @@ fn sync_mempalace(args: &[String]) -> Result<(), String> {
 
     let mut conn = open_session_db()?;
     memorywhale_cli::migrate(&conn)?; // brings up the mempalace_sync table (v5)
-    let mut mems = memorywhale_core::sqlite::load_memories(&conn);
+    let mut mems = memorywhale_core::sqlite::load_memories(&conn)
+        .map_err(|e| format!("failed to load memories for sync: {e}"))?;
     if limit > 0 && mems.len() > limit {
         mems.truncate(limit);
     }
@@ -2627,7 +2634,8 @@ fn search_memory(args: &[String]) -> Result<(), String> {
     // One loader, one engine — the same code path the desktop Recall panel uses.
     // "now" is supplied here by the caller so scoring stays deterministic.
     let now = Utc::now();
-    let mems = memorywhale_core::sqlite::load_memories(&conn);
+    let mems = memorywhale_core::sqlite::load_memories(&conn)
+        .map_err(|e| format!("failed to load memories for search: {e}"))?;
     // No flags => `mems` comes back untouched, i.e. exactly the old behaviour.
     let mems = memorywhale_cli::scope_memories(
         &conn,
@@ -3437,7 +3445,8 @@ fn explain_cmd(args: &[String]) -> Result<(), String> {
     // scoring stays deterministic.
     let conn = open_session_db()?;
     let now = Utc::now();
-    let mems = memorywhale_core::sqlite::load_memories(&conn);
+    let mems = memorywhale_core::sqlite::load_memories(&conn)
+        .map_err(|e| format!("failed to load memories for explain: {e}"))?;
     let mems = memorywhale_cli::scope_memories(
         &conn,
         mems,
@@ -3466,11 +3475,12 @@ fn explain_cmd(args: &[String]) -> Result<(), String> {
 /// and to render neighbor text.
 fn memory_map(
     conn: &rusqlite::Connection,
-) -> std::collections::HashMap<i64, memorywhale_core::Memory> {
-    memorywhale_core::sqlite::load_memories(conn)
+) -> Result<std::collections::HashMap<i64, memorywhale_core::Memory>, String> {
+    Ok(memorywhale_core::sqlite::load_memories(conn)
+        .map_err(|e| format!("failed to load memories for links: {e}"))?
         .into_iter()
         .map(|m| (m.id, m))
-        .collect()
+        .collect())
 }
 
 fn parse_link_id(arg: &str) -> Result<i64, String> {
@@ -3492,7 +3502,7 @@ fn link_cmd(args: &[String]) -> Result<(), String> {
         _ => return Err("usage: mw link <a> <b> [rel:<type>]".to_string()),
     };
     let conn = open_session_db()?;
-    let known = memory_map(&conn);
+    let known = memory_map(&conn)?;
     for id in [a, b] {
         if !known.contains_key(&id) {
             return Err(format!(
@@ -3533,7 +3543,7 @@ fn links_cmd(args: &[String]) -> Result<(), String> {
         _ => return Err("usage: mw links <id>".to_string()),
     };
     let conn = open_session_db()?;
-    let map = memory_map(&conn);
+    let map = memory_map(&conn)?;
     if !map.contains_key(&id) {
         return Err(format!(
             "no memory with id {id} (list ids with `mw search`)"
@@ -3565,8 +3575,9 @@ struct PetSnapshot {
     expired: i64,
 }
 
-fn pet_snapshot(conn: &rusqlite::Connection) -> PetSnapshot {
-    let mems = memorywhale_core::sqlite::load_memories(conn);
+fn pet_snapshot(conn: &rusqlite::Connection) -> Result<PetSnapshot, String> {
+    let mems = memorywhale_core::sqlite::load_memories(conn)
+        .map_err(|e| format!("failed to load memories for pet: {e}"))?;
     let total = mems.len();
     let now = Utc::now();
     let days = mems
@@ -3584,12 +3595,12 @@ fn pet_snapshot(conn: &rusqlite::Connection) -> PetSnapshot {
             |r| r.get(0),
         )
         .unwrap_or(0);
-    PetSnapshot {
+    Ok(PetSnapshot {
         total,
         days,
         links,
         expired,
-    }
+    })
 }
 
 /// Render one frame of the whale. `tick` animates the swim/spout/blink; pass 0
@@ -3653,11 +3664,11 @@ fn pet_cmd(args: &[String]) -> Result<(), String> {
     let conn = open_session_db()?;
     if args.iter().any(|a| a == "--watch") {
         use std::io::Write;
-        let mut snap = pet_snapshot(&conn);
+        let mut snap = pet_snapshot(&conn)?;
         let mut tick: u64 = 0;
         loop {
             if tick.is_multiple_of(10) {
-                snap = pet_snapshot(&conn); // refresh the store every ~2.5s
+                snap = pet_snapshot(&conn)?; // refresh the store every ~2.5s
             }
             print!("\x1b[2J\x1b[H{}", pet_frame(&snap, tick));
             let _ = std::io::stdout().flush();
@@ -3665,7 +3676,7 @@ fn pet_cmd(args: &[String]) -> Result<(), String> {
             tick += 1;
         }
     }
-    println!("{}", pet_frame(&pet_snapshot(&conn), 0));
+    println!("{}", pet_frame(&pet_snapshot(&conn)?, 0));
     Ok(())
 }
 

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -1825,7 +1825,7 @@ mod tests {
 
         let now = Utc.with_ymd_and_hms(2026, 7, 19, 12, 0, 0).unwrap();
         let rank = |q: &str| -> Vec<i64> {
-            let eng = BuiltinEngine::new(load_memories(&conn));
+            let eng = BuiltinEngine::new(load_memories(&conn).unwrap());
             eng.retrieve(&Query::new(q, now), 20)
                 .into_iter()
                 .filter_map(|s| match decode_id(s.memory.id) {
@@ -2273,7 +2273,7 @@ mod tests {
         // Assert through the REAL retrieval path — the shared loader every
         // surface (mw search, MCP, desktop) goes through — not a re-implemented
         // query, so this test fails if the loader ever drops the approved filter.
-        let loaded = memorywhale_core::sqlite::load_memories(&conn);
+        let loaded = memorywhale_core::sqlite::load_memories(&conn).unwrap();
         let visible: Vec<i64> = loaded
             .iter()
             .filter_map(|m| match memorywhale_core::sqlite::decode_id(m.id) {
@@ -2404,6 +2404,7 @@ mod tests {
         assert_eq!(kept, ("superseded".to_string(), Some(replacement)));
 
         let visible: Vec<i64> = memorywhale_core::sqlite::load_memories(&conn)
+            .unwrap()
             .into_iter()
             .filter_map(
                 |memory| match memorywhale_core::sqlite::decode_id(memory.id) {
@@ -2457,7 +2458,7 @@ mod tests {
         assert_eq!(notes, legacy_notes, "original notes must survive untouched");
 
         // Scoped retrieval now works through the shared loader + scope filter.
-        let mems = memorywhale_core::sqlite::load_memories(&conn);
+        let mems = memorywhale_core::sqlite::load_memories(&conn).unwrap();
         assert_eq!(mems.len(), 2);
         let scoped = scope_memories(&conn, mems.clone(), Some("camera-driver"), None, None);
         assert_eq!(scoped.len(), 1);

--- a/crates/mw-cli/src/storage.rs
+++ b/crates/mw-cli/src/storage.rs
@@ -252,7 +252,7 @@ mod tests {
             assert_eq!(count, expected, "{table} rows changed during upgrade");
         }
 
-        let memories = memorywhale_core::sqlite::load_memories(&conn);
+        let memories = memorywhale_core::sqlite::load_memories(&conn).unwrap();
         assert!(
             memories
                 .iter()

--- a/crates/mw-cli/src/tui.rs
+++ b/crates/mw-cli/src/tui.rs
@@ -576,7 +576,7 @@ pub fn run() -> Result<(), String> {
     let conn = Connection::open(crate::database_path()?)
         .map_err(|e| format!("failed to open memory db: {e}"))?;
     let _ = crate::migrate(&conn);
-    let mems = load_memories(&conn);
+    let mems = load_memories(&conn).map_err(|e| format!("failed to load memories for TUI: {e}"))?;
     if mems.is_empty() {
         return Err("no memories yet — run some commands with `mw` first".to_string());
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,8 @@ enum AppError {
     #[error(transparent)]
     Db(#[from] rusqlite::Error),
     #[error(transparent)]
+    Retrieval(#[from] memorywhale_core::sqlite::LoadError),
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 }
 
@@ -582,7 +584,7 @@ fn recall_memories(
             .db
             .lock()
             .map_err(|_| AppError::Message("database lock poisoned".to_string()))?;
-        let mems = memorywhale_core::sqlite::load_memories(&conn);
+        let mems = memorywhale_core::sqlite::load_memories(&conn)?;
         build_recall_engine(&conn, mems)
     };
     let q = memorywhale_core::Query::new(query, Utc::now());
@@ -604,7 +606,7 @@ fn explain_memory(
             .db
             .lock()
             .map_err(|_| AppError::Message("database lock poisoned".to_string()))?;
-        let mems = memorywhale_core::sqlite::load_memories(&conn);
+        let mems = memorywhale_core::sqlite::load_memories(&conn)?;
         build_recall_engine(&conn, mems)
     };
     let q = memorywhale_core::Query::new(query, Utc::now());


### PR DESCRIPTION
Closes #156.

## Problem

`load_memories` previously converted prepare/query/row failures into empty vectors, so a damaged or incompatible present table looked like a valid empty source. Bookmark fallback also used arbitrary SQL prepare failure to select a less restrictive legacy query.

## Fix

- Added structured `LoadError` / `LoadErrorKind` with table and stage (`schema`, `prepare`, `query`, `row decode`).
- Optional absent source tables remain empty, preserving the CLI/desktop schema split.
- Present tables now propagate schema, query, and row-decode failures.
- Bookmark compatibility is selected from `PRAGMA table_info`: current (`approved` + `status`), approved-only, or oldest legacy shape; failures no longer downgrade filtering.
- Replaced `rows.flatten()` across loaders with explicit error propagation.
- Updated CLI, MCP, TUI, desktop, and example call sites deliberately; user-facing surfaces report incomplete-memory errors rather than silently searching partial data.

## Tests

Added coverage for empty/absent tables, legacy/current bookmark variants, malformed present rows, and invalid present schemas.

Verification: `cargo fmt --all --check`, clippy `-D warnings`, `cargo test -p memorywhale-core --lib`, `cargo check --workspace`, and `git diff --check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database loading errors are now reported clearly instead of being treated as empty results.
  * Unsupported bookmark schemas, including status-only schemas, are rejected with actionable details.
  * Memory search, recall, syncing, validation, and display now surface retrieval failures consistently.
* **Reliability**
  * Schema, query, preparation, and row-decoding failures now receive structured reporting.
  * Optional tables are handled correctly when absent, while failures in existing tables are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->