### PR TITLE
release: 0.9.0 — memory stewardship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,59 @@
 All notable changes to MemoryWhale are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [0.9.0] — Memory stewardship
+
+Product version `0.9.0`; `memorywhale-core` `0.3.0`.
+
+This release makes memory maintenance explicit and safer: users can compact
+redundant evidence without deleting rows, retrieval reuses FTS indexes, and
+present-but-damaged SQLite sources report errors instead of appearing empty.
+It also adds desktop CSP hardening, a public security policy, a website refresh,
+and localized README entry points.
+
+### Added
+
+- **Rule-of-thumb memory compaction** — `mw memory compact` previews a
+  conservative plan by default; `--apply` is explicit. Failed, fingerprinted,
+  and bookmarked runs stay protected. Session raw files and original byte
+  counts remain intact, while large successful output is bounded with
+  head/tail markers. (#212)
+- **Memory compaction reference** — documents thresholds, safety invariants,
+  dry-run workflow, and the distinction between TTL expiry and compaction.
+  (#212)
+- **ContextGC ecosystem documentation** — explains how active context
+  management complements MemoryWhale's durable development memory. (#220)
+- **Localized README entry points** — Simplified Chinese, Korean, Traditional
+  Chinese, and Japanese. (#214, #215, #216, #217)
+
+### Improved
+
+- **FTS5 retrieval performance** — caches a bounded set of corpus indexes across
+  engine instances and requests, coalesces concurrent builds, preserves
+  `BuiltinEngine`'s `Send + Sync` contract, and invalidates on corpus changes.
+  (#221)
+- **Website onboarding** — adds use cases, integration discovery, docs/security
+  navigation, `mw demo`, real install commands, v0.8 release messaging, and
+  responsive long-command handling. (#213)
+
+### Security
+
+- **Restrictive Tauri CSP** — same-origin scripts/assets, Tauri IPC only,
+  explicit `base-uri 'none'` and `form-action 'none'`, no wildcard scripts or
+  `unsafe-eval`. (#218)
+- **Retrieval integrity** — absent optional source tables remain supported, but
+  present schema/query/row failures now surface as structured errors. Bookmark
+  compatibility is selected from schema metadata and unsupported shapes fail
+  closed. (#219)
+- **Security disclosure policy** — added `SECURITY.md` and enabled GitHub
+  private vulnerability reporting. (#207)
+
+### Notes
+
+- No `memorywhale-core` version bump: the public core API remains compatible.
+- Upgrade from v0.8.0 if you want compaction, safer retrieval failures, FTS5
+  reuse, or the desktop CSP hardening.
+
 ## [0.8.0] — Security & hardening
 
 Product version `0.8.0`; `memorywhale-core` `0.3.0`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/crates/memorywhale-core/examples/eval.rs
+++ b/crates/memorywhale-core/examples/eval.rs
@@ -135,7 +135,7 @@ fn dcg_at_k(rel: &[bool], k: usize) -> f64 {
         .sum()
 }
 fn ndcg_at_k(rel: &[bool], num_relevant: usize, k: usize) -> f64 {
-    let ideal: Vec<bool> = std::iter::repeat(true).take(num_relevant).collect();
+    let ideal = vec![true; num_relevant];
     let idcg = dcg_at_k(&ideal, k);
     if idcg == 0.0 {
         0.0

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale-cli"
-version = "0.8.0"
+version = "0.9.0"
 description = "MemoryWhale CLI — local-first terminal memory. Record commands, sessions, and output into local SQLite; browse them in a built-in web dashboard. Nothing is uploaded."
 authors = ["Isabel Wu <wuisabel@usc.edu>"]
 license = "MIT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorywhale",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorywhale",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorywhale",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MemoryWhale",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "identifier": "com.memorywhale.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Prepares the v0.9.0 Memory Stewardship release.

## Release contents

- `mw memory compact` rule-of-thumb policy (#212)
- storage loader correctness and explicit present-table errors (#219)
- cached, concurrent-safe FTS5 retrieval (#221)
- restrictive Tauri CSP hardening (#218)
- ContextGC ecosystem documentation (#220)
- website onboarding and discovery improvements (#213)
- Simplified Chinese, Korean, Traditional Chinese, and Japanese README entry points (#214–#217)
- security disclosure policy (#207)

## Versioning

Bumps product versions from 0.8.0 to 0.9.0 in `memorywhale-cli`, `package.json`, `package-lock.json`, and `src-tauri/tauri.conf.json`; `memorywhale-core` remains 0.3.0 because its public API is compatible.

Adds a complete `CHANGELOG.md` section. `scripts/check-release-version.sh` passes.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --release -p memorywhale-cli --bins`
- `cargo publish --dry-run -p memorywhale-core`
- `cargo publish --dry-run -p memorywhale-cli`
- `npm run build`
- `node scripts/check-site.mjs`
- `bash scripts/check-doc-references.sh`
- `git diff --check`

All pass.

After merge:

```bash
git tag v0.9.0
git push --tags
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Introduced version 0.9.0 with updated compatibility notes and upgrade guidance.
  * Documented explicit memory compaction and improved full-text retrieval.
  * Added retrieval integrity protections and a restrictive desktop security policy.
  * Updated website and localized README content.
  * Added a security disclosure policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->