### PR TITLE
perf(retrieval): cache FTS5 index per corpus

### DIFF
--- a/crates/memorywhale-core/src/engine.rs
+++ b/crates/memorywhale-core/src/engine.rs
@@ -80,6 +80,10 @@ struct FtsCache {
     conn: Mutex<Connection>,
 }
 
+struct FtsEntry {
+    index: OnceLock<Option<Arc<FtsCache>>>,
+}
+
 fn corpus_fingerprint(memories: &[Memory]) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     for memory in memories {
@@ -117,32 +121,37 @@ fn build_fts_cache(memories: &[Memory]) -> Option<FtsCache> {
 /// not hold the global cache lock or evict another project's index immediately.
 fn cached_fts_cache(memories: &[Memory], fingerprint: u64) -> Option<Arc<FtsCache>> {
     const MAX_CACHED_CORPORA: usize = 8;
-    static FTS_CACHE: OnceLock<Mutex<HashMap<u64, Arc<FtsCache>>>> = OnceLock::new();
+    static FTS_CACHE: OnceLock<Mutex<HashMap<u64, Arc<FtsEntry>>>> = OnceLock::new();
 
     let cache = FTS_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
-    {
-        let cache = cache
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(index) = cache.get(&fingerprint) {
-            return Some(Arc::clone(index));
-        }
-    }
-
-    let index = Arc::new(build_fts_cache(memories)?);
     let mut cache = cache
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if let Some(existing) = cache.get(&fingerprint) {
-        return Some(Arc::clone(existing));
-    }
-    if cache.len() >= MAX_CACHED_CORPORA {
-        if let Some(oldest) = cache.keys().next().copied() {
-            cache.remove(&oldest);
+    let entry = if let Some(entry) = cache.get(&fingerprint) {
+        Arc::clone(entry)
+    } else {
+        if cache.len() >= MAX_CACHED_CORPORA {
+            // Never evict an in-progress build. It may be temporarily above
+            // the normal bound while all entries are being initialized.
+            if let Some(evict) = cache
+                .iter()
+                .find_map(|(key, entry)| entry.index.get().map(|_| *key))
+            {
+                cache.remove(&evict);
+            }
         }
-    }
-    cache.insert(fingerprint, Arc::clone(&index));
-    Some(index)
+        let entry = Arc::new(FtsEntry {
+            index: OnceLock::new(),
+        });
+        cache.insert(fingerprint, Arc::clone(&entry));
+        entry
+    };
+    drop(cache);
+
+    entry
+        .index
+        .get_or_init(|| build_fts_cache(memories).map(Arc::new))
+        .clone()
 }
 
 /// The tokens the FTS index sees: lowercase alphanumeric tokens (len ≥ 2).

--- a/crates/memorywhale-core/src/engine.rs
+++ b/crates/memorywhale-core/src/engine.rs
@@ -131,13 +131,16 @@ fn cached_fts_cache(memories: &[Memory], fingerprint: u64) -> Option<Arc<FtsCach
         Arc::clone(entry)
     } else {
         if cache.len() >= MAX_CACHED_CORPORA {
-            // Never evict an in-progress build. It may be temporarily above
-            // the normal bound while all entries are being initialized.
-            if let Some(evict) = cache
+            // Never evict an in-progress build. If all slots are initializing,
+            // bypass the shared cache rather than exceeding its hard bound.
+            let evict = cache
                 .iter()
-                .find_map(|(key, entry)| entry.index.get().map(|_| *key))
-            {
+                .find_map(|(key, entry)| entry.index.get().map(|_| *key));
+            if let Some(evict) = evict {
                 cache.remove(&evict);
+            } else {
+                drop(cache);
+                return build_fts_cache(memories).map(Arc::new);
             }
         }
         let entry = Arc::new(FtsEntry {

--- a/crates/memorywhale-core/src/engine.rs
+++ b/crates/memorywhale-core/src/engine.rs
@@ -7,11 +7,11 @@
 //! an optional, swappable backend rather than a hard dependency. Callers never
 //! change.
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 #[cfg(feature = "embeddings")]
 use std::sync::Arc;
+use std::sync::{Mutex, OnceLock};
 
 use rusqlite::Connection;
 
@@ -46,13 +46,29 @@ use crate::{Memory, Query, ScoredMemory, Weights};
 /// Best-effort: if FTS5 is somehow unavailable, returns an empty map and the
 /// scorer falls back to term overlap. rusqlite is `bundled` (FTS5 compiled in),
 /// so that path is not expected in practice.
-fn bm25_similarities(conn: &Connection, query: &str) -> HashMap<i64, f32> {
+fn bm25_similarities(memories: &[Memory], query: &str) -> HashMap<i64, f32> {
+    static FTS_CACHE: OnceLock<Mutex<Option<FtsCache>>> = OnceLock::new();
     let mut out = HashMap::new();
     let match_expr = fts_match_expr(query);
     if match_expr.is_empty() {
         return out;
     }
-    let mut stmt = match conn
+    let fingerprint = corpus_fingerprint(memories);
+    let mut cache = FTS_CACHE
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if cache
+        .as_ref()
+        .is_none_or(|cached| cached.fingerprint != fingerprint)
+    {
+        *cache = build_fts_cache(memories, fingerprint);
+    }
+    let Some(cached) = cache.as_ref() else {
+        return out;
+    };
+    let mut stmt = match cached
+        .conn
         .prepare("SELECT rowid, bm25(mem_fts, 1.0, 1.0) FROM mem_fts WHERE mem_fts MATCH ?1")
     {
         Ok(s) => s,
@@ -150,7 +166,6 @@ pub trait MemoryEngine {
 pub struct BuiltinEngine {
     pub memories: Vec<Memory>,
     pub weights: Weights,
-    fts_cache: RefCell<Option<FtsCache>>,
     #[cfg(feature = "embeddings")]
     embedder: Option<Arc<dyn Embedder>>,
 }
@@ -160,7 +175,6 @@ impl BuiltinEngine {
         Self {
             memories,
             weights: Weights::default(),
-            fts_cache: RefCell::new(None),
             #[cfg(feature = "embeddings")]
             embedder: None,
         }
@@ -200,21 +214,6 @@ impl BuiltinEngine {
     fn query_embedding(&self, _query: &Query) -> Option<Vec<f32>> {
         None
     }
-
-    fn bm25_similarities(&self, query: &str) -> HashMap<i64, f32> {
-        let fingerprint = corpus_fingerprint(&self.memories);
-        let mut cache = self.fts_cache.borrow_mut();
-        if cache
-            .as_ref()
-            .is_none_or(|cached| cached.fingerprint != fingerprint)
-        {
-            *cache = build_fts_cache(&self.memories, fingerprint);
-        }
-        cache
-            .as_ref()
-            .map(|cached| bm25_similarities(&cached.conn, query))
-            .unwrap_or_default()
-    }
 }
 
 impl MemoryEngine for BuiltinEngine {
@@ -231,7 +230,7 @@ impl MemoryEngine for BuiltinEngine {
         // Keyword relevance from FTS5 BM25 — only when we're not on the semantic
         // (embedding) path, which supersedes it.
         let sims = if qe.is_none() {
-            self.bm25_similarities(&query.text)
+            bm25_similarities(&self.memories, &query.text)
         } else {
             HashMap::new()
         };
@@ -260,7 +259,7 @@ impl MemoryEngine for BuiltinEngine {
     fn explain(&self, id: i64, query: &Query) -> Option<ScoredMemory> {
         let qe = self.query_embedding(query);
         let sims = if qe.is_none() {
-            self.bm25_similarities(&query.text)
+            bm25_similarities(&self.memories, &query.text)
         } else {
             HashMap::new()
         };
@@ -696,6 +695,12 @@ mod tests {
 
         assert_eq!(before_similarity, 0.0);
         assert!(after_similarity > before_similarity);
+    }
+
+    #[test]
+    fn builtin_engine_remains_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<BuiltinEngine>();
     }
 
     #[test]

--- a/crates/memorywhale-core/src/engine.rs
+++ b/crates/memorywhale-core/src/engine.rs
@@ -84,7 +84,57 @@ struct FtsEntry {
     index: OnceLock<Option<Arc<FtsCache>>>,
 }
 
-type FtsCacheStore = (Mutex<HashMap<u64, Arc<FtsEntry>>>, Condvar);
+const MAX_CACHED_CORPORA: usize = 8;
+
+struct FtsCacheStore {
+    entries: Mutex<HashMap<u64, Arc<FtsEntry>>>,
+    wake: Condvar,
+}
+
+impl FtsCacheStore {
+    fn new() -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+            wake: Condvar::new(),
+        }
+    }
+
+    fn reserve(&self, fingerprint: u64) -> Arc<FtsEntry> {
+        loop {
+            let mut entries = self
+                .entries
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if let Some(entry) = entries.get(&fingerprint) {
+                return Arc::clone(entry);
+            }
+            if entries.len() >= MAX_CACHED_CORPORA {
+                if let Some(evict) = entries
+                    .iter()
+                    .find_map(|(key, entry)| entry.index.get().map(|_| *key))
+                {
+                    entries.remove(&evict);
+                    continue;
+                }
+                drop(self.wake.wait(entries));
+                continue;
+            }
+            let entry = Arc::new(FtsEntry {
+                index: OnceLock::new(),
+            });
+            entries.insert(fingerprint, Arc::clone(&entry));
+            return entry;
+        }
+    }
+
+    fn notify(&self) {
+        let _entries = self
+            .entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.wake.notify_all();
+    }
+}
 
 fn corpus_fingerprint(memories: &[Memory]) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -122,46 +172,16 @@ fn build_fts_cache(memories: &[Memory]) -> Option<FtsCache> {
 /// Each corpus gets its own connection mutex, so a query for one project does
 /// not hold the global cache lock or evict another project's index immediately.
 fn cached_fts_cache(memories: &[Memory], fingerprint: u64) -> Option<Arc<FtsCache>> {
-    const MAX_CACHED_CORPORA: usize = 8;
     static FTS_CACHE: OnceLock<FtsCacheStore> = OnceLock::new();
 
-    let (cache, wake) = FTS_CACHE.get_or_init(|| (Mutex::new(HashMap::new()), Condvar::new()));
-    let entry = loop {
-        let mut cache = cache
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(entry) = cache.get(&fingerprint) {
-            break Arc::clone(entry);
-        }
-
-        if cache.len() < MAX_CACHED_CORPORA {
-            let entry = Arc::new(FtsEntry {
-                index: OnceLock::new(),
-            });
-            cache.insert(fingerprint, Arc::clone(&entry));
-            break entry;
-        }
-
-        // Every slot is currently building. Wait for one to finish instead
-        // of allowing an overflow build to duplicate work or grow the map.
-        if let Some(evict) = cache
-            .iter()
-            .find_map(|(key, entry)| entry.index.get().map(|_| *key))
-        {
-            cache.remove(&evict);
-            continue;
-        }
-        drop(wake.wait(cache));
-    };
+    let store = FTS_CACHE.get_or_init(FtsCacheStore::new);
+    let entry = store.reserve(fingerprint);
 
     let result = entry
         .index
         .get_or_init(|| build_fts_cache(memories).map(Arc::new))
         .clone();
-    let _cache = cache
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    wake.notify_all();
+    store.notify();
     result
 }
 
@@ -777,6 +797,36 @@ mod tests {
         for thread in threads {
             thread.join().unwrap();
         }
+    }
+
+    #[test]
+    fn saturated_cache_admission_waits_and_stays_bounded() {
+        use std::sync::mpsc;
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::Duration;
+
+        let store = Arc::new(FtsCacheStore::new());
+        for fingerprint in 0..MAX_CACHED_CORPORA as u64 {
+            store.reserve(fingerprint);
+        }
+        let (sent, received) = mpsc::channel();
+        let waiter_store = Arc::clone(&store);
+        let waiter = thread::spawn(move || sent.send(waiter_store.reserve(99)));
+
+        assert!(received.recv_timeout(Duration::from_millis(50)).is_err());
+        let first = {
+            let entries = store.entries.lock().unwrap();
+            Arc::clone(entries.get(&0).unwrap())
+        };
+        assert!(first.index.set(None).is_ok());
+        store.notify();
+
+        received
+            .recv_timeout(Duration::from_secs(1))
+            .expect("saturated waiter was not woken");
+        waiter.join().unwrap().unwrap();
+        assert!(store.entries.lock().unwrap().len() <= MAX_CACHED_CORPORA);
     }
 
     #[test]

--- a/crates/memorywhale-core/src/engine.rs
+++ b/crates/memorywhale-core/src/engine.rs
@@ -9,9 +9,7 @@
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
-#[cfg(feature = "embeddings")]
-use std::sync::Arc;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use rusqlite::Connection;
 
@@ -47,28 +45,20 @@ use crate::{Memory, Query, ScoredMemory, Weights};
 /// scorer falls back to term overlap. rusqlite is `bundled` (FTS5 compiled in),
 /// so that path is not expected in practice.
 fn bm25_similarities(memories: &[Memory], query: &str) -> HashMap<i64, f32> {
-    static FTS_CACHE: OnceLock<Mutex<Option<FtsCache>>> = OnceLock::new();
     let mut out = HashMap::new();
     let match_expr = fts_match_expr(query);
     if match_expr.is_empty() {
         return out;
     }
     let fingerprint = corpus_fingerprint(memories);
-    let mut cache = FTS_CACHE
-        .get_or_init(|| Mutex::new(None))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if cache
-        .as_ref()
-        .is_none_or(|cached| cached.fingerprint != fingerprint)
-    {
-        *cache = build_fts_cache(memories, fingerprint);
-    }
-    let Some(cached) = cache.as_ref() else {
+    let Some(cached) = cached_fts_cache(memories, fingerprint) else {
         return out;
     };
-    let mut stmt = match cached
+    let conn = cached
         .conn
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut stmt = match conn
         .prepare("SELECT rowid, bm25(mem_fts, 1.0, 1.0) FROM mem_fts WHERE mem_fts MATCH ?1")
     {
         Ok(s) => s,
@@ -87,8 +77,7 @@ fn bm25_similarities(memories: &[Memory], query: &str) -> HashMap<i64, f32> {
 }
 
 struct FtsCache {
-    fingerprint: u64,
-    conn: Connection,
+    conn: Mutex<Connection>,
 }
 
 fn corpus_fingerprint(memories: &[Memory]) -> u64 {
@@ -101,7 +90,7 @@ fn corpus_fingerprint(memories: &[Memory]) -> u64 {
     hasher.finish()
 }
 
-fn build_fts_cache(memories: &[Memory], fingerprint: u64) -> Option<FtsCache> {
+fn build_fts_cache(memories: &[Memory]) -> Option<FtsCache> {
     let conn = Connection::open_in_memory().ok()?;
     conn.execute("CREATE VIRTUAL TABLE mem_fts USING fts5(text, tags)", [])
         .ok()?;
@@ -118,7 +107,42 @@ fn build_fts_cache(memories: &[Memory], fingerprint: u64) -> Option<FtsCache> {
         .ok()?;
     }
     drop(ins);
-    Some(FtsCache { fingerprint, conn })
+    Some(FtsCache {
+        conn: Mutex::new(conn),
+    })
+}
+
+/// Reuse a bounded set of corpus indexes across engine instances and requests.
+/// Each corpus gets its own connection mutex, so a query for one project does
+/// not hold the global cache lock or evict another project's index immediately.
+fn cached_fts_cache(memories: &[Memory], fingerprint: u64) -> Option<Arc<FtsCache>> {
+    const MAX_CACHED_CORPORA: usize = 8;
+    static FTS_CACHE: OnceLock<Mutex<HashMap<u64, Arc<FtsCache>>>> = OnceLock::new();
+
+    let cache = FTS_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    {
+        let cache = cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(index) = cache.get(&fingerprint) {
+            return Some(Arc::clone(index));
+        }
+    }
+
+    let index = Arc::new(build_fts_cache(memories)?);
+    let mut cache = cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(existing) = cache.get(&fingerprint) {
+        return Some(Arc::clone(existing));
+    }
+    if cache.len() >= MAX_CACHED_CORPORA {
+        if let Some(oldest) = cache.keys().next().copied() {
+            cache.remove(&oldest);
+        }
+    }
+    cache.insert(fingerprint, Arc::clone(&index));
+    Some(index)
 }
 
 /// The tokens the FTS index sees: lowercase alphanumeric tokens (len ≥ 2).

--- a/crates/memorywhale-core/src/engine.rs
+++ b/crates/memorywhale-core/src/engine.rs
@@ -158,6 +158,9 @@ fn cached_fts_cache(memories: &[Memory], fingerprint: u64) -> Option<Arc<FtsCach
         .index
         .get_or_init(|| build_fts_cache(memories).map(Arc::new))
         .clone();
+    let _cache = cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     wake.notify_all();
     result
 }
@@ -742,6 +745,38 @@ mod tests {
     fn builtin_engine_remains_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<BuiltinEngine>();
+    }
+
+    #[test]
+    fn concurrent_same_corpus_builds_one_index() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        let memories = Arc::new(vec![Memory {
+            id: 8_765_432,
+            text: "single-flight-fts-corpus-unique".to_string(),
+            created_at: now(),
+            last_used: now(),
+            mentions: 0,
+            importance: 0.5,
+            tags: vec!["single-flight".to_string()],
+            embedding: None,
+        }]);
+        let barrier = Arc::new(Barrier::new(8));
+        let threads: Vec<_> = (0..8)
+            .map(|_| {
+                let memories = Arc::clone(&memories);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let scores = bm25_similarities(&memories, "single-flight-fts-corpus-unique");
+                    assert!(!scores.is_empty());
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().unwrap();
+        }
     }
 
     #[test]

--- a/crates/memorywhale-core/src/engine.rs
+++ b/crates/memorywhale-core/src/engine.rs
@@ -7,7 +7,9 @@
 //! an optional, swappable backend rather than a hard dependency. Callers never
 //! change.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 #[cfg(feature = "embeddings")]
 use std::sync::Arc;
 
@@ -18,8 +20,8 @@ use crate::embed::Embedder;
 use crate::scorer::score_with_lexical;
 use crate::{Memory, Query, ScoredMemory, Weights};
 
-/// Build an in-memory SQLite FTS5 index over `memories`, MATCH `query`, and
-/// return a per-id keyword relevance in `[0,1]` derived from SQLite's `bm25` rank.
+/// Query an in-memory SQLite FTS5 index and return a per-id keyword relevance
+/// in `[0,1]` derived from SQLite's `bm25` rank.
 ///
 /// The index has two columns — `text` (the memory body) and `tags` (its tags,
 /// space-joined). Tags are explicit user/agent signal, so a query term that only
@@ -44,32 +46,11 @@ use crate::{Memory, Query, ScoredMemory, Weights};
 /// Best-effort: if FTS5 is somehow unavailable, returns an empty map and the
 /// scorer falls back to term overlap. rusqlite is `bundled` (FTS5 compiled in),
 /// so that path is not expected in practice.
-fn bm25_similarities(memories: &[Memory], query: &str) -> HashMap<i64, f32> {
+fn bm25_similarities(conn: &Connection, query: &str) -> HashMap<i64, f32> {
     let mut out = HashMap::new();
     let match_expr = fts_match_expr(query);
     if match_expr.is_empty() {
         return out;
-    }
-    let conn = match Connection::open_in_memory() {
-        Ok(c) => c,
-        Err(_) => return out,
-    };
-    if conn
-        .execute("CREATE VIRTUAL TABLE mem_fts USING fts5(text, tags)", [])
-        .is_err()
-    {
-        return out;
-    }
-    {
-        let mut ins =
-            match conn.prepare("INSERT INTO mem_fts(rowid, text, tags) VALUES (?1, ?2, ?3)") {
-                Ok(s) => s,
-                Err(_) => return out,
-            };
-        // Insert in corpus order → deterministic bm25.
-        for m in memories {
-            let _ = ins.execute(rusqlite::params![m.id, m.text, m.tags.join(" ")]);
-        }
     }
     let mut stmt = match conn
         .prepare("SELECT rowid, bm25(mem_fts, 1.0, 1.0) FROM mem_fts WHERE mem_fts MATCH ?1")
@@ -87,6 +68,41 @@ fn bm25_similarities(memories: &[Memory], query: &str) -> HashMap<i64, f32> {
         }
     }
     out
+}
+
+struct FtsCache {
+    fingerprint: u64,
+    conn: Connection,
+}
+
+fn corpus_fingerprint(memories: &[Memory]) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for memory in memories {
+        memory.id.hash(&mut hasher);
+        memory.text.hash(&mut hasher);
+        memory.tags.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+fn build_fts_cache(memories: &[Memory], fingerprint: u64) -> Option<FtsCache> {
+    let conn = Connection::open_in_memory().ok()?;
+    conn.execute("CREATE VIRTUAL TABLE mem_fts USING fts5(text, tags)", [])
+        .ok()?;
+    let mut ins = conn
+        .prepare("INSERT INTO mem_fts(rowid, text, tags) VALUES (?1, ?2, ?3)")
+        .ok()?;
+    // Insert in corpus order → deterministic bm25.
+    for memory in memories {
+        ins.execute(rusqlite::params![
+            memory.id,
+            memory.text,
+            memory.tags.join(" ")
+        ])
+        .ok()?;
+    }
+    drop(ins);
+    Some(FtsCache { fingerprint, conn })
 }
 
 /// The tokens the FTS index sees: lowercase alphanumeric tokens (len ≥ 2).
@@ -134,6 +150,7 @@ pub trait MemoryEngine {
 pub struct BuiltinEngine {
     pub memories: Vec<Memory>,
     pub weights: Weights,
+    fts_cache: RefCell<Option<FtsCache>>,
     #[cfg(feature = "embeddings")]
     embedder: Option<Arc<dyn Embedder>>,
 }
@@ -143,6 +160,7 @@ impl BuiltinEngine {
         Self {
             memories,
             weights: Weights::default(),
+            fts_cache: RefCell::new(None),
             #[cfg(feature = "embeddings")]
             embedder: None,
         }
@@ -182,6 +200,21 @@ impl BuiltinEngine {
     fn query_embedding(&self, _query: &Query) -> Option<Vec<f32>> {
         None
     }
+
+    fn bm25_similarities(&self, query: &str) -> HashMap<i64, f32> {
+        let fingerprint = corpus_fingerprint(&self.memories);
+        let mut cache = self.fts_cache.borrow_mut();
+        if cache
+            .as_ref()
+            .is_none_or(|cached| cached.fingerprint != fingerprint)
+        {
+            *cache = build_fts_cache(&self.memories, fingerprint);
+        }
+        cache
+            .as_ref()
+            .map(|cached| bm25_similarities(&cached.conn, query))
+            .unwrap_or_default()
+    }
 }
 
 impl MemoryEngine for BuiltinEngine {
@@ -198,7 +231,7 @@ impl MemoryEngine for BuiltinEngine {
         // Keyword relevance from FTS5 BM25 — only when we're not on the semantic
         // (embedding) path, which supersedes it.
         let sims = if qe.is_none() {
-            bm25_similarities(&self.memories, &query.text)
+            self.bm25_similarities(&query.text)
         } else {
             HashMap::new()
         };
@@ -227,7 +260,7 @@ impl MemoryEngine for BuiltinEngine {
     fn explain(&self, id: i64, query: &Query) -> Option<ScoredMemory> {
         let qe = self.query_embedding(query);
         let sims = if qe.is_none() {
-            bm25_similarities(&self.memories, &query.text)
+            self.bm25_similarities(&query.text)
         } else {
             HashMap::new()
         };
@@ -627,6 +660,42 @@ mod tests {
             sim_n.score
         );
         assert!(sim_m.score > sim_n.score);
+    }
+
+    #[test]
+    fn fts_cache_refreshes_when_public_corpus_changes() {
+        let mut engine = BuiltinEngine::new(vec![Memory {
+            id: 1,
+            text: "ordinary text".to_string(),
+            created_at: now(),
+            last_used: now(),
+            mentions: 0,
+            importance: 0.5,
+            tags: vec![],
+            embedding: None,
+        }]);
+        let query = Query::new("cache-invalidation-token", now());
+        let before = engine.explain(1, &query).unwrap();
+        let before_similarity = before
+            .signals
+            .iter()
+            .find(|signal| signal.name == "similarity")
+            .unwrap()
+            .score;
+
+        // `memories` is public for compatibility; fingerprinting must detect
+        // this mutation and rebuild the cached FTS rows before the next query.
+        engine.memories[0].text = "cache-invalidation-token appears here".to_string();
+        let after = engine.explain(1, &query).unwrap();
+        let after_similarity = after
+            .signals
+            .iter()
+            .find(|signal| signal.name == "similarity")
+            .unwrap()
+            .score;
+
+        assert_eq!(before_similarity, 0.0);
+        assert!(after_similarity > before_similarity);
     }
 
     #[test]

--- a/crates/memorywhale-core/src/engine.rs
+++ b/crates/memorywhale-core/src/engine.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 
 use rusqlite::Connection;
 
@@ -84,6 +84,8 @@ struct FtsEntry {
     index: OnceLock<Option<Arc<FtsCache>>>,
 }
 
+type FtsCacheStore = (Mutex<HashMap<u64, Arc<FtsEntry>>>, Condvar);
+
 fn corpus_fingerprint(memories: &[Memory]) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     for memory in memories {
@@ -121,40 +123,43 @@ fn build_fts_cache(memories: &[Memory]) -> Option<FtsCache> {
 /// not hold the global cache lock or evict another project's index immediately.
 fn cached_fts_cache(memories: &[Memory], fingerprint: u64) -> Option<Arc<FtsCache>> {
     const MAX_CACHED_CORPORA: usize = 8;
-    static FTS_CACHE: OnceLock<Mutex<HashMap<u64, Arc<FtsEntry>>>> = OnceLock::new();
+    static FTS_CACHE: OnceLock<FtsCacheStore> = OnceLock::new();
 
-    let cache = FTS_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut cache = cache
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let entry = if let Some(entry) = cache.get(&fingerprint) {
-        Arc::clone(entry)
-    } else {
-        if cache.len() >= MAX_CACHED_CORPORA {
-            // Never evict an in-progress build. If all slots are initializing,
-            // bypass the shared cache rather than exceeding its hard bound.
-            let evict = cache
-                .iter()
-                .find_map(|(key, entry)| entry.index.get().map(|_| *key));
-            if let Some(evict) = evict {
-                cache.remove(&evict);
-            } else {
-                drop(cache);
-                return build_fts_cache(memories).map(Arc::new);
-            }
+    let (cache, wake) = FTS_CACHE.get_or_init(|| (Mutex::new(HashMap::new()), Condvar::new()));
+    let entry = loop {
+        let mut cache = cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(entry) = cache.get(&fingerprint) {
+            break Arc::clone(entry);
         }
-        let entry = Arc::new(FtsEntry {
-            index: OnceLock::new(),
-        });
-        cache.insert(fingerprint, Arc::clone(&entry));
-        entry
-    };
-    drop(cache);
 
-    entry
+        if cache.len() < MAX_CACHED_CORPORA {
+            let entry = Arc::new(FtsEntry {
+                index: OnceLock::new(),
+            });
+            cache.insert(fingerprint, Arc::clone(&entry));
+            break entry;
+        }
+
+        // Every slot is currently building. Wait for one to finish instead
+        // of allowing an overflow build to duplicate work or grow the map.
+        if let Some(evict) = cache
+            .iter()
+            .find_map(|(key, entry)| entry.index.get().map(|_| *key))
+        {
+            cache.remove(&evict);
+            continue;
+        }
+        drop(wake.wait(cache));
+    };
+
+    let result = entry
         .index
         .get_or_init(|| build_fts_cache(memories).map(Arc::new))
-        .clone()
+        .clone();
+    wake.notify_all();
+    result
 }
 
 /// The tokens the FTS index sees: lowercase alphanumeric tokens (len ≥ 2).


### PR DESCRIPTION
Closes #155.

## Problem

`BuiltinEngine::retrieve` and `explain` rebuilt an in-memory SQLite FTS5 table and inserted the entire corpus on every query. This made repeated search/explain work scale with corpus size per request.

## Fix

- Build the FTS5 index once per `BuiltinEngine` and reuse it for repeated queries.
- Fingerprint memory IDs, text, and tags; rebuild automatically if callers mutate the existing public `memories` vector, preserving API compatibility and avoiding stale rankings.
- Keep the existing tokenizer, BM25 weights, query expression, score normalization, fallback behavior, and ranking semantics unchanged.

## Tests

- Existing BM25/tag/ranking tests pass.
- Added corpus-mutation invalidation coverage proving a changed memory is visible to the next explain query.

Verification: `cargo fmt --all --check`, clippy `-D warnings`, full core/CLI tests, workspace build, and `git diff --check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved full-text search responsiveness by reusing search indexes across repeated queries.
  - Improved efficiency during concurrent searches by safely sharing cached indexes.
  - Limited retained indexes to help manage resource usage across memory collections.

- **Reliability**
  - Improved behavior when multiple searches initialize indexes simultaneously.
  - Ensured searches use the correct, up-to-date index after a memory collection changes.
  - Preserved consistent search behavior during concurrent access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->