### PR TITLE
feat(api): add opt-in local JSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ end-to-end scenario with real commands.
 - [Terminal capture](docs/guides/terminal-capture.md)
 - [Agent memory](docs/guides/agent-memory.md)
 - [CLI reference](docs/reference/cli.md)
+- [Local JSON API](docs/reference/api.md)
 - [MCP reference](docs/reference/mcp.md)
 - [Security and local threat model](docs/SECURITY.md)
 - [Ecosystem](ECOSYSTEM.md) — Delphin, ContextGC, and MemoryWhale together

--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -16,6 +16,7 @@ use chrono::{DateTime, FixedOffset, Local, Utc};
 use regex::Regex;
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::Serialize;
+use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
@@ -30,6 +31,8 @@ static STARTUP_NOTICE: OnceLock<String> = OnceLock::new();
 static AUTH_TOKEN: OnceLock<String> = OnceLock::new();
 /// Whether the server bound a loopback address (drives Host-header checks).
 static LOOPBACK_BIND: OnceLock<bool> = OnceLock::new();
+/// Whether the versioned JSON API is enabled for this server process.
+static API_ENABLED: OnceLock<bool> = OnceLock::new();
 
 const IO_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_CONNECTIONS: usize = 64;
@@ -74,7 +77,7 @@ fn run() -> Result<(), String> {
     let mut config = parse_server_args(std::env::args().skip(1))?;
     if config.help {
         println!(
-            "mw-serve [--lan | --host <addr>] [--port <n>] [--token <secret>] [--print-token]  — serve memory as a web dashboard and MCP HTTP endpoint"
+            "mw-serve [--lan | --host <addr>] [--port <n>] [--token <secret>] [--print-token] [--api]  — serve memory locally"
         );
         return Ok(());
     }
@@ -98,6 +101,7 @@ fn run() -> Result<(), String> {
         let _ = AUTH_TOKEN.set(config.token.clone());
     }
     let _ = LOOPBACK_BIND.set(is_loopback_host(&config.host));
+    let _ = API_ENABLED.set(config.api);
 
     let db = database_path()?;
 
@@ -197,6 +201,7 @@ struct ServerConfig {
     token: String,
     help: bool,
     print_token: bool,
+    api: bool,
 }
 
 fn parse_server_args<I>(args: I) -> Result<ServerConfig, String>
@@ -208,6 +213,7 @@ where
     let mut token = std::env::var("MEMORYWHALE_TOKEN").unwrap_or_default();
     let mut help = false;
     let mut print_token = false;
+    let mut api = false;
     let mut args = args.into_iter();
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -216,6 +222,7 @@ where
                 break;
             }
             "--lan" => host = "0.0.0.0".to_string(),
+            "--api" => api = true,
             "--host" => host = args.next().ok_or("--host needs an address")?,
             "--port" => {
                 port = args
@@ -234,6 +241,7 @@ where
         token,
         help,
         print_token,
+        api,
     })
 }
 
@@ -318,6 +326,353 @@ fn json_http(status: &str, body: &str, extra_headers: &str) -> String {
     format!(
         "HTTP/1.1 {status}\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: {}\r\n{SECURITY_HEADERS}{extra_headers}Connection: close\r\n\r\n{body}",
         body.len()
+    )
+}
+
+fn json_response(status: &str, body: &str, extra_headers: &str) -> String {
+    format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: {}\r\n{SECURITY_HEADERS}{extra_headers}Connection: close\r\n\r\n",
+        body.len()
+    )
+}
+
+const API_VERSION: &str = "v1";
+const API_DEFAULT_LIMIT: usize = 20;
+const API_MAX_LIMIT: usize = 50;
+
+fn redact_json(value: &mut Value) {
+    match value {
+        Value::String(text) => *text = redact_secrets(text),
+        Value::Array(values) => values.iter_mut().for_each(redact_json),
+        Value::Object(values) => values.values_mut().for_each(redact_json),
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+fn api_envelope(mut data: Value) -> String {
+    redact_json(&mut data);
+    serde_json::to_string(&json!({ "api_version": API_VERSION, "data": data }))
+        .expect("JSON API envelope is serializable")
+}
+
+fn api_error(status: &'static str, code: &str, message: &str) -> (&'static str, String) {
+    (
+        status,
+        serde_json::to_string(&json!({
+            "api_version": API_VERSION,
+            "error": {"code": code, "message": redact_secrets(message)}
+        }))
+        .expect("JSON API error is serializable"),
+    )
+}
+
+fn api_http_error(status: &'static str) -> (&'static str, String) {
+    let (code, message) = match status {
+        "408 Request Timeout" => ("request_timeout", "request timed out"),
+        "413 Payload Too Large" => ("body_too_large", "request body is too large"),
+        "431 Request Header Fields Too Large" => {
+            ("headers_too_large", "request headers are too large")
+        }
+        _ => ("bad_request", "request could not be parsed"),
+    };
+    api_error(status, code, message)
+}
+
+fn api_route(raw_path: &str) -> (&'static str, String) {
+    let path = raw_path.split('?').next().unwrap_or("/");
+    match path {
+        "/api/v1" | "/api/v1/" => {
+            api_error("404 Not Found", "not_found", "use a versioned API endpoint")
+        }
+        "/api/v1/health" => api_health(),
+        "/api/v1/search" => api_search(raw_path),
+        "/api/v1/repositories" => api_repositories(),
+        "/api/v1/sessions" => api_sessions(raw_path),
+        _ if path.starts_with("/api/v1/memories/") => {
+            api_memory(path.trim_start_matches("/api/v1/memories/"))
+        }
+        _ if path.starts_with("/api/v1/commands/") => {
+            api_command(path.trim_start_matches("/api/v1/commands/"))
+        }
+        _ => api_error("404 Not Found", "not_found", "unknown API endpoint"),
+    }
+}
+
+fn api_open() -> Result<Connection, (&'static str, String)> {
+    open_db().map_err(|error| api_error("500 Internal Server Error", "database", &error))
+}
+
+fn api_health() -> (&'static str, String) {
+    let conn = match api_open() {
+        Ok(conn) => conn,
+        Err(response) => return response,
+    };
+    let memory_count = match memorywhale_core::sqlite::load_memories(&conn) {
+        Ok(memories) => memories.len(),
+        Err(error) => {
+            return api_error("503 Service Unavailable", "memory_load", &error.to_string())
+        }
+    };
+    (
+        "200 OK",
+        api_envelope(json!({
+            "status": "ok",
+            "version": env!("CARGO_PKG_VERSION"),
+            "memory_count": memory_count
+        })),
+    )
+}
+
+fn api_limit(raw_path: &str) -> Result<usize, (&'static str, String)> {
+    let Some(value) = query_param(raw_path, "limit") else {
+        return Ok(API_DEFAULT_LIMIT);
+    };
+    let limit = value.parse::<usize>().map_err(|_| {
+        api_error(
+            "400 Bad Request",
+            "invalid_limit",
+            "limit must be a positive integer",
+        )
+    })?;
+    if !(1..=API_MAX_LIMIT).contains(&limit) {
+        return Err(api_error(
+            "400 Bad Request",
+            "invalid_limit",
+            "limit must be between 1 and 50",
+        ));
+    }
+    Ok(limit)
+}
+
+fn api_search(raw_path: &str) -> (&'static str, String) {
+    let query = query_param(raw_path, "q").unwrap_or_default();
+    if query.trim().is_empty() {
+        return api_error("400 Bad Request", "missing_query", "q is required");
+    }
+    let limit = match api_limit(raw_path) {
+        Ok(limit) => limit,
+        Err(response) => return response,
+    };
+    let conn = match api_open() {
+        Ok(conn) => conn,
+        Err(response) => return response,
+    };
+    let memories = match memorywhale_core::sqlite::load_memories(&conn) {
+        Ok(memories) => memories,
+        Err(error) => {
+            return api_error("503 Service Unavailable", "memory_load", &error.to_string())
+        }
+    };
+    let engine = memorywhale_core::engine::BuiltinEngine::new(memories);
+    let hits = memorywhale_core::engine::MemoryEngine::retrieve(
+        &engine,
+        &memorywhale_core::Query::new(&query, Utc::now()),
+        limit,
+    );
+    let results: Vec<Value> = hits
+        .into_iter()
+        .map(|hit| {
+            let reasons = hit.reasons();
+            let (source, source_id) = memorywhale_core::sqlite::decode_id(hit.memory.id);
+            json!({
+                "id": hit.memory.id,
+                "source": source.tag(),
+                "source_id": source_id,
+                "command_id": (source == memorywhale_core::sqlite::Source::Command)
+                    .then_some(source_id),
+                "score": hit.score,
+                "memory": hit.memory,
+                "signals": hit.signals,
+                "reasons": reasons
+            })
+        })
+        .collect();
+    (
+        "200 OK",
+        api_envelope(json!({"query": query, "results": results})),
+    )
+}
+
+fn api_memory(raw_id: &str) -> (&'static str, String) {
+    let Ok(id) = percent_decode(raw_id).parse::<i64>() else {
+        return api_error(
+            "400 Bad Request",
+            "invalid_id",
+            "memory id must be an integer",
+        );
+    };
+    let conn = match api_open() {
+        Ok(conn) => conn,
+        Err(response) => return response,
+    };
+    let memories = match memorywhale_core::sqlite::load_memories(&conn) {
+        Ok(memories) => memories,
+        Err(error) => {
+            return api_error("503 Service Unavailable", "memory_load", &error.to_string())
+        }
+    };
+    match memories.into_iter().find(|memory| memory.id == id) {
+        Some(memory) => ("200 OK", api_envelope(json!({"memory": memory}))),
+        None => api_error("404 Not Found", "not_found", "memory was not found"),
+    }
+}
+
+type ApiCommandRow = (
+    String,
+    String,
+    Option<String>,
+    Option<i64>,
+    String,
+    String,
+    String,
+    String,
+);
+
+fn api_command(raw_id: &str) -> (&'static str, String) {
+    let Ok(id) = percent_decode(raw_id).parse::<i64>() else {
+        return api_error(
+            "400 Bad Request",
+            "invalid_id",
+            "command id must be an integer",
+        );
+    };
+    let conn = match api_open() {
+        Ok(conn) => conn,
+        Err(response) => return response,
+    };
+    let row: Option<ApiCommandRow> = match conn
+        .query_row(
+            "SELECT command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at
+                 FROM command_runs WHERE id = ?1",
+            params![id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                ))
+            },
+        )
+        .optional()
+    {
+        Ok(row) => row,
+        Err(error) => {
+            return api_error("500 Internal Server Error", "database", &error.to_string())
+        }
+    };
+    let Some((command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at)) = row else {
+        return api_error("404 Not Found", "not_found", "command was not found");
+    };
+    let argv = serde_json::from_str::<Value>(&argv_json).unwrap_or(Value::Null);
+    (
+        "200 OK",
+        api_envelope(json!({
+            "id": id,
+            "command": command,
+            "argv": argv,
+            "cwd": cwd,
+            "exit_code": exit_code,
+            "stdout": stdout,
+            "stderr": stderr,
+            "notes": notes,
+            "created_at": created_at
+        })),
+    )
+}
+
+fn api_sessions(raw_path: &str) -> (&'static str, String) {
+    let limit = match api_limit(raw_path) {
+        Ok(limit) => limit,
+        Err(response) => return response,
+    };
+    let conn = match api_open() {
+        Ok(conn) => conn,
+        Err(response) => return response,
+    };
+    let mut stmt = match conn.prepare(
+        "SELECT id, started_at, ended_at, status, byte_count, notes, cwd
+         FROM sessions ORDER BY id DESC LIMIT ?1",
+    ) {
+        Ok(stmt) => stmt,
+        Err(error) => {
+            return api_error("500 Internal Server Error", "database", &error.to_string())
+        }
+    };
+    let rows = match stmt.query_map(params![limit as i64], |row| {
+        Ok(json!({
+            "id": row.get::<_, i64>(0)?,
+            "started_at": row.get::<_, String>(1)?,
+            "ended_at": row.get::<_, String>(2)?,
+            "status": row.get::<_, String>(3)?,
+            "byte_count": row.get::<_, i64>(4)?,
+            "notes": row.get::<_, String>(5)?,
+            "cwd": row.get::<_, Option<String>>(6)?
+        }))
+    }) {
+        Ok(rows) => rows,
+        Err(error) => {
+            return api_error("500 Internal Server Error", "database", &error.to_string())
+        }
+    };
+    let mut sessions = Vec::new();
+    for row in rows {
+        match row {
+            Ok(row) => sessions.push(row),
+            Err(error) => {
+                return api_error("500 Internal Server Error", "database", &error.to_string())
+            }
+        }
+    }
+    ("200 OK", api_envelope(json!({"sessions": sessions})))
+}
+
+fn api_repositories() -> (&'static str, String) {
+    let conn = match api_open() {
+        Ok(conn) => conn,
+        Err(response) => return response,
+    };
+    let mut stmt = match conn.prepare(
+        "SELECT repository_id, repository_name, worktree_root FROM command_runs
+         WHERE repository_id IS NOT NULL
+         UNION
+         SELECT repository_id, repository_name, worktree_root FROM sessions
+         WHERE repository_id IS NOT NULL
+         ORDER BY repository_name, worktree_root",
+    ) {
+        Ok(stmt) => stmt,
+        Err(error) => {
+            return api_error("500 Internal Server Error", "database", &error.to_string())
+        }
+    };
+    let rows = match stmt.query_map([], |row| {
+        Ok(json!({
+            "id": row.get::<_, String>(0)?,
+            "name": row.get::<_, Option<String>>(1)?,
+            "worktree_root": row.get::<_, Option<String>>(2)?
+        }))
+    }) {
+        Ok(rows) => rows,
+        Err(error) => {
+            return api_error("500 Internal Server Error", "database", &error.to_string())
+        }
+    };
+    let mut repositories = Vec::new();
+    for row in rows {
+        match row {
+            Ok(row) => repositories.push(row),
+            Err(error) => {
+                return api_error("500 Internal Server Error", "database", &error.to_string())
+            }
+        }
+    }
+    (
+        "200 OK",
+        api_envelope(json!({"repositories": repositories})),
     )
 }
 
@@ -503,24 +858,43 @@ fn serve_dashboard<R: BufRead>(
     method: String,
     raw_path: String,
 ) {
+    let path = request_path(&raw_path);
+    let is_api_path = path == "/api/v1" || path.starts_with("/api/v1/");
     let msg = match read_http_message(reader, MAX_BODY_BYTES) {
         Ok(msg) => msg,
         Err(status) => {
-            let _ = write_error(stream, status);
+            if is_api_path {
+                let (status, body) = api_http_error(status);
+                let response = json_response(status, &body, "");
+                let _ = stream.write_all(response.as_bytes());
+                if method != "HEAD" {
+                    let _ = stream.write_all(body.as_bytes());
+                }
+            } else {
+                let _ = write_error(stream, status);
+            }
             return;
         }
     };
     // DNS-rebinding protection: on loopback binds, only loopback Host names
     // may reach the dashboard. A rebound attacker hostname gets 403.
     if !host_ok(&msg.host_header) {
-        let _ = write_error(stream, "403 Forbidden");
+        if is_api_path {
+            let (status, body) = api_error("403 Forbidden", "forbidden", "host is not allowed");
+            let response = json_response(status, &body, "");
+            let _ = stream.write_all(response.as_bytes());
+            if method != "HEAD" {
+                let _ = stream.write_all(body.as_bytes());
+            }
+        } else {
+            let _ = write_error(stream, "403 Forbidden");
+        }
         return;
     }
 
     let cookie = msg.cookie;
     let request_body = msg.body;
     let is_head = method == "HEAD";
-    let path = request_path(&raw_path);
     let method_allowed = method == "GET" || is_head || (method == "POST" && path == "/login");
     if !method_allowed {
         let allow = if path == "/login" {
@@ -528,8 +902,25 @@ fn serve_dashboard<R: BufRead>(
         } else {
             "GET, HEAD"
         };
-        let response = response("405 Method Not Allowed", "", &format!("Allow: {allow}\r\n"));
+        let response = if is_api_path {
+            let (status, body) = api_error(
+                "405 Method Not Allowed",
+                "method_not_allowed",
+                "the JSON API accepts GET and HEAD",
+            );
+            json_response(status, &body, &format!("Allow: {allow}\r\n"))
+        } else {
+            response("405 Method Not Allowed", "", &format!("Allow: {allow}\r\n"))
+        };
         let _ = stream.write_all(response.as_bytes());
+        if is_api_path && !is_head {
+            let (_, body) = api_error(
+                "405 Method Not Allowed",
+                "method_not_allowed",
+                "the JSON API accepts GET and HEAD",
+            );
+            let _ = stream.write_all(body.as_bytes());
+        }
         return;
     }
 
@@ -579,6 +970,19 @@ fn serve_dashboard<R: BufRead>(
             let _ = stream.write_all(response.as_bytes());
             return;
         } else if !via_cookie {
+            if is_api_path {
+                let (status, body) = api_error(
+                    "401 Unauthorized",
+                    "unauthorized",
+                    "authentication required",
+                );
+                let response = json_response(status, &body, "WWW-Authenticate: Bearer\r\n");
+                let _ = stream.write_all(response.as_bytes());
+                if !is_head {
+                    let _ = stream.write_all(body.as_bytes());
+                }
+                return;
+            }
             let message = if login_attempt {
                 "<p>That token was not accepted.</p>"
             } else {
@@ -599,11 +1003,24 @@ fn serve_dashboard<R: BufRead>(
         }
     }
 
-    let (status, body) = route(&raw_path);
     let cookie_header: String = cookies
         .iter()
         .map(|c| format!("Set-Cookie: {c}\r\n"))
         .collect();
+    if is_api_path {
+        let (status, body) = if *API_ENABLED.get().unwrap_or(&false) {
+            api_route(&raw_path)
+        } else {
+            api_error("404 Not Found", "api_disabled", "the JSON API is disabled")
+        };
+        let response = json_response(status, &body, &cookie_header);
+        let _ = stream.write_all(response.as_bytes());
+        if !is_head {
+            let _ = stream.write_all(body.as_bytes());
+        }
+        return;
+    }
+    let (status, body) = route(&raw_path);
     let response = response(status, &body, &cookie_header);
     let _ = stream.write_all(response.as_bytes());
     if !is_head {
@@ -2868,6 +3285,23 @@ mod tests {
         // Set-Cookie extras are still appended for normal routes.
         let r2 = response("200 OK", "x", "Set-Cookie: mw_tz=utc\r\n");
         assert!(r2.contains("Set-Cookie: mw_tz=utc"));
+    }
+
+    #[test]
+    fn api_search_requires_a_query_and_returns_json() {
+        let _ = API_ENABLED.set(true);
+        let response = raw_response(b"GET /api/v1/search HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request"));
+        assert!(response.contains("Content-Type: application/json; charset=utf-8"));
+        assert!(response.contains("\"api_version\":\"v1\""));
+        assert!(response.contains("\"code\":\"missing_query\""));
+    }
+
+    #[test]
+    fn api_limit_rejects_unbounded_requests() {
+        assert!(api_limit("/api/v1/search?limit=0").is_err());
+        assert!(api_limit("/api/v1/search?limit=51").is_err());
+        assert!(api_limit("/api/v1/search?limit=not-a-number").is_err());
     }
 
     #[test]

--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -976,7 +976,7 @@ fn serve_dashboard<R: BufRead>(
                     "unauthorized",
                     "authentication required",
                 );
-                let response = json_response(status, &body, "WWW-Authenticate: Bearer\r\n");
+                let response = json_response(status, &body, "");
                 let _ = stream.write_all(response.as_bytes());
                 if !is_head {
                     let _ = stream.write_all(body.as_bytes());

--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -955,6 +955,8 @@ fn serve_dashboard<R: BufRead>(
             .split(';')
             .filter_map(|c| c.trim().strip_prefix("mw_token="))
             .any(|v| ct_eq(v, want));
+        let via_bearer =
+            is_api_path && bearer_token(&msg.authorization).is_some_and(|token| ct_eq(token, want));
         let login_attempt = method == "POST" && raw_path == "/login";
         let supplied = form_param(&request_body, "token");
         if login_attempt && supplied.as_deref().is_some_and(|s| ct_eq(s, want)) {
@@ -969,14 +971,14 @@ fn serve_dashboard<R: BufRead>(
             );
             let _ = stream.write_all(response.as_bytes());
             return;
-        } else if !via_cookie {
+        } else if !via_cookie && !via_bearer {
             if is_api_path {
                 let (status, body) = api_error(
                     "401 Unauthorized",
                     "unauthorized",
                     "authentication required",
                 );
-                let response = json_response(status, &body, "");
+                let response = json_response(status, &body, "WWW-Authenticate: Bearer\r\n");
                 let _ = stream.write_all(response.as_bytes());
                 if !is_head {
                     let _ = stream.write_all(body.as_bytes());

--- a/crates/mw-cli/tests/mw_serve_auth.rs
+++ b/crates/mw-cli/tests/mw_serve_auth.rs
@@ -61,6 +61,7 @@ fn dashboard_auth_cannot_be_bypassed_by_query_and_cookie_flow_works() {
             &port.to_string(),
             "--token",
             "shared-secret",
+            "--api",
         ])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -71,6 +72,15 @@ fn dashboard_auth_cannot_be_bypassed_by_query_and_cookie_flow_works() {
 
     let unauthenticated = request(&address, "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
     assert!(unauthenticated.starts_with("HTTP/1.1 401 Unauthorized"));
+
+    let unauthenticated_api = request(
+        &address,
+        "GET /api/v1/health HTTP/1.1\r\nHost: localhost\r\n\r\n",
+    );
+    assert!(unauthenticated_api.starts_with("HTTP/1.1 401 Unauthorized"));
+    assert!(unauthenticated_api.contains("Content-Type: application/json"));
+    assert!(unauthenticated_api.contains("\"code\":\"unauthorized\""));
+    assert!(!unauthenticated_api.contains("WWW-Authenticate:"));
 
     let query_token = request(
         &address,

--- a/crates/mw-cli/tests/mw_serve_auth.rs
+++ b/crates/mw-cli/tests/mw_serve_auth.rs
@@ -80,7 +80,14 @@ fn dashboard_auth_cannot_be_bypassed_by_query_and_cookie_flow_works() {
     assert!(unauthenticated_api.starts_with("HTTP/1.1 401 Unauthorized"));
     assert!(unauthenticated_api.contains("Content-Type: application/json"));
     assert!(unauthenticated_api.contains("\"code\":\"unauthorized\""));
-    assert!(!unauthenticated_api.contains("WWW-Authenticate:"));
+    assert!(unauthenticated_api.contains("WWW-Authenticate: Bearer"));
+
+    let bearer_api = request(
+        &address,
+        "GET /api/v1/health HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer shared-secret\r\n\r\n",
+    );
+    assert!(bearer_api.starts_with("HTTP/1.1 200 OK"));
+    assert!(bearer_api.contains("Content-Type: application/json"));
 
     let query_token = request(
         &address,

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ The repository documentation is organized by the question a reader is asking.
 ## Reference: what is the exact interface?
 
 - [CLI and helper binaries](reference/cli.md)
+- [Local JSON API](reference/api.md)
 - [Memory compaction](reference/compaction.md)
 - [Memory pet](reference/pet.md)
 - [MCP tools](reference/mcp.md)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -121,9 +121,10 @@ canonical `id`.
 ## Authentication
 
 Loopback requests use the same local trust model as the dashboard. When the
-server is bound beyond loopback, every API request must first authenticate with
-the dashboard's `mw_token` cookie obtained from `POST /login`; API keys or
-tokens in query strings are not supported.
+server uses a token, API requests may authenticate with the dashboard's
+`mw_token` cookie obtained from `POST /login` or with
+`Authorization: Bearer <token>`. API keys or tokens in query strings are not
+supported. A protected failure returns a JSON error plus a Bearer challenge.
 
 ## Example
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,137 @@
+# Local JSON API
+
+`mw-serve --api` enables a small, versioned, read-only JSON API alongside the
+human dashboard. The API is disabled unless the flag is present.
+
+```bash
+mw-serve --api                         # loopback by default
+MEMORYWHALE_TOKEN=secret mw-serve --lan --api
+```
+
+The API uses the same listener, connection limits, request bounds, security
+headers, host checks, and token gate as the dashboard. It is loopback-only by
+default. A non-loopback bind still requires `MEMORYWHALE_TOKEN` or `--token`.
+
+There are no write endpoints, arbitrary SQL endpoints, or arbitrary filesystem
+reads. MCP remains the primary agent interface.
+
+## Response envelope
+
+Successful responses use:
+
+```json
+{
+  "api_version": "v1",
+  "data": {}
+}
+```
+
+Errors use:
+
+```json
+{
+  "api_version": "v1",
+  "error": {
+    "code": "invalid_limit",
+    "message": "limit must be between 1 and 50"
+  }
+}
+```
+
+The API returns `application/json`, preserves the stored redaction policy, and
+limits search/list results to at most 50 items per request.
+
+The machine-readable contract is available at
+[`api.openapi.json`](api.openapi.json). Requests to the API while `--api` is
+disabled return `404` with `error.code` `api_disabled`; unsupported methods and
+unauthenticated LAN requests return JSON errors with the same envelope.
+
+## Endpoints
+
+### `GET /api/v1/health`
+
+Returns server version, status, and the number of loaded memories:
+
+```json
+{
+  "api_version": "v1",
+  "data": {
+    "status": "ok",
+    "version": "0.9.1",
+    "memory_count": 42
+  }
+}
+```
+
+### `GET /api/v1/search?q=<text>&limit=<n>`
+
+Searches the same explainable retrieval engine as the CLI. `q` is required;
+`limit` defaults to 20 and accepts 1–50.
+
+Each result includes the namespaced memory ID, score, full stored memory,
+signals, and human-readable ranking reasons:
+
+```json
+{
+  "api_version": "v1",
+  "data": {
+    "query": "linker error",
+    "results": [
+      {
+        "id": 1000000001,
+        "source": "command",
+        "source_id": 1,
+        "command_id": 1,
+        "score": 0.91,
+        "memory": {},
+        "signals": [],
+        "reasons": ["…"]
+      }
+    ]
+  }
+}
+```
+
+### `GET /api/v1/memories/:id`
+
+Returns one namespaced memory by ID, or `404` if it is not present.
+
+### `GET /api/v1/commands/:id`
+
+Returns one captured command run by its raw `command_runs.id`, including command, argv, cwd, exit code,
+stdout, stderr, notes, and timestamp. Malformed historical `argv_json` is
+returned as `null` rather than crashing the API.
+
+Search results include `command_id` when the result comes from a command
+record. Pass that value to this endpoint; do not use the namespaced search
+result `id` as the command route ID.
+
+### `GET /api/v1/sessions?limit=<n>`
+
+Returns the newest captured sessions, bounded by the same 1–50 limit. Each
+session includes its ID, timestamps, status, retained byte count, notes, and
+cwd.
+
+### `GET /api/v1/repositories`
+
+Returns persisted canonical repository IDs, names, and worktree roots. Linked
+worktrees remain distinguishable through `worktree_root` while sharing a
+canonical `id`.
+
+## Authentication
+
+Loopback requests use the same local trust model as the dashboard. When the
+server is bound beyond loopback, every API request must first authenticate with
+the dashboard's `mw_token` cookie obtained from `POST /login`; API keys or
+tokens in query strings are not supported.
+
+## Example
+
+```bash
+curl -fsS 'http://127.0.0.1:7071/api/v1/health'
+curl -fsS --get 'http://127.0.0.1:7071/api/v1/search' \
+  --data-urlencode 'q=linker error' --data-urlencode 'limit=10'
+```
+
+For a coding agent, use [`mw-mcp`](mcp.md). For the human dashboard, omit
+`--api` and open `/`.

--- a/docs/reference/api.openapi.json
+++ b/docs/reference/api.openapi.json
@@ -42,6 +42,9 @@
           {
             "mw_token": []
           },
+          {
+            "bearerAuth": []
+          },
           {}
         ]
       }
@@ -88,6 +91,9 @@
           {
             "mw_token": []
           },
+          {
+            "bearerAuth": []
+          },
           {}
         ]
       }
@@ -127,6 +133,9 @@
         "security": [
           {
             "mw_token": []
+          },
+          {
+            "bearerAuth": []
           },
           {}
         ]
@@ -168,6 +177,9 @@
           {
             "mw_token": []
           },
+          {
+            "bearerAuth": []
+          },
           {}
         ]
       }
@@ -208,6 +220,9 @@
           {
             "mw_token": []
           },
+          {
+            "bearerAuth": []
+          },
           {}
         ]
       }
@@ -239,6 +254,9 @@
         "security": [
           {
             "mw_token": []
+          },
+          {
+            "bearerAuth": []
           },
           {}
         ]
@@ -808,6 +826,11 @@
         "in": "cookie",
         "name": "mw_token",
         "description": "Required when the server uses a token or a non-loopback bind. Loopback binds without an explicit token are open."
+      },
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Accepted when the server uses a token; query-string credentials are never accepted."
       }
     }
   }

--- a/docs/reference/api.openapi.json
+++ b/docs/reference/api.openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "MemoryWhale Local JSON API",
     "version": "1.0.0",
-    "description": "Opt-in, loopback-only, read-only API served by mw-serve --api. Loopback binds may be unauthenticated; non-loopback binds and explicitly configured tokens require the mw_token cookie."
+      "description": "Opt-in, loopback-only, read-only API served by mw-serve --api. Loopback binds may be unauthenticated; token-protected requests accept either the mw_token cookie or Authorization: Bearer credentials, and non-loopback binds always require a token."
   },
   "servers": [
     {

--- a/docs/reference/api.openapi.json
+++ b/docs/reference/api.openapi.json
@@ -1,0 +1,814 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "MemoryWhale Local JSON API",
+    "version": "1.0.0",
+    "description": "Opt-in, loopback-only, read-only API served by mw-serve --api. Loopback binds may be unauthenticated; non-loopback binds and explicitly configured tokens require the mw_token cookie."
+  },
+  "servers": [
+    {
+      "url": "http://127.0.0.1:7071"
+    }
+  ],
+  "paths": {
+    "/api/v1/health": {
+      "get": {
+        "summary": "Check API and database health",
+        "responses": {
+          "200": {
+            "description": "Healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "404": {
+            "$ref": "#/components/responses/ApiDisabled"
+          }
+        },
+        "security": [
+          {
+            "mw_token": []
+          },
+          {}
+        ]
+      }
+    },
+    "/api/v1/search": {
+      "get": {
+        "summary": "Search memories",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Query"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ranked results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "404": {
+            "$ref": "#/components/responses/ApiDisabled"
+          }
+        },
+        "security": [
+          {
+            "mw_token": []
+          },
+          {}
+        ]
+      }
+    },
+    "/api/v1/memories/{id}": {
+      "get": {
+        "summary": "Fetch one memory",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/MemoryId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Memory",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          }
+        },
+        "security": [
+          {
+            "mw_token": []
+          },
+          {}
+        ]
+      }
+    },
+    "/api/v1/commands/{id}": {
+      "get": {
+        "summary": "Fetch one captured command",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/CommandId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Command run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommandResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          }
+        },
+        "security": [
+          {
+            "mw_token": []
+          },
+          {}
+        ]
+      }
+    },
+    "/api/v1/sessions": {
+      "get": {
+        "summary": "List recent sessions",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sessions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "404": {
+            "$ref": "#/components/responses/ApiDisabled"
+          }
+        },
+        "security": [
+          {
+            "mw_token": []
+          },
+          {}
+        ]
+      }
+    },
+    "/api/v1/repositories": {
+      "get": {
+        "summary": "List known repositories and worktrees",
+        "responses": {
+          "200": {
+            "description": "Repositories",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepositoriesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "404": {
+            "$ref": "#/components/responses/ApiDisabled"
+          }
+        },
+        "security": [
+          {
+            "mw_token": []
+          },
+          {}
+        ]
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "Query": {
+        "name": "q",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "Limit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 50,
+          "default": 20
+        }
+      },
+      "MemoryId": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "CommandId": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Invalid request",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "ServiceUnavailable": {
+        "description": "Database or memory loading failed",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Authentication is required for this server bind.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "MethodNotAllowed": {
+        "description": "The endpoint accepts GET or HEAD only.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "ApiDisabled": {
+        "description": "The server was started without --api.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Envelope": {
+        "type": "object",
+        "required": [
+          "api_version",
+          "data"
+        ],
+        "properties": {
+          "api_version": {
+            "const": "v1"
+          },
+          "data": {}
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": [
+          "api_version",
+          "error"
+        ],
+        "properties": {
+          "api_version": {
+            "const": "v1"
+          },
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "HealthResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Envelope"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "required": [
+                  "status",
+                  "version",
+                  "memory_count"
+                ],
+                "properties": {
+                  "status": {
+                    "const": "ok"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "memory_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "MemoryResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Envelope"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "required": [
+                  "memory"
+                ],
+                "properties": {
+                  "memory": {
+                    "$ref": "#/components/schemas/Memory"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "SearchResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Envelope"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "required": [
+                  "query",
+                  "results"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string"
+                  },
+                  "results": {
+                    "type": "array",
+                    "maxItems": 50,
+                    "items": {
+                      "$ref": "#/components/schemas/SearchResult"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "CommandResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Envelope"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/Command"
+              }
+            }
+          }
+        ]
+      },
+      "SessionsResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Envelope"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "required": [
+                  "sessions"
+                ],
+                "properties": {
+                  "sessions": {
+                    "type": "array",
+                    "maxItems": 50,
+                    "items": {
+                      "$ref": "#/components/schemas/Session"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "RepositoriesResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Envelope"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "required": [
+                  "repositories"
+                ],
+                "properties": {
+                  "repositories": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Repository"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Memory": {
+        "type": "object",
+        "required": [
+          "id",
+          "text",
+          "created_at",
+          "last_used",
+          "mentions",
+          "importance",
+          "tags",
+          "embedding"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "text": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_used": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "mentions": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "importance": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "embedding": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "Signal": {
+        "type": "object",
+        "required": [
+          "name",
+          "weight",
+          "score",
+          "applicable",
+          "detail"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "weight": {
+            "type": "number"
+          },
+          "score": {
+            "type": "number"
+          },
+          "applicable": {
+            "type": "boolean"
+          },
+          "detail": {
+            "type": "string"
+          }
+        }
+      },
+      "SearchResult": {
+        "type": "object",
+        "required": [
+          "id",
+          "source",
+          "source_id",
+          "command_id",
+          "score",
+          "memory",
+          "signals",
+          "reasons"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "source": {
+            "type": "string"
+          },
+          "source_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "command_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "score": {
+            "type": "number"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/Memory"
+          },
+          "signals": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Signal"
+            }
+          },
+          "reasons": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Command": {
+        "type": "object",
+        "required": [
+          "id",
+          "command",
+          "argv",
+          "cwd",
+          "exit_code",
+          "stdout",
+          "stderr",
+          "notes",
+          "created_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "command": {
+            "type": "string"
+          },
+          "argv": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "cwd": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "exit_code": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "stdout": {
+            "type": "string"
+          },
+          "stderr": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Session": {
+        "type": "object",
+        "required": [
+          "id",
+          "started_at",
+          "ended_at",
+          "status",
+          "byte_count",
+          "notes",
+          "cwd"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "started_at": {
+            "type": "string"
+          },
+          "ended_at": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "byte_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "notes": {
+            "type": "string"
+          },
+          "cwd": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "Repository": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "worktree_root"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "worktree_root": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "mw_token": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "mw_token",
+        "description": "Required when the server uses a token or a non-loopback bind. Loopback binds without an explicit token are open."
+      }
+    }
+  }
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -164,11 +164,15 @@ add/update/skip breakdown without contacting the server.
 ## mw-serve / mw-view / mw-recover / mw-mcp
 
 ```bash
-mw-serve [--lan | --host addr] [--port n] [--token secret] [--print-token]  # web dashboard + POST /mcp
+mw-serve [--lan | --host addr] [--port n] [--token secret] [--print-token] [--api]  # dashboard, HTTP MCP, optional JSON API
 mw-view <id>                                        # open one memory directly
 mw-recover                                          # recover interrupted recordings
 mw-mcp                                              # MCP server for AI agents (stdio): recent_errors, search_memory, get_context, remember, similar_failures, stats — see docs/reference/mcp.md
 ```
+
+The opt-in `/api/v1` JSON API is enabled with `mw-serve --api`. See the
+[local JSON API reference](api.md) for its read-only endpoints and response
+envelopes.
 
 ## Data location
 

--- a/scripts/check-doc-references.sh
+++ b/scripts/check-doc-references.sh
@@ -30,4 +30,33 @@ if grep -Eq 'Binaries \\(`src-tauri/src/bin/`\\)|Build the helper binaries from 
   exit 1
 fi
 
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+spec = json.loads(Path("docs/reference/api.openapi.json").read_text())
+assert spec.get("openapi", "").startswith("3.")
+assert "mw_token" in spec["components"]["securitySchemes"]
+for response in spec["components"]["responses"].values():
+    media = response.get("content", {}).get("application/json")
+    if media is not None:
+        assert "schema" in media
+for path_item in spec["paths"].values():
+    for operation in path_item.values():
+        if not isinstance(operation, dict):
+            continue
+        assert any(
+            isinstance(requirement.get("mw_token"), list)
+            for requirement in operation.get("security", [])
+        )
+        assert "401" in operation.get("responses", {})
+        for response in operation.get("responses", {}).values():
+            media = response.get("content", {}).get("application/json")
+            if media is not None:
+                assert "schema" in media
+assert spec["components"]["schemas"]["SearchResponse"]["allOf"][1]["properties"]["data"]["properties"]["results"]["maxItems"] == 50
+assert spec["components"]["schemas"]["CommandResponse"]["allOf"][1]["properties"]["data"]["$ref"] == "#/components/schemas/Command"
+assert "command_id" in spec["components"]["schemas"]["SearchResult"]["required"]
+PY
+
 echo "documentation references match $count MCP tools and all CLI binaries"


### PR DESCRIPTION
Implements issue #235 with an opt-in, versioned, read-only local JSON API.

## Endpoints

- `GET /api/v1/health`
- `GET /api/v1/search?q=...&limit=...`
- `GET /api/v1/memories/:id`
- `GET /api/v1/commands/:id`
- `GET /api/v1/sessions?limit=...`
- `GET /api/v1/repositories`

## Security

- disabled unless `mw-serve --api` is passed;
- uses the existing hardened HTTP parser, connection bounds, Host checks, and auth gate;
- loopback by default;
- LAN binds still require the shared token;
- no writes, arbitrary SQL, filesystem reads, or query-string credentials;
- JSON responses use the existing security headers and bounded list limits.

## Docs/tests

Adds `docs/reference/api.md`, CLI/README links, JSON envelope/error documentation, bounded limit tests, and API HTTP response coverage.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace`
- `bash scripts/check-doc-references.sh`
- `git diff --check`
- live `mw-serve --api` health/search curl smoke test

All pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in, versioned, read-only JSON API to `mw-serve` via `--api`.
  * Added health, search, memory, command, session, and repository endpoints with structured responses, authentication, request limits, secret redaction, and clear error handling.

* **Documentation**
  * Added API reference materials, usage examples, CLI guidance, and an OpenAPI specification covering endpoints, responses, security, and limits.
  * Added automated validation for API documentation and response schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->