### PR TITLE
fix(release): publish core API alongside CLI 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/memorywhale-core/Cargo.toml
+++ b/crates/memorywhale-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Explainable retrieval for MemoryWhale: a MemoryEngine interface, a built-in scorer that ranks memories with per-signal reasons, and an optional MemPalace backend over MCP."
 license = "MIT"

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -21,7 +21,7 @@ dirs = "5"
 # MCP server, with a builtin fallback when that server is unreachable.
 # `version` (alongside `path`) is required so `cargo publish` can resolve the
 # dependency from crates.io — publish memorywhale-core first, then this crate.
-memorywhale-core = { path = "../memorywhale-core", version = "0.3.0", features = ["mempalace"] }
+memorywhale-core = { path = "../memorywhale-core", version = "0.4.0", features = ["mempalace"] }
 regex = "1"
 # Pure-Rust interactive terminal UI (`mw tui`) — no system libraries, so it
 # keeps the bare-machine / Jetson build story intact. Bundles crossterm.


### PR DESCRIPTION
Fixes the v0.9.0 crates.io packaging failure.

The release workflow successfully built platform archives, but the crates job failed while verifying `memorywhale-cli v0.9.0`: it resolved `memorywhale-core v0.3.0` from crates.io, which predates the public `privacy` module and caused the package verification build to fail.

## Fix

- bumps `memorywhale-core` from 0.3.0 to 0.4.0;
- updates the CLI path+registry dependency to `memorywhale-core ^0.4.0`;
- updates `Cargo.lock`.

## Verification

- `cargo check --workspace`
- `cargo publish --dry-run -p memorywhale-core`
- `cargo publish --dry-run -p memorywhale-cli` (verified after core publication)

The actual packages were published in dependency order:

- `memorywhale-core v0.4.0`
- `memorywhale-cli v0.9.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MemoryWhale Core release version to 0.4.0.
  * Updated the command-line application to use the new Core version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->