### PR TITLE
feat(doctor): report per-agent MCP and automatic-capture status

### DIFF
--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -313,7 +313,7 @@ fn print_help() {
          mw context [project:name] [--last-error] [--limit N]  print a compact digest to paste into an AI agent\n\
          mw agent [session-id]    export a full session as agent-ready text to paste later (default: latest)\n\
          mw ask [question] [--chat chatgpt|claude|gemini|URL] [--session] [--no-open]  package the last failure for your chat AI\n\
-         mw doctor                check the install, shell hooks, and MCP server\n\
+         mw doctor                check the install, shell hooks, MCP server, and Claude/Rho integrations\n\
          mw global on|off|status  auto-record every new terminal by wiring a shell startup hook\n\
          mw hooks install|uninstall  always-on lightweight capture: command, cwd, exit code, duration (no output)\n\
          mw integrate claude [--revert]  install or remove Claude Code hook, skill, and MCP\n\
@@ -4026,6 +4026,7 @@ fn doctor() -> Result<(), String> {
     }
 
     let mcp_binary = sibling_binary("mw-mcp");
+    let mut mcp_stdio_ok = false;
     match probe_mcp_server(&mcp_binary, &[], Duration::from_secs(2)) {
         Ok(probe) => {
             let expected = [
@@ -4042,6 +4043,7 @@ fn doctor() -> Result<(), String> {
                 .filter(|name| !probe.tools.iter().any(|tool| tool == name))
                 .collect();
             if missing.is_empty() {
+                mcp_stdio_ok = true;
                 ok(
                     "mcp",
                     format!(
@@ -4062,6 +4064,11 @@ fn doctor() -> Result<(), String> {
         }
         Err(err) => warn("mcp", mcp_remediation(&err)),
     }
+
+    print!(
+        "{}",
+        memorywhale_cli::integrate::render_doctor_reports(mcp_stdio_ok)
+    );
 
     Ok(())
 }

--- a/crates/mw-cli/src/integrate/claude/inspect.rs
+++ b/crates/mw-cli/src/integrate/claude/inspect.rs
@@ -16,7 +16,7 @@ use crate::integrate::report::{IntegrationReport, McpFact, PieceStatus};
 /// Inspect Claude Code MCP, hook, and skill status without mutating files or
 /// running the Claude CLI.
 pub(crate) fn doctor_report(mcp_stdio_ok: bool) -> IntegrationReport {
-    let env_set = std::env::var_os("CLAUDE_CONFIG_DIR").is_some();
+    let env_set = std::env::var_os("CLAUDE_CONFIG_DIR").is_some_and(|value| !value.is_empty());
     let Ok(config_dir) = claude_config_dir() else {
         return IntegrationReport::not_detected("Claude Code", "claude");
     };
@@ -58,10 +58,13 @@ fn inspect_mcp(mcp_config_path: &Path) -> McpFact {
     let Ok(value) = serde_json::from_str::<Value>(&content) else {
         return McpFact::Unreadable;
     };
-    match value
-        .get("mcpServers")
-        .and_then(|servers| servers.get(MCP_SERVER_NAME))
-    {
+    let Some(servers) = value.get("mcpServers") else {
+        return McpFact::Absent;
+    };
+    let Some(servers) = servers.as_object() else {
+        return McpFact::Unreadable;
+    };
+    match servers.get(MCP_SERVER_NAME) {
         None => McpFact::Absent,
         Some(entry) if mcp_server_entry_matches(entry) => McpFact::Stdio,
         Some(_) => McpFact::Stale,
@@ -110,15 +113,16 @@ fn memorywhale_bash_commands(groups: &[HookGroup]) -> Vec<String> {
 }
 
 fn hook_commands_current(commands: &[String], remember_path: Option<&Path>) -> bool {
-    commands
-        .iter()
-        .any(|command| hook_command_is_current(command, remember_path))
+    !commands.is_empty()
+        && commands
+            .iter()
+            .all(|command| hook_command_is_current(command, remember_path))
 }
 
 fn hook_command_is_current(command: &str, remember_path: Option<&Path>) -> bool {
     match remember_path {
         Some(path) => command.trim() == hook_command(path),
-        None => is_memorywhale_hook_command(command) && !command.trim().starts_with("python3 \""),
+        None => false,
     }
 }
 
@@ -224,6 +228,68 @@ mod tests {
         assert_eq!(report.mcp, McpStatus::Unreadable);
         assert_eq!(report.hook, PieceStatus::Unreadable);
         assert_eq!(report.skill, PieceStatus::Installed);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_missing_helper_does_not_report_hook_installed() {
+        let dir = sandbox("no-helper");
+        let remember = remember();
+        let (settings, _) = merge_settings("", &remember).unwrap();
+        let stale = settings.replace(
+            remember.display().to_string().as_str(),
+            "/old/bin/mw-remember",
+        );
+        std::fs::write(dir.join("settings.json"), stale).unwrap();
+        let report = inspect_at(&dir, &dir.join(".claude.json"), None, false);
+        assert_eq!(report.hook, PieceStatus::Stale);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_mixed_current_and_stale_hook_is_stale() {
+        let dir = sandbox("mixed-hooks");
+        let remember = remember();
+        let current = hook_command(&remember);
+        let settings = serde_json::json!({
+            "hooks": {
+                "PostToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": current},
+                        {"type": "command", "command": "\"/old/bin/mw-remember\" --from-hook claude"}
+                    ]
+                }],
+                "PostToolUseFailure": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": current}
+                    ]
+                }]
+            }
+        });
+        std::fs::write(dir.join("settings.json"), settings.to_string()).unwrap();
+        let report = inspect_at(&dir, &dir.join(".claude.json"), Some(&remember), false);
+        assert_eq!(report.hook, PieceStatus::Stale);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_invalid_mcp_servers_container_is_unreadable() {
+        let dir = sandbox("mcp-array");
+        std::fs::write(dir.join(".claude.json"), r#"{"mcpServers":[]}"#).unwrap();
+        let report = inspect_at(&dir, &dir.join(".claude.json"), Some(&remember()), true);
+        assert_eq!(report.mcp, McpStatus::Unreadable);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_unreadable_skill_is_not_absence() {
+        let dir = sandbox("bad-skill");
+        std::fs::create_dir_all(dir.join("skills/memorywhale")).unwrap();
+        std::fs::write(dir.join("skills/memorywhale/SKILL.md"), [0xff, 0xfe]).unwrap();
+        let report = inspect_at(&dir, &dir.join(".claude.json"), Some(&remember()), false);
+        assert_eq!(report.skill, PieceStatus::Unreadable);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/mw-cli/src/integrate/claude/inspect.rs
+++ b/crates/mw-cli/src/integrate/claude/inspect.rs
@@ -1,0 +1,253 @@
+//! Read-only Claude Code doctor inspection.
+
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::{
+    claude_config_dir, hook_command, is_memorywhale_hook_command, mcp_server_entry_matches,
+    parse_settings, user_scoped_mcp_config_path, HookGroup, MCP_SERVER_NAME,
+};
+use crate::integrate::files::{
+    command_on_path, mw_remember_executable, read_existing, skill_is_installed,
+};
+use crate::integrate::report::{IntegrationReport, McpFact, PieceStatus};
+
+/// Inspect Claude Code MCP, hook, and skill status without mutating files or
+/// running the Claude CLI.
+pub(crate) fn doctor_report(mcp_stdio_ok: bool) -> IntegrationReport {
+    let env_set = std::env::var_os("CLAUDE_CONFIG_DIR").is_some();
+    let Ok(config_dir) = claude_config_dir() else {
+        return IntegrationReport::not_detected("Claude Code", "claude");
+    };
+    let mcp_path = user_scoped_mcp_config_path().unwrap_or_else(|| config_dir.join(".claude.json"));
+    let detected =
+        env_set || config_dir.exists() || mcp_path.is_file() || command_on_path("claude");
+    if !detected {
+        return IntegrationReport::not_detected("Claude Code", "claude");
+    }
+    inspect_at(
+        &config_dir,
+        &mcp_path,
+        mw_remember_executable().ok().as_deref(),
+        mcp_stdio_ok,
+    )
+}
+
+fn inspect_at(
+    config_dir: &Path,
+    mcp_config_path: &Path,
+    remember_path: Option<&Path>,
+    mcp_stdio_ok: bool,
+) -> IntegrationReport {
+    IntegrationReport::detected(
+        "Claude Code",
+        "claude",
+        inspect_mcp(mcp_config_path).into_status(mcp_stdio_ok),
+        inspect_hook(config_dir, remember_path),
+        PieceStatus::skill(skill_is_installed(config_dir)),
+    )
+}
+
+fn inspect_mcp(mcp_config_path: &Path) -> McpFact {
+    let content = match read_existing(mcp_config_path) {
+        Ok(Some(text)) => text,
+        Ok(None) => return McpFact::Absent,
+        Err(_) => return McpFact::Unreadable,
+    };
+    let Ok(value) = serde_json::from_str::<Value>(&content) else {
+        return McpFact::Unreadable;
+    };
+    match value
+        .get("mcpServers")
+        .and_then(|servers| servers.get(MCP_SERVER_NAME))
+    {
+        None => McpFact::Absent,
+        Some(entry) if mcp_server_entry_matches(entry) => McpFact::Stdio,
+        Some(_) => McpFact::Stale,
+    }
+}
+
+fn inspect_hook(config_dir: &Path, remember_path: Option<&Path>) -> PieceStatus {
+    let content = match read_existing(&config_dir.join("settings.json")) {
+        Ok(None) => return PieceStatus::NotInstalled,
+        Err(_) => return PieceStatus::Unreadable,
+        Ok(Some(text)) => text,
+    };
+    let settings = match parse_settings(&content) {
+        Ok(settings) => settings,
+        Err(_) => return PieceStatus::Unreadable,
+    };
+    let Some(hooks) = settings.hooks.as_ref() else {
+        return PieceStatus::NotInstalled;
+    };
+    let post = memorywhale_bash_commands(&hooks.post_tool_use);
+    let failure = memorywhale_bash_commands(&hooks.post_tool_use_failure);
+    if post.is_empty() && failure.is_empty() {
+        return PieceStatus::NotInstalled;
+    }
+    if hook_commands_current(&post, remember_path) && hook_commands_current(&failure, remember_path)
+    {
+        PieceStatus::Installed
+    } else {
+        PieceStatus::Stale
+    }
+}
+
+fn memorywhale_bash_commands(groups: &[HookGroup]) -> Vec<String> {
+    groups
+        .iter()
+        .filter(|group| group.matcher.as_deref() == Some("Bash"))
+        .flat_map(|group| group.hooks.iter().flatten())
+        .filter(|entry| {
+            entry
+                .command
+                .as_deref()
+                .is_some_and(is_memorywhale_hook_command)
+        })
+        .filter_map(|entry| entry.command.clone())
+        .collect()
+}
+
+fn hook_commands_current(commands: &[String], remember_path: Option<&Path>) -> bool {
+    commands
+        .iter()
+        .any(|command| hook_command_is_current(command, remember_path))
+}
+
+fn hook_command_is_current(command: &str, remember_path: Option<&Path>) -> bool {
+    match remember_path {
+        Some(path) => command.trim() == hook_command(path),
+        None => is_memorywhale_hook_command(command) && !command.trim().starts_with("python3 \""),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::merge_settings;
+    use super::*;
+    use crate::integrate::report::McpStatus;
+    use std::path::PathBuf;
+
+    fn sandbox(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "mw-claude-doctor-{name}-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn remember() -> PathBuf {
+        PathBuf::from("/home/me/.local/bin/mw-remember")
+    }
+
+    #[test]
+    fn inspect_fresh_config_dir_reports_missing_pieces() {
+        let dir = sandbox("fresh");
+        let report = inspect_at(&dir, &dir.join(".claude.json"), Some(&remember()), true);
+        assert!(report.detected);
+        assert_eq!(report.mcp, McpStatus::NotConfigured);
+        assert_eq!(report.hook, PieceStatus::NotInstalled);
+        assert_eq!(report.skill, PieceStatus::NotInstalled);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_partial_skill_only() {
+        let dir = sandbox("skill-only");
+        let skill_dir = dir.join("skills/memorywhale");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), crate::integrate::SKILL).unwrap();
+        let report = inspect_at(&dir, &dir.join(".claude.json"), Some(&remember()), true);
+        assert_eq!(report.mcp, McpStatus::NotConfigured);
+        assert_eq!(report.hook, PieceStatus::NotInstalled);
+        assert_eq!(report.skill, PieceStatus::Installed);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_stale_hook_and_mcp() {
+        let dir = sandbox("stale");
+        let remember = remember();
+        let (settings, _) = merge_settings("", &remember).unwrap();
+        let stale = settings.replace(
+            remember.display().to_string().as_str(),
+            "/old/home/.local/bin/mw-remember",
+        );
+        std::fs::write(dir.join("settings.json"), stale).unwrap();
+        std::fs::write(
+            dir.join(".claude.json"),
+            r#"{"mcpServers":{"memorywhale":{"command":"/missing/mw-mcp"}}}"#,
+        )
+        .unwrap();
+        let report = inspect_at(&dir, &dir.join(".claude.json"), Some(&remember), true);
+        assert_eq!(report.mcp, McpStatus::Stale);
+        assert_eq!(report.hook, PieceStatus::Stale);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_full_install_uses_generic_mcp_probe() {
+        let dir = sandbox("full");
+        let remember = remember();
+        let (settings, _) = merge_settings("", &remember).unwrap();
+        std::fs::write(dir.join("settings.json"), settings).unwrap();
+        std::fs::create_dir_all(dir.join("skills/memorywhale")).unwrap();
+        std::fs::write(dir.join("skills/memorywhale/SKILL.md"), "skill").unwrap();
+        std::fs::write(
+            dir.join(".claude.json"),
+            r#"{"mcpServers":{"memorywhale":{"command":"mw-mcp","args":[]}}}"#,
+        )
+        .unwrap();
+
+        let reachable = inspect_at(&dir, &dir.join(".claude.json"), Some(&remember), true);
+        assert_eq!(reachable.mcp, McpStatus::Configured { reachable: true });
+        assert_eq!(reachable.hook, PieceStatus::Installed);
+        assert_eq!(reachable.skill, PieceStatus::Installed);
+
+        let configured = inspect_at(&dir, &dir.join(".claude.json"), Some(&remember), false);
+        assert_eq!(configured.mcp, McpStatus::Configured { reachable: false });
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_unreadable_settings_and_mcp_are_independent() {
+        let dir = sandbox("unreadable");
+        std::fs::write(dir.join("settings.json"), "{not json").unwrap();
+        std::fs::write(dir.join(".claude.json"), "not-json").unwrap();
+        std::fs::create_dir_all(dir.join("skills/memorywhale")).unwrap();
+        std::fs::write(dir.join("skills/memorywhale/SKILL.md"), "skill").unwrap();
+        let report = inspect_at(&dir, &dir.join(".claude.json"), Some(&remember()), true);
+        assert_eq!(report.mcp, McpStatus::Unreadable);
+        assert_eq!(report.hook, PieceStatus::Unreadable);
+        assert_eq!(report.skill, PieceStatus::Installed);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_legacy_python_hook_is_stale() {
+        let dir = sandbox("legacy");
+        std::fs::write(
+            dir.join("settings.json"),
+            r#"{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{"type": "command", "command": "python3 \"/tmp/.claude/hooks/mw-record.py\""}]
+    }],
+    "PostToolUseFailure": [{
+      "matcher": "Bash",
+      "hooks": [{"type": "command", "command": "python3 \"/tmp/.claude/hooks/mw-record.py\""}]
+    }]
+  }
+}"#,
+        )
+        .unwrap();
+        let report = inspect_at(&dir, &dir.join(".claude.json"), Some(&remember()), false);
+        assert_eq!(report.hook, PieceStatus::Stale);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/mw-cli/src/integrate/claude/mod.rs
+++ b/crates/mw-cli/src/integrate/claude/mod.rs
@@ -319,13 +319,17 @@ fn user_scoped_mcp_config_path_from(
     home: Option<&Path>,
 ) -> Option<PathBuf> {
     if let Some(dir) = config_dir {
-        return Some(dir.join(".claude.json"));
+        if !dir.as_os_str().is_empty() {
+            return Some(dir.join(".claude.json"));
+        }
     }
     home.map(|path| path.join(".claude.json"))
 }
 
 fn user_scoped_mcp_config_path() -> Option<PathBuf> {
-    let config_dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from);
+    let config_dir = std::env::var_os("CLAUDE_CONFIG_DIR")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from);
     user_scoped_mcp_config_path_from(config_dir.as_deref(), dirs::home_dir().as_deref())
 }
 
@@ -655,6 +659,10 @@ mod tests {
         let home = PathBuf::from("/home/me");
         assert_eq!(
             user_scoped_mcp_config_path_from(None, Some(home.as_path())),
+            Some(home.join(".claude.json"))
+        );
+        assert_eq!(
+            user_scoped_mcp_config_path_from(Some(Path::new("")), Some(home.as_path())),
             Some(home.join(".claude.json"))
         );
     }

--- a/crates/mw-cli/src/integrate/claude/mod.rs
+++ b/crates/mw-cli/src/integrate/claude/mod.rs
@@ -187,7 +187,9 @@ fn uninstall() -> Result<RevertResult, String> {
 
 fn claude_config_dir() -> Result<PathBuf, String> {
     if let Some(path) = std::env::var_os("CLAUDE_CONFIG_DIR") {
-        return Ok(PathBuf::from(path));
+        if !path.is_empty() {
+            return Ok(PathBuf::from(path));
+        }
     }
     dirs::home_dir()
         .ok_or_else(|| "could not resolve the home directory".to_string())

--- a/crates/mw-cli/src/integrate/claude/mod.rs
+++ b/crates/mw-cli/src/integrate/claude/mod.rs
@@ -1,5 +1,9 @@
 //! Claude Code integration: capture hook, skill, and MCP registration.
 
+mod inspect;
+
+pub(crate) use inspect::doctor_report;
+
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/crates/mw-cli/src/integrate/files.rs
+++ b/crates/mw-cli/src/integrate/files.rs
@@ -156,11 +156,15 @@ pub(crate) fn command_on_path(name: &str) -> bool {
     false
 }
 
-pub(crate) fn skill_is_installed(config_dir: &Path) -> bool {
-    let path = BundledLayout::from_config_dir(config_dir.to_path_buf()).skill_path;
-    match fs::read_to_string(&path) {
-        Ok(text) => !text.trim().is_empty(),
-        Err(_) => false,
+/// Whether the bundled skill file is present and nonempty.
+///
+/// `Err` means the file exists but could not be read (permissions or invalid
+/// UTF-8). Callers must not treat that as absence.
+pub(crate) fn skill_is_installed(config_dir: &Path) -> Result<bool, std::io::Error> {
+    match read_existing(&BundledLayout::from_config_dir(config_dir.to_path_buf()).skill_path) {
+        Ok(Some(text)) => Ok(!text.trim().is_empty()),
+        Ok(None) => Ok(false),
+        Err(err) => Err(err),
     }
 }
 

--- a/crates/mw-cli/src/integrate/files.rs
+++ b/crates/mw-cli/src/integrate/files.rs
@@ -31,11 +31,21 @@ pub(crate) fn parse_revert(args: &[String], usage: &str) -> Result<bool, String>
     Ok(revert)
 }
 
+/// Read `path` if it exists. `Ok(None)` means the file is absent; `Err` means
+/// it existed but could not be read.
+pub(crate) fn read_existing(path: &Path) -> Result<Option<String>, std::io::Error> {
+    match fs::read_to_string(path) {
+        Ok(text) => Ok(Some(text)),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
 pub(crate) fn read_or_empty(path: &Path) -> Result<String, String> {
-    if path.exists() {
-        fs::read_to_string(path).map_err(|err| format!("failed to read {}: {err}", path.display()))
-    } else {
-        Ok(String::new())
+    match read_existing(path) {
+        Ok(Some(text)) => Ok(text),
+        Ok(None) => Ok(String::new()),
+        Err(err) => Err(format!("failed to read {}: {err}", path.display())),
     }
 }
 
@@ -126,6 +136,31 @@ fn remember_name(dir: &Path) -> PathBuf {
         dir.join("mw-remember.exe")
     } else {
         dir.join("mw-remember")
+    }
+}
+
+/// True when `name` (or `name.exe` on Windows) exists as a file on PATH.
+/// Looks at the filesystem only; does not execute the binary.
+pub(crate) fn command_on_path(name: &str) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    for dir in std::env::split_paths(&path) {
+        if dir.join(name).is_file() {
+            return true;
+        }
+        if cfg!(windows) && dir.join(format!("{name}.exe")).is_file() {
+            return true;
+        }
+    }
+    false
+}
+
+pub(crate) fn skill_is_installed(config_dir: &Path) -> bool {
+    let path = BundledLayout::from_config_dir(config_dir.to_path_buf()).skill_path;
+    match fs::read_to_string(&path) {
+        Ok(text) => !text.trim().is_empty(),
+        Err(_) => false,
     }
 }
 

--- a/crates/mw-cli/src/integrate/mod.rs
+++ b/crates/mw-cli/src/integrate/mod.rs
@@ -1,9 +1,18 @@
 //! Agent integrations installed by `mw integrate`.
 
 mod files;
+mod report;
 
 pub mod claude;
 pub mod hermes;
 pub mod rho;
 
 pub(crate) const SKILL: &str = include_str!("../../integrate/SKILL.md");
+
+/// Claude Code and Rho integration status for `mw doctor`.
+pub fn render_doctor_reports(mcp_stdio_ok: bool) -> String {
+    report::render_reports(&[
+        claude::doctor_report(mcp_stdio_ok),
+        rho::doctor_report(mcp_stdio_ok),
+    ])
+}

--- a/crates/mw-cli/src/integrate/report.rs
+++ b/crates/mw-cli/src/integrate/report.rs
@@ -35,11 +35,11 @@ pub(crate) enum PieceStatus {
 }
 
 impl PieceStatus {
-    pub(crate) fn skill(installed: bool) -> Self {
-        if installed {
-            Self::Installed
-        } else {
-            Self::NotInstalled
+    pub(crate) fn skill(result: Result<bool, std::io::Error>) -> Self {
+        match result {
+            Ok(true) => Self::Installed,
+            Ok(false) => Self::NotInstalled,
+            Err(_) => Self::Unreadable,
         }
     }
 

--- a/crates/mw-cli/src/integrate/report.rs
+++ b/crates/mw-cli/src/integrate/report.rs
@@ -1,0 +1,188 @@
+//! Shared doctor status for thin client integrations.
+
+fn next_step(detail: &str, client: &str) -> String {
+    format!("{detail}; run `mw integrate {client}`")
+}
+
+/// MCP registration as doctor should print it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum McpStatus {
+    Configured { reachable: bool },
+    NotConfigured,
+    Stale,
+    Unreadable,
+}
+
+impl McpStatus {
+    fn phrase(self, client: &str) -> String {
+        match self {
+            Self::Configured { reachable: true } => "configured and reachable".to_string(),
+            Self::Configured { reachable: false } => "configured".to_string(),
+            Self::NotConfigured => next_step("not configured", client),
+            Self::Stale => next_step("stale", client),
+            Self::Unreadable => next_step("unreadable", client),
+        }
+    }
+}
+
+/// Hook or skill as doctor should print it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PieceStatus {
+    Installed,
+    NotInstalled,
+    Stale,
+    Unreadable,
+}
+
+impl PieceStatus {
+    pub(crate) fn skill(installed: bool) -> Self {
+        if installed {
+            Self::Installed
+        } else {
+            Self::NotInstalled
+        }
+    }
+
+    fn phrase(self, client: &str) -> String {
+        match self {
+            Self::Installed => "installed".to_string(),
+            Self::NotInstalled => next_step("not installed", client),
+            Self::Stale => next_step("stale", client),
+            Self::Unreadable => next_step("unreadable", client),
+        }
+    }
+}
+
+/// What the client config says about MemoryWhale MCP, before doctor maps in the
+/// generic stdio probe. Never carries URLs, headers, or tokens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum McpFact {
+    Absent,
+    Stdio,
+    Http,
+    Stale,
+    Unreadable,
+}
+
+impl McpFact {
+    pub(crate) fn into_status(self, stdio_ok: bool) -> McpStatus {
+        match self {
+            Self::Absent => McpStatus::NotConfigured,
+            Self::Stdio if stdio_ok => McpStatus::Configured { reachable: true },
+            Self::Stdio | Self::Http => McpStatus::Configured { reachable: false },
+            Self::Stale => McpStatus::Stale,
+            Self::Unreadable => McpStatus::Unreadable,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IntegrationReport {
+    pub title: &'static str,
+    pub client: &'static str,
+    pub detected: bool,
+    pub mcp: McpStatus,
+    pub hook: PieceStatus,
+    pub skill: PieceStatus,
+}
+
+impl IntegrationReport {
+    pub fn not_detected(title: &'static str, client: &'static str) -> Self {
+        Self {
+            title,
+            client,
+            detected: false,
+            mcp: McpStatus::NotConfigured,
+            hook: PieceStatus::NotInstalled,
+            skill: PieceStatus::NotInstalled,
+        }
+    }
+
+    pub fn detected(
+        title: &'static str,
+        client: &'static str,
+        mcp: McpStatus,
+        hook: PieceStatus,
+        skill: PieceStatus,
+    ) -> Self {
+        Self {
+            title,
+            client,
+            detected: true,
+            mcp,
+            hook,
+            skill,
+        }
+    }
+
+    pub fn render(&self) -> String {
+        let mut out = format!("  {}\n", self.title);
+        if !self.detected {
+            out.push_str("    not detected\n");
+            return out;
+        }
+        out.push_str(&line("MCP", self.mcp.phrase(self.client)));
+        out.push_str(&line("auto-capture hook", self.hook.phrase(self.client)));
+        out.push_str(&line("skill", self.skill.phrase(self.client)));
+        out
+    }
+}
+
+fn line(label: &str, phrase: String) -> String {
+    format!("    {label:<19} {phrase}\n")
+}
+
+pub(crate) fn render_reports(reports: &[IntegrationReport]) -> String {
+    let mut out = String::from("\nIntegrations\n");
+    for report in reports {
+        out.push_str(&report.render());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_separates_not_detected_from_missing_pieces() {
+        let undetected = IntegrationReport::not_detected("Claude Code", "claude");
+        assert_eq!(undetected.render(), "  Claude Code\n    not detected\n");
+
+        let missing = IntegrationReport::detected(
+            "Rho",
+            "rho",
+            McpStatus::NotConfigured,
+            PieceStatus::NotInstalled,
+            PieceStatus::Installed,
+        );
+        let rendered = missing.render();
+        assert!(rendered.contains("MCP                 not configured; run `mw integrate rho`"));
+        assert!(rendered.contains("auto-capture hook   not installed; run `mw integrate rho`"));
+        assert!(rendered.contains("skill               installed"));
+        assert!(!rendered.contains("not detected"));
+    }
+
+    #[test]
+    fn render_reports_lists_each_client() {
+        let text = render_reports(&[
+            IntegrationReport::detected(
+                "Claude Code",
+                "claude",
+                McpStatus::Configured { reachable: true },
+                PieceStatus::Installed,
+                PieceStatus::Installed,
+            ),
+            IntegrationReport::detected(
+                "Rho",
+                "rho",
+                McpStatus::Configured { reachable: false },
+                PieceStatus::Stale,
+                PieceStatus::Installed,
+            ),
+        ]);
+        assert!(text.starts_with("\nIntegrations\n"));
+        assert!(text.contains("configured and reachable"));
+        assert!(text.contains("stale; run `mw integrate rho`"));
+    }
+}

--- a/crates/mw-cli/src/integrate/rho/inspect.rs
+++ b/crates/mw-cli/src/integrate/rho/inspect.rs
@@ -74,8 +74,7 @@ fn inspect_hook(config_dir: &Path, remember_path: Option<&Path>) -> PieceStatus 
     };
     match remember_path {
         Some(path) if hook_matches(table, path) => PieceStatus::Installed,
-        Some(_) => PieceStatus::Stale,
-        None => PieceStatus::Installed,
+        _ => PieceStatus::Stale,
     }
 }
 
@@ -169,6 +168,27 @@ headers = { Authorization = "Bearer supersecret-token" }
         let rendered = http.render();
         assert!(!rendered.contains("supersecret-token"));
         assert!(!rendered.contains("127.0.0.1"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_missing_helper_does_not_report_hook_installed() {
+        let dir = sandbox("no-helper");
+        let (hooks, _) = merge_hooks("", &remember()).unwrap();
+        let stale = hooks.replace("/home/me/.local/bin/mw-remember", "/old/bin/mw-remember");
+        std::fs::write(dir.join("hooks.toml"), stale).unwrap();
+        let report = inspect_at(&dir, None, false);
+        assert_eq!(report.hook, PieceStatus::Stale);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_unreadable_skill_is_not_absence() {
+        let dir = sandbox("bad-skill");
+        std::fs::create_dir_all(dir.join("skills/memorywhale")).unwrap();
+        std::fs::write(dir.join("skills/memorywhale/SKILL.md"), [0xff, 0xfe]).unwrap();
+        let report = inspect_at(&dir, Some(&remember()), false);
+        assert_eq!(report.skill, PieceStatus::Unreadable);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/mw-cli/src/integrate/rho/inspect.rs
+++ b/crates/mw-cli/src/integrate/rho/inspect.rs
@@ -1,0 +1,186 @@
+//! Read-only Rho doctor inspection.
+
+use std::path::Path;
+
+use super::mcp::inspect_memorywhale;
+use super::{hook_matches, is_memorywhale_hook, parse_toml, require_hooks_version, rho_home};
+use crate::integrate::files::{
+    command_on_path, mw_remember_executable, read_existing, skill_is_installed,
+};
+use crate::integrate::report::{IntegrationReport, McpFact, PieceStatus};
+
+/// Inspect Rho MCP, hook, and skill status without mutating files or probing
+/// HTTP endpoints.
+pub(crate) fn doctor_report(mcp_stdio_ok: bool) -> IntegrationReport {
+    let env_set = std::env::var_os("RHO_HOME").is_some_and(|value| !value.is_empty());
+    let Ok(config_dir) = rho_home() else {
+        return IntegrationReport::not_detected("Rho", "rho");
+    };
+    let detected = env_set || config_dir.exists() || command_on_path("rho");
+    if !detected {
+        return IntegrationReport::not_detected("Rho", "rho");
+    }
+    inspect_at(
+        &config_dir,
+        mw_remember_executable().ok().as_deref(),
+        mcp_stdio_ok,
+    )
+}
+
+fn inspect_at(
+    config_dir: &Path,
+    remember_path: Option<&Path>,
+    mcp_stdio_ok: bool,
+) -> IntegrationReport {
+    IntegrationReport::detected(
+        "Rho",
+        "rho",
+        inspect_mcp(config_dir).into_status(mcp_stdio_ok),
+        inspect_hook(config_dir, remember_path),
+        PieceStatus::skill(skill_is_installed(config_dir)),
+    )
+}
+
+fn inspect_mcp(config_dir: &Path) -> McpFact {
+    match read_existing(&config_dir.join("config.toml")) {
+        Ok(Some(text)) => inspect_memorywhale(&text),
+        Ok(None) => McpFact::Absent,
+        Err(_) => McpFact::Unreadable,
+    }
+}
+
+fn inspect_hook(config_dir: &Path, remember_path: Option<&Path>) -> PieceStatus {
+    let existing = match read_existing(&config_dir.join("hooks.toml")) {
+        Ok(None) => return PieceStatus::NotInstalled,
+        Err(_) => return PieceStatus::Unreadable,
+        Ok(Some(text)) if text.trim().is_empty() => return PieceStatus::NotInstalled,
+        Ok(Some(text)) => text,
+    };
+    let doc = match parse_toml(&existing, "hooks.toml") {
+        Ok(doc) => doc,
+        Err(_) => return PieceStatus::Unreadable,
+    };
+    if require_hooks_version(&doc).is_err() {
+        return PieceStatus::Unreadable;
+    }
+    let Some(hook) = doc.get("hook") else {
+        return PieceStatus::NotInstalled;
+    };
+    let Some(hooks) = hook.as_array_of_tables() else {
+        return PieceStatus::Unreadable;
+    };
+    let Some(table) = hooks.iter().find(|table| is_memorywhale_hook(table)) else {
+        return PieceStatus::NotInstalled;
+    };
+    match remember_path {
+        Some(path) if hook_matches(table, path) => PieceStatus::Installed,
+        Some(_) => PieceStatus::Stale,
+        None => PieceStatus::Installed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mcp::{merge_mcp, McpTarget};
+    use super::super::merge_hooks;
+    use super::*;
+    use crate::integrate::report::McpStatus;
+    use std::path::PathBuf;
+
+    fn sandbox(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "mw-rho-doctor-{name}-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn remember() -> PathBuf {
+        PathBuf::from("/home/me/.local/bin/mw-remember")
+    }
+
+    #[test]
+    fn inspect_fresh_rho_home_reports_missing_pieces() {
+        let dir = sandbox("fresh");
+        let report = inspect_at(&dir, Some(&remember()), true);
+        assert!(report.detected);
+        assert_eq!(report.mcp, McpStatus::NotConfigured);
+        assert_eq!(report.hook, PieceStatus::NotInstalled);
+        assert_eq!(report.skill, PieceStatus::NotInstalled);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_partial_and_stale_rho_install() {
+        let dir = sandbox("partial");
+        std::fs::create_dir_all(dir.join("skills/memorywhale")).unwrap();
+        std::fs::write(dir.join("skills/memorywhale/SKILL.md"), "skill").unwrap();
+        let (hooks, _) = merge_hooks("", &remember()).unwrap();
+        let stale_hooks = hooks.replace(
+            "/home/me/.local/bin/mw-remember",
+            "/old/home/.local/bin/mw-remember",
+        );
+        std::fs::write(dir.join("hooks.toml"), stale_hooks).unwrap();
+        std::fs::write(
+            dir.join("config.toml"),
+            r#"[mcp.servers.memorywhale]
+transport = "stdio"
+command = "/missing/mw-mcp"
+"#,
+        )
+        .unwrap();
+        let report = inspect_at(&dir, Some(&remember()), true);
+        assert_eq!(report.skill, PieceStatus::Installed);
+        assert_eq!(report.hook, PieceStatus::Stale);
+        assert_eq!(report.mcp, McpStatus::Stale);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_full_stdio_and_http_without_leaking_secrets() {
+        let dir = sandbox("full");
+        let remember = remember();
+        let (hooks, _) = merge_hooks("", &remember).unwrap();
+        std::fs::write(dir.join("hooks.toml"), hooks).unwrap();
+        std::fs::create_dir_all(dir.join("skills/memorywhale")).unwrap();
+        std::fs::write(dir.join("skills/memorywhale/SKILL.md"), "skill").unwrap();
+        let (stdio, _) = merge_mcp("", &McpTarget::stdio()).unwrap();
+        std::fs::write(dir.join("config.toml"), &stdio).unwrap();
+
+        let reachable = inspect_at(&dir, Some(&remember), true);
+        assert_eq!(reachable.mcp, McpStatus::Configured { reachable: true });
+        assert_eq!(reachable.hook, PieceStatus::Installed);
+        assert_eq!(reachable.skill, PieceStatus::Installed);
+
+        std::fs::write(
+            dir.join("config.toml"),
+            r#"[mcp.servers.memorywhale]
+transport = "streamable_http"
+url = "http://127.0.0.1:7071/mcp"
+headers = { Authorization = "Bearer supersecret-token" }
+"#,
+        )
+        .unwrap();
+        let http = inspect_at(&dir, Some(&remember), true);
+        assert_eq!(http.mcp, McpStatus::Configured { reachable: false });
+        let rendered = http.render();
+        assert!(!rendered.contains("supersecret-token"));
+        assert!(!rendered.contains("127.0.0.1"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_unreadable_hooks_leave_mcp_readable() {
+        let dir = sandbox("unreadable");
+        std::fs::write(dir.join("hooks.toml"), "version = [").unwrap();
+        let (stdio, _) = merge_mcp("", &McpTarget::stdio()).unwrap();
+        std::fs::write(dir.join("config.toml"), stdio).unwrap();
+        let report = inspect_at(&dir, Some(&remember()), false);
+        assert_eq!(report.hook, PieceStatus::Unreadable);
+        assert_eq!(report.mcp, McpStatus::Configured { reachable: false });
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/mw-cli/src/integrate/rho/mcp.rs
+++ b/crates/mw-cli/src/integrate/rho/mcp.rs
@@ -359,7 +359,10 @@ pub(super) fn inspect_memorywhale(existing: &str) -> McpFact {
     let Some(server) = memorywhale_server(&doc) else {
         return McpFact::Absent;
     };
-    if server.get("enabled").and_then(Item::as_bool) == Some(false) {
+    if server
+        .get("enabled")
+        .is_some_and(|item| item.as_bool() != Some(true))
+    {
         return McpFact::Stale;
     }
     match server.get("transport").and_then(Item::as_str) {
@@ -818,5 +821,12 @@ command = "mw-mcp"
 enabled = false
 "#;
         assert_eq!(inspect_memorywhale(disabled), McpFact::Stale);
+
+        let enabled_string = r#"[mcp.servers.memorywhale]
+transport = "stdio"
+command = "mw-mcp"
+enabled = "false"
+"#;
+        assert_eq!(inspect_memorywhale(enabled_string), McpFact::Stale);
     }
 }

--- a/crates/mw-cli/src/integrate/rho/mcp.rs
+++ b/crates/mw-cli/src/integrate/rho/mcp.rs
@@ -44,9 +44,15 @@ impl McpTarget {
     }
 }
 
+fn enabled_is_not_true(server: &dyn TableLike) -> bool {
+    server
+        .get("enabled")
+        .is_some_and(|item| item.as_bool() != Some(true))
+}
+
 fn mcp_server_matches(doc: &DocumentMut, target: &McpTarget) -> bool {
     memorywhale_server(doc).is_some_and(|server| {
-        if server.get("enabled").and_then(Item::as_bool) == Some(false) {
+        if enabled_is_not_true(server) {
             return false;
         }
         if server.get("transport").and_then(Item::as_str) != Some(target.transport) {
@@ -264,7 +270,7 @@ pub(super) fn merge_mcp(existing: &str, target: &McpTarget) -> Result<(String, b
             changed |= remove_authorization_from_env(server);
         }
     }
-    if server.get("enabled").and_then(Item::as_bool) == Some(false) {
+    if enabled_is_not_true(server) {
         server.insert("enabled", value(true));
         changed = true;
     }
@@ -359,10 +365,7 @@ pub(super) fn inspect_memorywhale(existing: &str) -> McpFact {
     let Some(server) = memorywhale_server(&doc) else {
         return McpFact::Absent;
     };
-    if server
-        .get("enabled")
-        .is_some_and(|item| item.as_bool() != Some(true))
-    {
+    if enabled_is_not_true(server) {
         return McpFact::Stale;
     }
     match server.get("transport").and_then(Item::as_str) {
@@ -487,6 +490,24 @@ enabled = false
 "#;
         let (merged, changed) = merge_mcp(original).unwrap();
         assert!(changed);
+        let doc = merged.parse::<DocumentMut>().unwrap();
+        let server = doc["mcp"]["servers"]["memorywhale"]
+            .as_table_like()
+            .expect("memorywhale server table");
+        assert_eq!(server.get("enabled").and_then(Item::as_bool), Some(true));
+    }
+
+    #[test]
+    fn merge_mcp_repairs_non_boolean_enabled() {
+        let original = r#"[mcp.servers.memorywhale]
+transport = "stdio"
+command = "mw-mcp"
+enabled = "false"
+"#;
+        assert_eq!(inspect_memorywhale(original), McpFact::Stale);
+        let (merged, changed) = merge_mcp(original).unwrap();
+        assert!(changed);
+        assert_eq!(inspect_memorywhale(&merged), McpFact::Stdio);
         let doc = merged.parse::<DocumentMut>().unwrap();
         let server = doc["mcp"]["servers"]["memorywhale"]
             .as_table_like()

--- a/crates/mw-cli/src/integrate/rho/mcp.rs
+++ b/crates/mw-cli/src/integrate/rho/mcp.rs
@@ -3,6 +3,7 @@
 use toml_edit::{value, DocumentMut, InlineTable, Item, Table, TableLike};
 
 use super::{parse_toml, set_string};
+use crate::integrate::report::McpFact;
 
 const MCP_COMMAND: &str = "mw-mcp";
 const MCP_TRANSPORT: &str = "stdio";
@@ -340,6 +341,41 @@ fn remove_authorization_from_env(table: &mut dyn TableLike) -> bool {
         table.remove("headers_from_env");
     }
     true
+}
+
+/// Read-only classification of the MemoryWhale MCP stanza. Never returns URLs,
+/// headers, or tokens.
+pub(super) fn inspect_memorywhale(existing: &str) -> McpFact {
+    if existing.trim().is_empty() {
+        return McpFact::Absent;
+    }
+    let doc = match parse_toml(existing, "config.toml") {
+        Ok(doc) => doc,
+        Err(_) => return McpFact::Unreadable,
+    };
+    if require_mcp_tables(&doc).is_err() {
+        return McpFact::Unreadable;
+    }
+    let Some(server) = memorywhale_server(&doc) else {
+        return McpFact::Absent;
+    };
+    if server.get("enabled").and_then(Item::as_bool) == Some(false) {
+        return McpFact::Stale;
+    }
+    match server.get("transport").and_then(Item::as_str) {
+        Some(MCP_TRANSPORT) => {
+            if server.get("command").and_then(Item::as_str) == Some(MCP_COMMAND) {
+                McpFact::Stdio
+            } else {
+                McpFact::Stale
+            }
+        }
+        Some(MCP_HTTP_TRANSPORT) => match server.get("url").and_then(Item::as_str) {
+            Some(url) if url.starts_with("http://") || url.starts_with("https://") => McpFact::Http,
+            _ => McpFact::Stale,
+        },
+        _ => McpFact::Stale,
+    }
 }
 
 pub(super) fn unmerge_mcp(existing: &str) -> Result<(String, bool), String> {
@@ -753,5 +789,34 @@ headers_from_env = { Authorization = 1 }
             server["headers_from_env"]["Authorization"].as_str(),
             Some("MEMORYWHALE_AUTHORIZATION")
         );
+    }
+
+    #[test]
+    fn inspect_memorywhale_classifies_stdio_http_stale_and_absent() {
+        assert_eq!(inspect_memorywhale(""), McpFact::Absent);
+        assert_eq!(inspect_memorywhale("model = ["), McpFact::Unreadable);
+
+        let (stdio, _) = merge_mcp("").unwrap();
+        assert_eq!(inspect_memorywhale(&stdio), McpFact::Stdio);
+
+        let http = r#"[mcp.servers.memorywhale]
+transport = "streamable_http"
+url = "http://127.0.0.1:7071/mcp"
+headers = { Authorization = "Bearer supersecret-token" }
+"#;
+        assert_eq!(inspect_memorywhale(http), McpFact::Http);
+
+        let stale = r#"[mcp.servers.memorywhale]
+transport = "stdio"
+command = "/missing/mw-mcp"
+"#;
+        assert_eq!(inspect_memorywhale(stale), McpFact::Stale);
+
+        let disabled = r#"[mcp.servers.memorywhale]
+transport = "stdio"
+command = "mw-mcp"
+enabled = false
+"#;
+        assert_eq!(inspect_memorywhale(disabled), McpFact::Stale);
     }
 }

--- a/crates/mw-cli/src/integrate/rho/mod.rs
+++ b/crates/mw-cli/src/integrate/rho/mod.rs
@@ -1,5 +1,10 @@
 //! Rho integration: capture hook, skill, and MCP registration.
 
+mod inspect;
+mod mcp;
+
+pub(crate) use inspect::doctor_report;
+
 use std::path::{Path, PathBuf};
 
 use toml_edit::{value, Array, ArrayOfTables, DocumentMut, Item, Table, TableLike};
@@ -10,7 +15,6 @@ use super::files::{
 };
 use crate::agent_hook::Agent;
 
-mod mcp;
 use mcp::{merge_mcp, unmerge_mcp, McpTarget};
 
 const HOOK_ID: &str = "memorywhale-record";

--- a/crates/mw-cli/tests/doctor_integrations.rs
+++ b/crates/mw-cli/tests/doctor_integrations.rs
@@ -32,6 +32,17 @@ fn stdout(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
 }
 
+fn client_block<'a>(text: &'a str, title: &str, next_title: &str) -> &'a str {
+    let start = format!("  {title}\n");
+    let after = text.split(&start).nth(1).unwrap_or("");
+    if next_title.is_empty() {
+        after
+    } else {
+        let next = format!("  {next_title}\n");
+        after.split(&next).next().unwrap_or(after)
+    }
+}
+
 fn assert_core_diagnostics_present(text: &str) {
     assert!(text.contains("MemoryWhale doctor"), "{text}");
     assert!(text.contains("data dir"), "{text}");
@@ -65,23 +76,34 @@ fn doctor_honors_custom_claude_and_rho_dirs_and_ignores_home_decoys() {
     assert!(output.status.success(), "doctor failed: {output:?}");
     let text = stdout(&output);
     assert_core_diagnostics_present(&text);
+
+    let claude_block = client_block(&text, "Claude Code", "Rho");
     assert!(
-        text.contains("not configured; run `mw integrate claude`"),
+        claude_block.contains("MCP                 not configured; run `mw integrate claude`"),
         "{text}"
     );
     assert!(
-        text.contains("not installed; run `mw integrate claude`"),
+        claude_block.contains("auto-capture hook   not installed; run `mw integrate claude`"),
         "{text}"
     );
     assert!(
-        text.contains("not configured; run `mw integrate rho`"),
+        claude_block.contains("skill               not installed; run `mw integrate claude`"),
+        "{text}"
+    );
+
+    let rho_block = client_block(&text, "Rho", "");
+    assert!(
+        rho_block.contains("MCP                 not configured; run `mw integrate rho`"),
         "{text}"
     );
     assert!(
-        text.contains("not installed; run `mw integrate rho`"),
+        rho_block.contains("auto-capture hook   not installed; run `mw integrate rho`"),
         "{text}"
     );
-    assert!(!text.contains("decoy skill"), "{text}");
+    assert!(
+        rho_block.contains("skill               not installed; run `mw integrate rho`"),
+        "{text}"
+    );
     let _ = std::fs::remove_dir_all(&home);
     let _ = std::fs::remove_dir_all(&claude);
     let _ = std::fs::remove_dir_all(&rho);
@@ -109,6 +131,27 @@ fn doctor_reports_not_detected_when_client_configs_are_absent() {
     assert!(text.contains("Rho\n    not detected"), "{text}");
     assert!(!text.contains("mw integrate claude"), "{text}");
     assert!(!text.contains("mw integrate rho"), "{text}");
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn doctor_ignores_empty_claude_config_dir() {
+    let home = sandbox("empty-claude-env");
+    let data = home.join("mw-data");
+    std::fs::create_dir_all(&data).unwrap();
+
+    let output = mw_cmd()
+        .args(["doctor"])
+        .env("HOME", &home)
+        .env("MEMORYWHALE_DATA_DIR", &data)
+        .env("CLAUDE_CONFIG_DIR", "")
+        .env_remove("RHO_HOME")
+        .env("PATH", "")
+        .output()
+        .expect("run mw doctor");
+    assert!(output.status.success(), "doctor failed: {output:?}");
+    let text = stdout(&output);
+    assert!(text.contains("Claude Code\n    not detected"), "{text}");
     let _ = std::fs::remove_dir_all(&home);
 }
 

--- a/crates/mw-cli/tests/doctor_integrations.rs
+++ b/crates/mw-cli/tests/doctor_integrations.rs
@@ -1,0 +1,213 @@
+use std::process::Command;
+
+fn mw_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_mw"))
+}
+
+fn sandbox(name: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "mw-doctor-{name}-{}-{}",
+        std::process::id(),
+        std::thread::current().name().unwrap_or("test")
+    ));
+    let _ = std::fs::remove_dir_all(&path);
+    std::fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn doctor(home: &std::path::Path, claude: &std::path::Path, rho: &std::path::Path) -> Command {
+    let data = home.join("mw-data");
+    std::fs::create_dir_all(&data).unwrap();
+    let mut cmd = mw_cmd();
+    cmd.args(["doctor"])
+        .env("HOME", home)
+        .env("CLAUDE_CONFIG_DIR", claude)
+        .env("RHO_HOME", rho)
+        .env("MEMORYWHALE_DATA_DIR", data)
+        .env("PATH", "");
+    cmd
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn assert_core_diagnostics_present(text: &str) {
+    assert!(text.contains("MemoryWhale doctor"), "{text}");
+    assert!(text.contains("data dir"), "{text}");
+    assert!(text.contains("database"), "{text}");
+    assert!(text.contains("recording"), "{text}");
+    assert!(text.contains("auto-record"), "{text}");
+    assert!(
+        text.contains("ok   mcp:") || text.contains("WARN mcp:"),
+        "generic mcp diagnostic missing: {text}"
+    );
+    assert!(text.contains("Integrations"), "{text}");
+}
+
+#[test]
+fn doctor_honors_custom_claude_and_rho_dirs_and_ignores_home_decoys() {
+    let home = sandbox("decoy-home");
+    let claude = sandbox("claude-empty");
+    let rho = sandbox("rho-empty");
+    std::fs::create_dir_all(home.join(".claude/skills/memorywhale")).unwrap();
+    std::fs::write(
+        home.join(".claude/skills/memorywhale/SKILL.md"),
+        "decoy skill",
+    )
+    .unwrap();
+    std::fs::create_dir_all(home.join(".rho/skills/memorywhale")).unwrap();
+    std::fs::write(home.join(".rho/skills/memorywhale/SKILL.md"), "decoy skill").unwrap();
+
+    let output = doctor(&home, &claude, &rho)
+        .output()
+        .expect("run mw doctor");
+    assert!(output.status.success(), "doctor failed: {output:?}");
+    let text = stdout(&output);
+    assert_core_diagnostics_present(&text);
+    assert!(
+        text.contains("not configured; run `mw integrate claude`"),
+        "{text}"
+    );
+    assert!(
+        text.contains("not installed; run `mw integrate claude`"),
+        "{text}"
+    );
+    assert!(
+        text.contains("not configured; run `mw integrate rho`"),
+        "{text}"
+    );
+    assert!(
+        text.contains("not installed; run `mw integrate rho`"),
+        "{text}"
+    );
+    assert!(!text.contains("decoy skill"), "{text}");
+    let _ = std::fs::remove_dir_all(&home);
+    let _ = std::fs::remove_dir_all(&claude);
+    let _ = std::fs::remove_dir_all(&rho);
+}
+
+#[test]
+fn doctor_reports_not_detected_when_client_configs_are_absent() {
+    let home = sandbox("no-clients");
+    let data = home.join("mw-data");
+    std::fs::create_dir_all(&data).unwrap();
+
+    let output = mw_cmd()
+        .args(["doctor"])
+        .env("HOME", &home)
+        .env("MEMORYWHALE_DATA_DIR", &data)
+        .env_remove("CLAUDE_CONFIG_DIR")
+        .env_remove("RHO_HOME")
+        .env("PATH", "")
+        .output()
+        .expect("run mw doctor");
+    assert!(output.status.success(), "doctor failed: {output:?}");
+    let text = stdout(&output);
+    assert_core_diagnostics_present(&text);
+    assert!(text.contains("Claude Code\n    not detected"), "{text}");
+    assert!(text.contains("Rho\n    not detected"), "{text}");
+    assert!(!text.contains("mw integrate claude"), "{text}");
+    assert!(!text.contains("mw integrate rho"), "{text}");
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn doctor_reports_partial_stale_and_full_client_state() {
+    let home = sandbox("mixed-home");
+    let claude = sandbox("claude-full");
+    let rho = sandbox("rho-partial");
+
+    std::fs::write(
+        claude.join(".claude.json"),
+        r#"{"mcpServers":{"memorywhale":{"command":"mw-mcp","args":[]}}}"#,
+    )
+    .unwrap();
+    let install = mw_cmd()
+        .args(["integrate", "claude"])
+        .env("HOME", &home)
+        .env("CLAUDE_CONFIG_DIR", &claude)
+        .env("PATH", "")
+        .output()
+        .expect("install claude");
+    assert!(
+        install.status.success(),
+        "claude integrate failed: {install:?}"
+    );
+
+    std::fs::create_dir_all(rho.join("skills/memorywhale")).unwrap();
+    std::fs::write(rho.join("skills/memorywhale/SKILL.md"), "skill").unwrap();
+    std::fs::write(
+        rho.join("hooks.toml"),
+        r#"version = 1
+
+[[hook]]
+id = "memorywhale-record"
+on = "after_tool_use"
+tools = ["bash", "powershell"]
+command = ["/old/home/.local/bin/mw-remember", "--from-hook", "rho"]
+timeout = "15s"
+"#,
+    )
+    .unwrap();
+
+    let output = doctor(&home, &claude, &rho)
+        .output()
+        .expect("run mw doctor");
+    assert!(output.status.success(), "doctor failed: {output:?}");
+    let text = stdout(&output);
+    assert_core_diagnostics_present(&text);
+
+    let claude_block = text
+        .split("  Rho\n")
+        .next()
+        .and_then(|chunk| chunk.split("  Claude Code\n").nth(1))
+        .unwrap_or("");
+    assert!(
+        claude_block.contains("configured and reachable")
+            || claude_block.contains("MCP                 configured"),
+        "claude mcp: {text}"
+    );
+    assert!(
+        claude_block.contains("auto-capture hook   installed"),
+        "{text}"
+    );
+    assert!(
+        claude_block.contains("skill               installed"),
+        "{text}"
+    );
+
+    let rho_block = text.split("  Rho\n").nth(1).unwrap_or("");
+    assert!(
+        rho_block.contains("not configured; run `mw integrate rho`"),
+        "{text}"
+    );
+    assert!(
+        rho_block.contains("stale; run `mw integrate rho`"),
+        "{text}"
+    );
+    assert!(
+        rho_block.contains("skill               installed"),
+        "{text}"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+    let _ = std::fs::remove_dir_all(&claude);
+    let _ = std::fs::remove_dir_all(&rho);
+}
+
+#[test]
+fn doctor_exit_status_stays_ok_when_integrations_are_missing() {
+    let home = sandbox("exit-home");
+    let claude = sandbox("exit-claude");
+    let rho = sandbox("exit-rho");
+    let output = doctor(&home, &claude, &rho)
+        .output()
+        .expect("run mw doctor");
+    assert!(
+        output.status.success(),
+        "missing optional integrations must not fail doctor: {output:?}"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+    let _ = std::fs::remove_dir_all(&claude);
+    let _ = std::fs::remove_dir_all(&rho);
+}

--- a/crates/mw-cli/tests/doctor_integrations.rs
+++ b/crates/mw-cli/tests/doctor_integrations.rs
@@ -158,8 +158,9 @@ fn doctor_ignores_empty_claude_config_dir() {
         .expect("run mw doctor");
     assert!(output.status.success(), "doctor failed: {output:?}");
     let text = stdout(&output);
-    assert!(text.contains("Claude Code\n    not detected"), "{text}");
-    assert!(!text.contains("configured"), "{text}");
+    let claude_block = client_block(&text, "Claude Code", "Rho");
+    assert!(claude_block.contains("    not detected"), "{text}");
+    assert!(!claude_block.contains("configured"), "{text}");
     let _ = std::fs::remove_dir_all(&home);
     let _ = std::fs::remove_dir_all(&cwd);
 }

--- a/crates/mw-cli/tests/doctor_integrations.rs
+++ b/crates/mw-cli/tests/doctor_integrations.rs
@@ -137,11 +137,18 @@ fn doctor_reports_not_detected_when_client_configs_are_absent() {
 #[test]
 fn doctor_ignores_empty_claude_config_dir() {
     let home = sandbox("empty-claude-env");
+    let cwd = sandbox("empty-claude-cwd");
     let data = home.join("mw-data");
     std::fs::create_dir_all(&data).unwrap();
+    std::fs::write(
+        cwd.join(".claude.json"),
+        r#"{"mcpServers":{"memorywhale":{"command":"mw-mcp","args":[]}}}"#,
+    )
+    .unwrap();
 
     let output = mw_cmd()
         .args(["doctor"])
+        .current_dir(&cwd)
         .env("HOME", &home)
         .env("MEMORYWHALE_DATA_DIR", &data)
         .env("CLAUDE_CONFIG_DIR", "")
@@ -152,7 +159,9 @@ fn doctor_ignores_empty_claude_config_dir() {
     assert!(output.status.success(), "doctor failed: {output:?}");
     let text = stdout(&output);
     assert!(text.contains("Claude Code\n    not detected"), "{text}");
+    assert!(!text.contains("configured"), "{text}");
     let _ = std::fs::remove_dir_all(&home);
+    let _ = std::fs::remove_dir_all(&cwd);
 }
 
 #[test]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -40,7 +40,7 @@ mw context [project:name] [--last-error] [--limit N]   # compact failures digest
 mw agent [session-id]                 # export a full session as text to paste into an agent
 mw ask [question] [--chat gemini]     # package the last failure for your chat AI → clipboard
 mw pet [--watch]                      # show the whale whose mood reflects the memory store
-mw doctor                             # check the install, shell hooks, and MCP server
+mw doctor                             # check the install, shell hooks, MCP server, and Claude/Rho integrations
 mw export [project:name]              # export a bundle (Markdown + JSON + SQLite)
 mw import <bundle|sqlite>             # merge another machine's export
 mw push <ssh-host>                    # send this machine's memory to another (scp + remote import)
@@ -95,6 +95,13 @@ read-only MCP handshake and `tools/list` request. It reports whether the
 binary is missing, timed out, returned an invalid response, or advertised the
 expected six tools. It never calls a memory tool or edits a client
 configuration.
+
+After those install checks, `mw doctor` prints an Integrations section for
+Claude Code and Rho. MCP registration, the auto-capture hook, and the bundled
+skill are reported independently. Missing optional pieces tell you to run
+`mw integrate <client>`. Absent client configs or CLIs are `not detected`,
+not a failed MemoryWhale install. `CLAUDE_CONFIG_DIR` and `RHO_HOME` are
+honored. Doctor does not run client CLIs or print tokens.
 
 `mw git-fix` recognizes a handful of common git failure shapes — push rejected
 (non-fast-forward), merge conflicts, a dirty working tree blocking an

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -19,13 +19,13 @@ command writes to `~/.hermes/config.yaml`.
 
 ## `CLAUDE_CONFIG_DIR`
 
-Used by `mw integrate claude` to locate Claude Code configuration. Without it,
-the command writes to `~/.claude/`.
+Used by `mw integrate claude` and `mw doctor` to locate Claude Code
+configuration. Without it, those commands use `~/.claude/`.
 
 ## `RHO_HOME`
 
-Used by `mw integrate rho` to locate Rho configuration. Without it, the command
-writes to `~/.rho/`.
+Used by `mw integrate rho` and `mw doctor` to locate Rho configuration. Without
+it, those commands use `~/.rho/`.
 
 Additional command-specific variables are documented beside their commands in
 the [CLI reference](cli.md).

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -181,9 +181,10 @@ MemoryWhale's normal terminal capture paths.
   `memorywhale` server connection.
 - Run `/skills` to check skill discovery. If you created the top-level skills
   directory during an active session, restart Claude Code.
-- Run `mw doctor` to verify the MemoryWhale database and data directory. If
-  `MEMORYWHALE_DATA_DIR` is set, ensure Claude Code and your shell use the same
-  value.
+- Run `mw doctor` to verify the MemoryWhale database and data directory, and
+  to see Claude Code MCP, hook, and skill status separately from MemoryWhale's
+  own health. If `MEMORYWHALE_DATA_DIR` is set, ensure Claude Code and your
+  shell use the same value. `CLAUDE_CONFIG_DIR` is honored.
 
 ## Remove integration
 

--- a/integrations/rho/README.md
+++ b/integrations/rho/README.md
@@ -221,9 +221,10 @@ evidence to outlive the current session.
 - Run `/hooks` to confirm the MemoryWhale hook is active. A session that
   started without observational hooks needs a restart to pick a new one up.
 - Run `/skills` to check skill discovery.
-- Run `mw doctor` to verify the MemoryWhale database and data directory. If
-  `MEMORYWHALE_DATA_DIR` is set, put it in the server's `env` block, not only
-  in an unrelated terminal.
+- Run `mw doctor` to verify the MemoryWhale database and data directory, and
+  to see Rho MCP, hook, and skill status separately from MemoryWhale's own
+  health. If `MEMORYWHALE_DATA_DIR` is set, put it in the server's `env` block,
+  not only in an unrelated terminal. `RHO_HOME` is honored.
 - `RHO_HOME` moves the whole Rho directory, including `hooks.toml`,
   `config.toml`, and `skills/`.
 

--- a/linux/completions/_mw
+++ b/linux/completions/_mw
@@ -37,7 +37,7 @@ _mw() {
     'tui:interactive terminal browser'
     'sync-mempalace:mirror memories into MemPalace'
     'git-fix:diagnose the last failed git command'
-    'doctor:check the install'
+    'doctor:check the install, MCP server, and Claude/Rho integrations'
     'global:auto-record every new terminal (on/off/status)'
     'status:show global auto-record state'
     'hooks:install or remove shell auto-record hooks'

--- a/linux/completions/_mw
+++ b/linux/completions/_mw
@@ -37,7 +37,7 @@ _mw() {
     'tui:interactive terminal browser'
     'sync-mempalace:mirror memories into MemPalace'
     'git-fix:diagnose the last failed git command'
-    'doctor:check the install, MCP server, and Claude/Rho integrations'
+    'doctor:check the install, shell hooks, MCP server, and Claude/Rho integrations'
     'global:auto-record every new terminal (on/off/status)'
     'status:show global auto-record state'
     'hooks:install or remove shell auto-record hooks'

--- a/linux/man/mw.1
+++ b/linux/man/mw.1
@@ -218,7 +218,8 @@ skips launching the browser. Prints the payload instead if no clipboard tool
 .B mw doctor
 Check the install: data directory, database, the
 .BR script (1)
-dependency, and auto-record hook status.
+dependency, auto-record hook status, the local MCP server, and Claude Code
+and Rho integration (MCP registration, capture hook, and skill).
 .TP
 .B mw global on
 Wire a shell-startup hook so every new interactive terminal auto-records.


### PR DESCRIPTION
## Summary

`mw doctor` now reports Claude Code and Rho integration health separately from MemoryWhale itself.

The existing data dir, database, `script`, shell-hook, and generic `mw-mcp` checks are unchanged and still do not fail the process. After those, doctor prints:

```text
Integrations
  Claude Code
    MCP                 configured and reachable
    auto-capture hook   installed
    skill               installed
  Rho
    MCP                 configured
    auto-capture hook   not installed; run `mw integrate rho`
    skill               installed
```

MCP, hook, and skill are independent. Missing optional pieces tell you to run `mw integrate <client>`. If the client is not on the machine, the line is `not detected`, not a broken MemoryWhale install.

Inspection reuses the Claude/Rho integrate parsers and the existing bounded stdio MCP probe. It honors `CLAUDE_CONFIG_DIR` and `RHO_HOME`, does not run client CLIs, and does not print tokens or captured memory.

Closes #239

## Test plan

- [x] `cargo test -p memorywhale-cli --lib --test doctor_integrations --test claude_integration --test rho_integration`
- [x] `cargo clippy -p memorywhale-cli --all-targets -- -D warnings`
- Fresh, partial, stale, and full installs covered in unit tests
- Custom `CLAUDE_CONFIG_DIR` / `RHO_HOME` covered in `doctor_integrations`
- Exit status stays 0 when optional integrations are missing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded `mw doctor` to check Claude Code and Rho integrations.
  * Reports MCP registration, capture hooks, bundled skills, client detection, and incomplete, outdated, or unreadable configurations.
  * Safely hides sensitive configuration details and never modifies configuration files.
  * Supports custom configuration directories and distinguishes reachable integrations.

* **Documentation**
  * Updated CLI help, references, troubleshooting guides, shell completions, and man pages.

* **Tests**
  * Added coverage for missing, partial, stale, complete, unreadable, and legacy setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->