### PR TITLE
ci(release): tolerate unavailable Homebrew PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,10 +163,13 @@ jobs:
           git checkout -b "$branch"
           git commit -am "Set Homebrew formula to ${GITHUB_REF_NAME}"
           git push -f origin "$branch"
-          gh pr create --base main --head "$branch" \
+          if ! gh pr create --base main --head "$branch" \
             --title "Set Homebrew formula to ${GITHUB_REF_NAME}" \
-            --body "Automated Homebrew formula bump for ${GITHUB_REF_NAME}." \
-            || gh pr edit "$branch" --title "Set Homebrew formula to ${GITHUB_REF_NAME}"
+            --body "Automated Homebrew formula bump for ${GITHUB_REF_NAME}."; then
+            echo "::warning::GitHub Actions cannot create pull requests in this repository."
+            echo "Formula branch pushed successfully: https://github.com/${GITHUB_REPOSITORY}/tree/${branch}"
+            echo "Open a PR manually from ${branch} to main."
+          fi
 
   # Publish the CLI crate to crates.io once per release. Runs once (not in the
   # matrix above). Skips gracefully if the token secret isn't set or the version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,10 @@ jobs:
             echo "$pr_url"
           else
             echo "$pr_url" >&2
-            existing_pr=$(gh pr list --base main --head "$branch" --state open --json url --jq '.[0].url // empty')
+            existing_pr=""
+            if ! existing_pr=$(gh pr list --base main --head "$branch" --state open --json url --jq '.[0].url // empty'); then
+              echo "::warning::Could not check for an existing Homebrew formula PR; inspect the gh error above."
+            fi
             if [ -n "$existing_pr" ]; then
               echo "Formula PR already exists: $existing_pr"
             else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,12 +163,20 @@ jobs:
           git checkout -b "$branch"
           git commit -am "Set Homebrew formula to ${GITHUB_REF_NAME}"
           git push -f origin "$branch"
-          if ! gh pr create --base main --head "$branch" \
+          if pr_url=$(gh pr create --base main --head "$branch" \
             --title "Set Homebrew formula to ${GITHUB_REF_NAME}" \
-            --body "Automated Homebrew formula bump for ${GITHUB_REF_NAME}."; then
-            echo "::warning::GitHub Actions cannot create pull requests in this repository."
-            echo "Formula branch pushed successfully: https://github.com/${GITHUB_REPOSITORY}/tree/${branch}"
-            echo "Open a PR manually from ${branch} to main."
+            --body "Automated Homebrew formula bump for ${GITHUB_REF_NAME}." 2>&1); then
+            echo "$pr_url"
+          else
+            echo "$pr_url" >&2
+            existing_pr=$(gh pr list --base main --head "$branch" --state open --json url --jq '.[0].url // empty')
+            if [ -n "$existing_pr" ]; then
+              echo "Formula PR already exists: $existing_pr"
+            else
+              echo "::warning::Automated pull-request creation failed; inspect the gh error above."
+              echo "Formula branch pushed successfully: https://github.com/${GITHUB_REPOSITORY}/tree/${branch}"
+              echo "Open a PR manually from ${branch} to main."
+            fi
           fi
 
   # Publish the CLI crate to crates.io once per release. Runs once (not in the


### PR DESCRIPTION
The v0.9.0 release built all platform assets and published both crates, but the Homebrew job marked the workflow failed because GitHub Actions is not permitted to call `createPullRequest`. The formula branch was still pushed successfully and had to be turned into PR #225 manually.

Change the final `gh pr create || gh pr edit` chain to an `if ! gh pr create` block that emits a warning and the pushed branch URL, then exits successfully. Future releases will still produce the formula branch and alert maintainers without falsely failing the release workflow. Existing behavior is unchanged when PR creation permission is enabled.

Verification: Ruby YAML parse and `git diff --check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation for Homebrew formula pull requests.
  * Added clearer confirmation when a pull request is created successfully.
  * Improved warnings when pull-request lookup encounters an issue.
  * Avoided unnecessary manual-creation instructions when an existing open pull request is found.
  * Added clearer guidance for manually creating a pull request when automation cannot find one.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->