### PR TITLE
feat(doctor): report per-agent integration status

### DIFF
--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -4063,7 +4063,52 @@ fn doctor() -> Result<(), String> {
         Err(err) => warn("mcp", mcp_remediation(&err)),
     }
 
+    println!("\nIntegrations");
+    print_integration_diagnostics(
+        "Claude Code",
+        "claude",
+        memorywhale_cli::integrate::claude::diagnose(),
+    );
+    print_integration_diagnostics("Rho", "rho", memorywhale_cli::integrate::rho::diagnose());
+
     Ok(())
+}
+
+fn print_integration_diagnostics(
+    name: &str,
+    command_name: &str,
+    diagnostics: Result<memorywhale_cli::integrate::IntegrationDiagnostics, String>,
+) {
+    println!("  {name}");
+    match diagnostics {
+        Ok(status) => {
+            doctor_integration_check(
+                "MCP",
+                status.mcp,
+                &format!("not configured — run `mw integrate {command_name}`"),
+            );
+            doctor_integration_check(
+                "auto-capture",
+                status.auto_capture,
+                &format!("not installed — run `mw integrate {command_name}`"),
+            );
+            doctor_integration_check(
+                "skill",
+                status.skill,
+                &format!("not installed — run `mw integrate {command_name}`"),
+            );
+            println!("    config:       {}", status.config_dir.display());
+        }
+        Err(error) => println!("    WARN:          {error}"),
+    }
+}
+
+fn doctor_integration_check(label: &str, present: bool, remediation: &str) {
+    if present {
+        println!("    {label:<14} ok");
+    } else {
+        println!("    {label:<14} WARN {remediation}");
+    }
 }
 
 fn mcp_remediation(error: &str) -> String {

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -4083,7 +4083,11 @@ fn print_integration_diagnostics(
     doctor_integration_check("MCP", &diagnostics.mcp, command_name);
     doctor_integration_check("auto-capture", &diagnostics.auto_capture, command_name);
     doctor_integration_check("skill", &diagnostics.skill, command_name);
-    println!("    config:       {}", diagnostics.config_dir.display());
+    if let Some(config_dir) = diagnostics.config_dir.as_deref() {
+        println!("    config:       {}", config_dir.display());
+    } else {
+        println!("    config:       unavailable");
+    }
 }
 
 fn doctor_integration_check(
@@ -4095,6 +4099,9 @@ fn doctor_integration_check(
         println!("    {label:<14} ok");
     } else {
         let detail = match status {
+            memorywhale_cli::integrate::ComponentStatus::Missing if label == "MCP" => {
+                format!("not configured — run `mw integrate {command_name}`")
+            }
             memorywhale_cli::integrate::ComponentStatus::Missing => {
                 format!("not installed — run `mw integrate {command_name}`")
             }

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -4077,37 +4077,33 @@ fn doctor() -> Result<(), String> {
 fn print_integration_diagnostics(
     name: &str,
     command_name: &str,
-    diagnostics: Result<memorywhale_cli::integrate::IntegrationDiagnostics, String>,
+    diagnostics: memorywhale_cli::integrate::IntegrationDiagnostics,
 ) {
     println!("  {name}");
-    match diagnostics {
-        Ok(status) => {
-            doctor_integration_check(
-                "MCP",
-                status.mcp,
-                &format!("not configured — run `mw integrate {command_name}`"),
-            );
-            doctor_integration_check(
-                "auto-capture",
-                status.auto_capture,
-                &format!("not installed — run `mw integrate {command_name}`"),
-            );
-            doctor_integration_check(
-                "skill",
-                status.skill,
-                &format!("not installed — run `mw integrate {command_name}`"),
-            );
-            println!("    config:       {}", status.config_dir.display());
-        }
-        Err(error) => println!("    WARN:          {error}"),
-    }
+    doctor_integration_check("MCP", &diagnostics.mcp, command_name);
+    doctor_integration_check("auto-capture", &diagnostics.auto_capture, command_name);
+    doctor_integration_check("skill", &diagnostics.skill, command_name);
+    println!("    config:       {}", diagnostics.config_dir.display());
 }
 
-fn doctor_integration_check(label: &str, present: bool, remediation: &str) {
-    if present {
+fn doctor_integration_check(
+    label: &str,
+    status: &memorywhale_cli::integrate::ComponentStatus,
+    command_name: &str,
+) {
+    if matches!(status, memorywhale_cli::integrate::ComponentStatus::Healthy) {
         println!("    {label:<14} ok");
     } else {
-        println!("    {label:<14} WARN {remediation}");
+        let detail = match status {
+            memorywhale_cli::integrate::ComponentStatus::Missing => {
+                format!("not installed — run `mw integrate {command_name}`")
+            }
+            memorywhale_cli::integrate::ComponentStatus::Invalid(error) => {
+                format!("invalid ({error}) — run `mw integrate {command_name}`")
+            }
+            memorywhale_cli::integrate::ComponentStatus::Healthy => unreachable!(),
+        };
+        println!("    {label:<14} WARN {detail}");
     }
 }
 

--- a/crates/mw-cli/src/integrate/claude.rs
+++ b/crates/mw-cli/src/integrate/claude.rs
@@ -58,6 +58,31 @@ struct ClaudePaths {
     settings_path: PathBuf,
 }
 
+/// Inspect the configured Claude Code files without modifying them.
+pub fn diagnose() -> Result<super::IntegrationDiagnostics, String> {
+    let paths = ClaudePaths::resolve()?;
+    let settings = read_or_empty(&paths.settings_path)?;
+    let auto_capture = if settings.trim().is_empty() {
+        false
+    } else {
+        let settings = parse_settings(&settings)?;
+        settings.hooks.as_ref().is_some_and(|hooks| {
+            hooks
+                .post_tool_use
+                .iter()
+                .chain(hooks.post_tool_use_failure.iter())
+                .flat_map(|group| group.hooks.as_deref().unwrap_or_default())
+                .any(HookEntry::is_memorywhale)
+        })
+    };
+    Ok(super::IntegrationDiagnostics {
+        config_dir: paths.bundled.config_dir,
+        mcp: user_scoped_mcp_registered(MCP_SERVER_NAME),
+        auto_capture,
+        skill: paths.bundled.skill_path.is_file(),
+    })
+}
+
 impl ClaudePaths {
     fn resolve() -> Result<Self, String> {
         let bundled = BundledLayout::from_config_dir(claude_config_dir()?);

--- a/crates/mw-cli/src/integrate/claude.rs
+++ b/crates/mw-cli/src/integrate/claude.rs
@@ -60,7 +60,17 @@ struct ClaudePaths {
 
 /// Inspect the configured Claude Code files without modifying them.
 pub fn diagnose() -> super::IntegrationDiagnostics {
-    let config_dir = claude_config_dir().unwrap_or_default();
+    let config_dir = match claude_config_dir() {
+        Ok(config_dir) => config_dir,
+        Err(error) => {
+            return super::IntegrationDiagnostics {
+                config_dir: None,
+                mcp: super::ComponentStatus::Invalid(error.clone()),
+                auto_capture: super::ComponentStatus::Invalid(error.clone()),
+                skill: super::ComponentStatus::Invalid(error),
+            }
+        }
+    };
     let paths = ClaudePaths {
         bundled: BundledLayout::from_config_dir(config_dir.clone()),
         settings_path: config_dir.join("settings.json"),
@@ -71,7 +81,7 @@ pub fn diagnose() -> super::IntegrationDiagnostics {
             Ok(settings) => {
                 let Some(remember_path) = mw_remember_executable().ok() else {
                     return super::IntegrationDiagnostics {
-                        config_dir,
+                        config_dir: Some(config_dir),
                         mcp: claude_mcp_status(MCP_SERVER_NAME),
                         auto_capture: super::ComponentStatus::Invalid(
                             "mw-remember executable was not found".to_string(),
@@ -81,7 +91,7 @@ pub fn diagnose() -> super::IntegrationDiagnostics {
                 };
                 let Some(hooks) = settings.hooks else {
                     return super::IntegrationDiagnostics {
-                        config_dir,
+                        config_dir: Some(config_dir),
                         mcp: claude_mcp_status(MCP_SERVER_NAME),
                         auto_capture: super::ComponentStatus::Missing,
                         skill: component_file_status(&paths.bundled.skill_path),
@@ -107,7 +117,7 @@ pub fn diagnose() -> super::IntegrationDiagnostics {
         Err(error) => super::ComponentStatus::Invalid(error),
     };
     super::IntegrationDiagnostics {
-        config_dir,
+        config_dir: Some(config_dir),
         mcp: claude_mcp_status(MCP_SERVER_NAME),
         auto_capture,
         skill: component_file_status(&paths.bundled.skill_path),

--- a/crates/mw-cli/src/integrate/claude.rs
+++ b/crates/mw-cli/src/integrate/claude.rs
@@ -59,28 +59,93 @@ struct ClaudePaths {
 }
 
 /// Inspect the configured Claude Code files without modifying them.
-pub fn diagnose() -> Result<super::IntegrationDiagnostics, String> {
-    let paths = ClaudePaths::resolve()?;
-    let settings = read_or_empty(&paths.settings_path)?;
-    let auto_capture = if settings.trim().is_empty() {
-        false
-    } else {
-        let settings = parse_settings(&settings)?;
-        settings.hooks.as_ref().is_some_and(|hooks| {
-            hooks
-                .post_tool_use
-                .iter()
-                .chain(hooks.post_tool_use_failure.iter())
-                .flat_map(|group| group.hooks.as_deref().unwrap_or_default())
-                .any(HookEntry::is_memorywhale)
-        })
+pub fn diagnose() -> super::IntegrationDiagnostics {
+    let config_dir = claude_config_dir().unwrap_or_default();
+    let paths = ClaudePaths {
+        bundled: BundledLayout::from_config_dir(config_dir.clone()),
+        settings_path: config_dir.join("settings.json"),
     };
-    Ok(super::IntegrationDiagnostics {
-        config_dir: paths.bundled.config_dir,
-        mcp: user_scoped_mcp_registered(MCP_SERVER_NAME),
+    let auto_capture = match read_or_empty(&paths.settings_path) {
+        Ok(settings) if settings.trim().is_empty() => super::ComponentStatus::Missing,
+        Ok(settings) => match parse_settings(&settings) {
+            Ok(settings) => {
+                let Some(remember_path) = mw_remember_executable().ok() else {
+                    return super::IntegrationDiagnostics {
+                        config_dir,
+                        mcp: claude_mcp_status(MCP_SERVER_NAME),
+                        auto_capture: super::ComponentStatus::Invalid(
+                            "mw-remember executable was not found".to_string(),
+                        ),
+                        skill: component_file_status(&paths.bundled.skill_path),
+                    };
+                };
+                let Some(hooks) = settings.hooks else {
+                    return super::IntegrationDiagnostics {
+                        config_dir,
+                        mcp: claude_mcp_status(MCP_SERVER_NAME),
+                        auto_capture: super::ComponentStatus::Missing,
+                        skill: component_file_status(&paths.bundled.skill_path),
+                    };
+                };
+                let has_hook = |groups: &[HookGroup]| {
+                    groups
+                        .iter()
+                        .filter(|group| group.matcher.as_deref() == Some("Bash"))
+                        .flat_map(|group| group.hooks.as_deref().unwrap_or_default())
+                        .any(|hook| hook.matches(&remember_path))
+                };
+                if has_hook(&hooks.post_tool_use) && has_hook(&hooks.post_tool_use_failure) {
+                    super::ComponentStatus::Healthy
+                } else {
+                    super::ComponentStatus::Invalid(
+                        "one or both Bash capture hooks are missing or stale".to_string(),
+                    )
+                }
+            }
+            Err(error) => super::ComponentStatus::Invalid(error),
+        },
+        Err(error) => super::ComponentStatus::Invalid(error),
+    };
+    super::IntegrationDiagnostics {
+        config_dir,
+        mcp: claude_mcp_status(MCP_SERVER_NAME),
         auto_capture,
-        skill: paths.bundled.skill_path.is_file(),
-    })
+        skill: component_file_status(&paths.bundled.skill_path),
+    }
+}
+
+fn component_file_status(path: &Path) -> super::ComponentStatus {
+    if path.is_file() {
+        super::ComponentStatus::Healthy
+    } else {
+        super::ComponentStatus::Missing
+    }
+}
+
+fn claude_mcp_status(server_name: &str) -> super::ComponentStatus {
+    let Some(path) = user_scoped_mcp_config_path() else {
+        return super::ComponentStatus::Missing;
+    };
+    let content = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return super::ComponentStatus::Missing
+        }
+        Err(error) => {
+            return super::ComponentStatus::Invalid(format!(
+                "failed to read {}: {error}",
+                path.display()
+            ))
+        }
+    };
+    let Some(entry) = user_scoped_mcp_entry_in_config(&content, server_name) else {
+        return super::ComponentStatus::Missing;
+    };
+    if mcp_server_entry_matches(&entry) {
+        super::ComponentStatus::Healthy
+    } else {
+        super::ComponentStatus::Invalid("memorywhale MCP entry is stale or unusable".to_string())
+    }
 }
 
 impl ClaudePaths {
@@ -156,6 +221,11 @@ impl HookEntry {
         self.command
             .as_deref()
             .is_some_and(is_memorywhale_hook_command)
+    }
+
+    fn matches(&self, remember_path: &Path) -> bool {
+        self.hook_type.as_deref() == Some("command")
+            && self.command.as_deref() == Some(hook_command(remember_path).as_str())
     }
 }
 

--- a/crates/mw-cli/src/integrate/mod.rs
+++ b/crates/mw-cli/src/integrate/mod.rs
@@ -10,11 +10,19 @@ pub mod rho;
 
 pub(crate) const SKILL: &str = include_str!("../../integrate/SKILL.md");
 
+/// The independently detectable state of one integration component.
+#[derive(Debug, Clone)]
+pub enum ComponentStatus {
+    Healthy,
+    Missing,
+    Invalid(String),
+}
+
 /// The independently detectable pieces of an agent integration.
 #[derive(Debug, Clone)]
 pub struct IntegrationDiagnostics {
     pub config_dir: PathBuf,
-    pub mcp: bool,
-    pub auto_capture: bool,
-    pub skill: bool,
+    pub mcp: ComponentStatus,
+    pub auto_capture: ComponentStatus,
+    pub skill: ComponentStatus,
 }

--- a/crates/mw-cli/src/integrate/mod.rs
+++ b/crates/mw-cli/src/integrate/mod.rs
@@ -1,5 +1,7 @@
 //! Agent integrations installed by `mw integrate`.
 
+use std::path::PathBuf;
+
 mod files;
 
 pub mod claude;
@@ -7,3 +9,12 @@ pub mod hermes;
 pub mod rho;
 
 pub(crate) const SKILL: &str = include_str!("../../integrate/SKILL.md");
+
+/// The independently detectable pieces of an agent integration.
+#[derive(Debug, Clone)]
+pub struct IntegrationDiagnostics {
+    pub config_dir: PathBuf,
+    pub mcp: bool,
+    pub auto_capture: bool,
+    pub skill: bool,
+}

--- a/crates/mw-cli/src/integrate/mod.rs
+++ b/crates/mw-cli/src/integrate/mod.rs
@@ -21,7 +21,7 @@ pub enum ComponentStatus {
 /// The independently detectable pieces of an agent integration.
 #[derive(Debug, Clone)]
 pub struct IntegrationDiagnostics {
-    pub config_dir: PathBuf,
+    pub config_dir: Option<PathBuf>,
     pub mcp: ComponentStatus,
     pub auto_capture: ComponentStatus,
     pub skill: ComponentStatus,

--- a/crates/mw-cli/src/integrate/rho/mcp.rs
+++ b/crates/mw-cli/src/integrate/rho/mcp.rs
@@ -273,39 +273,46 @@ pub(super) fn merge_mcp(existing: &str, target: &McpTarget) -> Result<(String, b
     Ok((doc.to_string(), true))
 }
 
-pub(super) fn configured(existing: &str) -> Result<bool, String> {
+pub(super) fn configured(existing: &str) -> Result<Option<bool>, String> {
     if existing.trim().is_empty() {
-        return Ok(false);
+        return Ok(None);
     }
     let doc = parse_toml(existing, "config.toml")?;
     require_mcp_tables(&doc)?;
-    Ok(memorywhale_server(&doc).is_some_and(|server| {
-        if server.get("enabled").and_then(Item::as_bool) == Some(false) {
-            return false;
-        }
-        match server.get("transport").and_then(Item::as_str) {
-            Some(MCP_TRANSPORT) => mcp_server_matches(&doc, &McpTarget::stdio()),
-            Some(MCP_HTTP_TRANSPORT) => {
-                let Some(url) = server.get("url").and_then(Item::as_str) else {
-                    return false;
-                };
-                if url.trim().is_empty() {
-                    return false;
-                }
-                let allow_insecure = server
-                    .get("allow_insecure_http")
-                    .and_then(Item::as_bool)
-                    .unwrap_or(false);
-                let authorization_from_env =
-                    authorization_env_name(server).ok().flatten().is_some();
-                mcp_server_matches(
-                    &doc,
-                    &McpTarget::http(url.to_string(), allow_insecure, authorization_from_env),
-                )
+    let Some(server) = memorywhale_server(&doc) else {
+        return Ok(None);
+    };
+    if server.get("enabled").and_then(Item::as_bool) == Some(false)
+        || headers_from_env_is_table(server).is_err()
+    {
+        return Ok(Some(false));
+    }
+    let configured = match server.get("transport").and_then(Item::as_str) {
+        Some(MCP_TRANSPORT) => mcp_server_matches(&doc, &McpTarget::stdio()),
+        Some(MCP_HTTP_TRANSPORT) => {
+            let Some(url) = server.get("url").and_then(Item::as_str) else {
+                return Ok(Some(false));
+            };
+            if url.trim().is_empty() {
+                return Ok(Some(false));
             }
-            _ => false,
+            let kind = match super::classify_http_url(url) {
+                Ok(kind) => kind,
+                Err(_) => return Ok(Some(false)),
+            };
+            let allow_insecure = kind.http && !kind.loopback;
+            let authorization_from_env = authorization_env_name(server)
+                .ok()
+                .flatten()
+                .is_some_and(|name| name == "MEMORYWHALE_AUTHORIZATION");
+            mcp_server_matches(
+                &doc,
+                &McpTarget::http(url.to_string(), allow_insecure, authorization_from_env),
+            )
         }
-    }))
+        _ => false,
+    };
+    Ok(Some(configured))
 }
 
 fn remove_key(table: &mut dyn TableLike, key: &str) -> bool {

--- a/crates/mw-cli/src/integrate/rho/mcp.rs
+++ b/crates/mw-cli/src/integrate/rho/mcp.rs
@@ -284,10 +284,25 @@ pub(super) fn configured(existing: &str) -> Result<bool, String> {
             return false;
         }
         match server.get("transport").and_then(Item::as_str) {
-            Some(MCP_TRANSPORT) => {
-                server.get("command").and_then(Item::as_str) == Some(MCP_COMMAND)
+            Some(MCP_TRANSPORT) => mcp_server_matches(&doc, &McpTarget::stdio()),
+            Some(MCP_HTTP_TRANSPORT) => {
+                let Some(url) = server.get("url").and_then(Item::as_str) else {
+                    return false;
+                };
+                if url.trim().is_empty() {
+                    return false;
+                }
+                let allow_insecure = server
+                    .get("allow_insecure_http")
+                    .and_then(Item::as_bool)
+                    .unwrap_or(false);
+                let authorization_from_env =
+                    authorization_env_name(server).ok().flatten().is_some();
+                mcp_server_matches(
+                    &doc,
+                    &McpTarget::http(url.to_string(), allow_insecure, authorization_from_env),
+                )
             }
-            Some(MCP_HTTP_TRANSPORT) => server.get("url").and_then(Item::as_str).is_some(),
             _ => false,
         }
     }))

--- a/crates/mw-cli/src/integrate/rho/mcp.rs
+++ b/crates/mw-cli/src/integrate/rho/mcp.rs
@@ -273,6 +273,26 @@ pub(super) fn merge_mcp(existing: &str, target: &McpTarget) -> Result<(String, b
     Ok((doc.to_string(), true))
 }
 
+pub(super) fn configured(existing: &str) -> Result<bool, String> {
+    if existing.trim().is_empty() {
+        return Ok(false);
+    }
+    let doc = parse_toml(existing, "config.toml")?;
+    require_mcp_tables(&doc)?;
+    Ok(memorywhale_server(&doc).is_some_and(|server| {
+        if server.get("enabled").and_then(Item::as_bool) == Some(false) {
+            return false;
+        }
+        match server.get("transport").and_then(Item::as_str) {
+            Some(MCP_TRANSPORT) => {
+                server.get("command").and_then(Item::as_str) == Some(MCP_COMMAND)
+            }
+            Some(MCP_HTTP_TRANSPORT) => server.get("url").and_then(Item::as_str).is_some(),
+            _ => false,
+        }
+    }))
+}
+
 fn remove_key(table: &mut dyn TableLike, key: &str) -> bool {
     table.remove(key).is_some()
 }

--- a/crates/mw-cli/src/integrate/rho/mod.rs
+++ b/crates/mw-cli/src/integrate/rho/mod.rs
@@ -182,6 +182,26 @@ struct RhoPaths {
     config_path: PathBuf,
 }
 
+/// Inspect the configured Rho files without modifying them.
+pub fn diagnose() -> Result<super::IntegrationDiagnostics, String> {
+    let paths = RhoPaths::resolve()?;
+    let remember_path = mw_remember_executable()?;
+    let hooks = read_or_empty(&paths.hooks_path)?;
+    let hooks_doc = parse_toml(&hooks, "hooks.toml")?;
+    require_hooks_version(&hooks_doc)?;
+    let auto_capture = hooks_doc
+        .get("hook")
+        .and_then(Item::as_array_of_tables)
+        .is_some_and(|hooks| hooks.iter().any(|hook| hook_matches(hook, &remember_path)));
+    let config = read_or_empty(&paths.config_path)?;
+    Ok(super::IntegrationDiagnostics {
+        config_dir: paths.bundled.config_dir,
+        mcp: mcp::configured(&config)?,
+        auto_capture,
+        skill: paths.bundled.skill_path.is_file(),
+    })
+}
+
 impl RhoPaths {
     fn resolve() -> Result<Self, String> {
         let bundled = BundledLayout::from_config_dir(rho_home()?);

--- a/crates/mw-cli/src/integrate/rho/mod.rs
+++ b/crates/mw-cli/src/integrate/rho/mod.rs
@@ -184,7 +184,17 @@ struct RhoPaths {
 
 /// Inspect the configured Rho files without modifying them.
 pub fn diagnose() -> super::IntegrationDiagnostics {
-    let config_dir = rho_home().unwrap_or_default();
+    let config_dir = match rho_home() {
+        Ok(config_dir) => config_dir,
+        Err(error) => {
+            return super::IntegrationDiagnostics {
+                config_dir: None,
+                mcp: super::ComponentStatus::Invalid(error.clone()),
+                auto_capture: super::ComponentStatus::Invalid(error.clone()),
+                skill: super::ComponentStatus::Invalid(error),
+            }
+        }
+    };
     let paths = RhoPaths {
         bundled: BundledLayout::from_config_dir(config_dir.clone()),
         hooks_path: config_dir.join("hooks.toml"),
@@ -196,7 +206,7 @@ pub fn diagnose() -> super::IntegrationDiagnostics {
             Ok(hooks_doc) => {
                 let Some(remember_path) = mw_remember_executable().ok() else {
                     return super::IntegrationDiagnostics {
-                        config_dir,
+                        config_dir: Some(config_dir),
                         mcp: mcp_status(&paths.config_path),
                         auto_capture: super::ComponentStatus::Invalid(
                             "mw-remember executable was not found".to_string(),
@@ -223,7 +233,7 @@ pub fn diagnose() -> super::IntegrationDiagnostics {
         Err(error) => super::ComponentStatus::Invalid(error),
     };
     super::IntegrationDiagnostics {
-        config_dir,
+        config_dir: Some(config_dir),
         mcp: mcp_status(&paths.config_path),
         auto_capture,
         skill: component_file_status(&paths.bundled.skill_path),
@@ -242,8 +252,9 @@ fn mcp_status(path: &Path) -> super::ComponentStatus {
     match read_or_empty(path) {
         Ok(config) if config.trim().is_empty() => super::ComponentStatus::Missing,
         Ok(config) => match mcp::configured(&config) {
-            Ok(true) => super::ComponentStatus::Healthy,
-            Ok(false) => super::ComponentStatus::Invalid(
+            Ok(Some(true)) => super::ComponentStatus::Healthy,
+            Ok(None) => super::ComponentStatus::Missing,
+            Ok(Some(false)) => super::ComponentStatus::Invalid(
                 "Rho memorywhale MCP entry is stale or unusable".to_string(),
             ),
             Err(error) => super::ComponentStatus::Invalid(error),

--- a/crates/mw-cli/src/integrate/rho/mod.rs
+++ b/crates/mw-cli/src/integrate/rho/mod.rs
@@ -183,23 +183,73 @@ struct RhoPaths {
 }
 
 /// Inspect the configured Rho files without modifying them.
-pub fn diagnose() -> Result<super::IntegrationDiagnostics, String> {
-    let paths = RhoPaths::resolve()?;
-    let remember_path = mw_remember_executable()?;
-    let hooks = read_or_empty(&paths.hooks_path)?;
-    let hooks_doc = parse_toml(&hooks, "hooks.toml")?;
-    require_hooks_version(&hooks_doc)?;
-    let auto_capture = hooks_doc
-        .get("hook")
-        .and_then(Item::as_array_of_tables)
-        .is_some_and(|hooks| hooks.iter().any(|hook| hook_matches(hook, &remember_path)));
-    let config = read_or_empty(&paths.config_path)?;
-    Ok(super::IntegrationDiagnostics {
-        config_dir: paths.bundled.config_dir,
-        mcp: mcp::configured(&config)?,
+pub fn diagnose() -> super::IntegrationDiagnostics {
+    let config_dir = rho_home().unwrap_or_default();
+    let paths = RhoPaths {
+        bundled: BundledLayout::from_config_dir(config_dir.clone()),
+        hooks_path: config_dir.join("hooks.toml"),
+        config_path: config_dir.join("config.toml"),
+    };
+    let auto_capture = match read_or_empty(&paths.hooks_path) {
+        Ok(hooks) if hooks.trim().is_empty() => super::ComponentStatus::Missing,
+        Ok(hooks) => match parse_toml(&hooks, "hooks.toml") {
+            Ok(hooks_doc) => {
+                let Some(remember_path) = mw_remember_executable().ok() else {
+                    return super::IntegrationDiagnostics {
+                        config_dir,
+                        mcp: mcp_status(&paths.config_path),
+                        auto_capture: super::ComponentStatus::Invalid(
+                            "mw-remember executable was not found".to_string(),
+                        ),
+                        skill: component_file_status(&paths.bundled.skill_path),
+                    };
+                };
+                if hooks_doc
+                    .get("hook")
+                    .and_then(Item::as_array_of_tables)
+                    .is_some_and(|hooks| {
+                        hooks.iter().any(|hook| hook_matches(hook, &remember_path))
+                    })
+                {
+                    super::ComponentStatus::Healthy
+                } else {
+                    super::ComponentStatus::Invalid(
+                        "Rho capture hook is missing or stale".to_string(),
+                    )
+                }
+            }
+            Err(error) => super::ComponentStatus::Invalid(error),
+        },
+        Err(error) => super::ComponentStatus::Invalid(error),
+    };
+    super::IntegrationDiagnostics {
+        config_dir,
+        mcp: mcp_status(&paths.config_path),
         auto_capture,
-        skill: paths.bundled.skill_path.is_file(),
-    })
+        skill: component_file_status(&paths.bundled.skill_path),
+    }
+}
+
+fn component_file_status(path: &Path) -> super::ComponentStatus {
+    if path.is_file() {
+        super::ComponentStatus::Healthy
+    } else {
+        super::ComponentStatus::Missing
+    }
+}
+
+fn mcp_status(path: &Path) -> super::ComponentStatus {
+    match read_or_empty(path) {
+        Ok(config) if config.trim().is_empty() => super::ComponentStatus::Missing,
+        Ok(config) => match mcp::configured(&config) {
+            Ok(true) => super::ComponentStatus::Healthy,
+            Ok(false) => super::ComponentStatus::Invalid(
+                "Rho memorywhale MCP entry is stale or unusable".to_string(),
+            ),
+            Err(error) => super::ComponentStatus::Invalid(error),
+        },
+        Err(error) => super::ComponentStatus::Invalid(error),
+    }
 }
 
 impl RhoPaths {

--- a/crates/mw-cli/tests/claude_integration.rs
+++ b/crates/mw-cli/tests/claude_integration.rs
@@ -42,6 +42,51 @@ fn custom_claude_config_dir_mcp_state_is_read_from_matching_claude_json() {
 }
 
 #[test]
+fn doctor_reports_claude_and_rho_integration_components() {
+    let claude_dir = sandbox("doctor-claude");
+    let rho_dir = sandbox("doctor-rho");
+    let data_dir = sandbox("doctor-data");
+
+    for (client, home_var) in [("claude", "CLAUDE_CONFIG_DIR"), ("rho", "RHO_HOME")] {
+        let home = if client == "claude" {
+            &claude_dir
+        } else {
+            &rho_dir
+        };
+        let output = mw_cmd()
+            .args(["integrate", client])
+            .env(home_var, home)
+            .env("MEMORYWHALE_DATA_DIR", &data_dir)
+            .output()
+            .expect("run integration installer");
+        assert!(output.status.success(), "installer failed: {output:?}");
+    }
+
+    let output = mw_cmd()
+        .arg("doctor")
+        .env("CLAUDE_CONFIG_DIR", &claude_dir)
+        .env("RHO_HOME", &rho_dir)
+        .env("MEMORYWHALE_DATA_DIR", &data_dir)
+        .output()
+        .expect("run doctor");
+    assert!(output.status.success(), "doctor failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Claude Code"),
+        "missing Claude section: {stdout}"
+    );
+    assert!(stdout.contains("Rho"), "missing Rho section: {stdout}");
+    assert!(
+        stdout.contains("auto-capture   ok"),
+        "missing hook status: {stdout}"
+    );
+    assert!(
+        stdout.contains("skill          ok"),
+        "missing skill status: {stdout}"
+    );
+}
+
+#[test]
 fn user_can_install_memorywhale_into_a_fresh_claude_config() {
     let claude_dir = sandbox("fresh");
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -94,7 +94,9 @@ the payload was secret-redacted at capture time.
 read-only MCP handshake and `tools/list` request. It reports whether the
 binary is missing, timed out, returned an invalid response, or advertised the
 expected six tools. It never calls a memory tool or edits a client
-configuration.
+configuration. The `Integrations` section independently reports whether the
+Claude Code and Rho MCP registration, automatic-capture hook, and skill are
+present, honoring `CLAUDE_CONFIG_DIR` and `RHO_HOME`.
 
 `mw git-fix` recognizes a handful of common git failure shapes — push rejected
 (non-fast-forward), merge conflicts, a dirty working tree blocking an


### PR DESCRIPTION
Implements issue #239.

## Changes

- adds shared `IntegrationDiagnostics` status data;
- reuses existing Claude config parsing/path resolution to report MCP, auto-capture hook, and skill independently;
- reuses existing Rho TOML/MCP parsing and path resolution for the same three checks;
- honors `CLAUDE_CONFIG_DIR` and `RHO_HOME`;
- prints actionable `mw integrate claude` / `mw integrate rho` remediation with the correct command slug;
- distinguishes missing optional client integration from core database/MCP failures;
- documents the expanded `mw doctor` output;
- validates supported Rho MCP transports instead of treating arbitrary entries as configured.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p memorywhale-core -p memorywhale-cli --all-targets -- -D warnings`
- `cargo test -p memorywhale-core -p memorywhale-cli`
- `bash scripts/check-doc-references.sh`
- custom-path end-to-end doctor integration test
- `git diff --check`

All pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `mw doctor` to report Claude Code and Rho integration health.
  * Checks MCP registration, automatic-capture hooks, installed skills, and configuration locations.
  * Distinguishes healthy, missing, invalid, and unconfigured components, with actionable remediation details.
  * Reports unavailable configuration directories without substituting default locations.
  * Continues providing diagnostics when individual files or executables are unavailable.

* **Documentation**
  * Updated CLI documentation to describe integration diagnostics and supported configuration directories.

* **Tests**
  * Added coverage validating successful diagnostics after installing Claude Code and Rho integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->