### PR TITLE
docs(ecosystem): add ContextGC relationship

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -18,8 +18,8 @@ memory belongs to *you*, not to any one model.
             ▼
         Delphin  ──writes conversation turns──▶  MemoryWhale
         (communication)                          (memory: recall + explain)
-             │
-             ▼
+                                                     │
+                                                     ▼
         ContextGC ──selects the active model working set──▶ AI model
         (context: keep / compress / evict)
 ```
@@ -30,8 +30,11 @@ memory belongs to *you*, not to any one model.
 
 The boundary is deliberate: ContextGC manages the temporary working set for a
 long-running agent, while MemoryWhale preserves useful development experience
-after it leaves that working set. ContextGC can promote a durable fix or
-decision through `mw-mcp`; noisy output can simply be evicted.
+after it leaves that working set. The intended future composition is for
+ContextGC to promote a durable fix or decision through `mw-mcp`; noisy output
+can simply be evicted. ContextGC's current integration documentation marks
+that adapter as future work, so this is not a shipped end-to-end integration
+yet.
 
 ## Wiring them together (optional)
 

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -20,8 +20,11 @@ memory belongs to *you*, not to any one model.
         (communication)                          (memory: recall + explain)
                                                      │
                                                      ▼
-        ContextGC ──selects the active model working set──▶ AI model
-        (context: keep / compress / evict)
+        MemoryWhale ◄── durable candidates + recall ──► ContextGC
+        (long-term memory)       (context: keep / compress / evict)
+                                      │
+                                      ▼
+                              active model working set
 ```
 
 - **Delphin** smooths the live conversation and records every turn.

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -7,6 +7,7 @@ memory belongs to *you*, not to any one model.
 | Project | Role | Repo |
 |---|---|---|
 | **Delphin** 🐬 | **Communication** — a duplex wrapper for AI agent CLIs: keep talking while the agent thinks; an arbiter decides interrupt-vs-wait. | https://github.com/wuisabel-gif/Delphin |
+| **ContextGC** 🧠 | **Context management** — predicts context pressure and selectively keeps, compresses, externalizes, or evicts the active model working set. | https://github.com/wuisabel-gif/ContextGC |
 | **MemoryWhale** 🐋 | **Memory** — an inspectable memory OS: capture, retrieve with explanations, forget. (this repo) | https://github.com/wuisabel-gif/MemWhale |
 
 ## How they fit together
@@ -17,10 +18,20 @@ memory belongs to *you*, not to any one model.
             ▼
         Delphin  ──writes conversation turns──▶  MemoryWhale
         (communication)                          (memory: recall + explain)
+             │
+             ▼
+        ContextGC ──selects the active model working set──▶ AI model
+        (context: keep / compress / evict)
 ```
 
 - **Delphin** smooths the live conversation and records every turn.
+- **ContextGC** manages what the model should keep in its active context right now.
 - **MemoryWhale** stores, ranks, and **explains** what's worth remembering.
+
+The boundary is deliberate: ContextGC manages the temporary working set for a
+long-running agent, while MemoryWhale preserves useful development experience
+after it leaves that working set. ContextGC can promote a durable fix or
+decision through `mw-mcp`; noisy output can simply be evicted.
 
 ## Wiring them together (optional)
 
@@ -37,5 +48,6 @@ explanation.
 
 ## Naming
 
-Both are cetaceans on purpose: **Delphin** (the dolphin) for communication,
-**MemoryWhale** for memory — related pieces of infrastructure, not isolated tools.
+These projects are related infrastructure, not one combined agent: **Delphin**
+for communication, **ContextGC** for active context, and **MemoryWhale** for
+durable memory.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ end-to-end scenario with real commands.
 - [CLI reference](docs/reference/cli.md)
 - [MCP reference](docs/reference/mcp.md)
 - [Security and local threat model](docs/SECURITY.md)
+- [Ecosystem](ECOSYSTEM.md) — Delphin, ContextGC, and MemoryWhale together
 - [Integration guides and capability matrix](integrations/README.md)
 
 ## Contributing

--- a/index.html
+++ b/index.html
@@ -903,6 +903,7 @@
           <a href="https://github.com/wuisabel-gif/MemWhale/releases/latest">Releases</a>
           <a href="https://github.com/wuisabel-gif/MemWhale" target="_blank" rel="noopener">GitHub ↗</a>
           <a href="https://github.com/wuisabel-gif/Delphin" target="_blank" rel="noopener">Delphin ↗</a>
+          <a href="https://github.com/wuisabel-gif/ContextGC" target="_blank" rel="noopener">ContextGC ↗</a>
         </div>
       </nav>
 


### PR DESCRIPTION
Adds ContextGC to MemoryWhale's documented ecosystem.

## Included

- `ECOSYSTEM.md` project row with the accurate role: ContextGC manages the temporary active model working set (keep/compress/externalize/evict), while MemoryWhale preserves durable development memory;
- relationship diagram showing Delphin (communication), ContextGC (active context), and MemoryWhale (long-term memory);
- explanation of the boundary and optional `ContextGC → MCP/stdio → mw-mcp → MemoryWhale` composition;
- README Ecosystem link;
- landing-page ContextGC link beside Delphin.

This is documentation/navigation only; no ContextGC dependency or client-specific behavior is added to MemoryWhale. Checks: `node scripts/check-site.mjs`, `bash scripts/check-doc-references.sh`, and `git diff --check` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an ecosystem overview covering Delphin, ContextGC, and MemoryWhale.
  - Updated architecture documentation to explain how context is selected, compressed, retained, or removed while durable experience is preserved.
  - Clarified that end-to-end promotion through `mw-mcp` is planned, not yet available.
  - Added an Ecosystem entry to the documentation index.
  - Added navigation access to the ContextGC project repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->