### PR TITLE
docs(integrations): standardize every integration guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/integration_request.md
+++ b/.github/ISSUE_TEMPLATE/integration_request.md
@@ -6,11 +6,11 @@ labels: documentation, good first issue
 ---
 
 ## Summary
-<!-- Which tool, and confirm it speaks MCP (can run a local stdio server). -->
-`<tool>` supports MCP servers, so it can use MemoryWhale's six tools
-(`recent_errors`, `search_memory`, `get_context`, `remember`,
-`similar_failures`, `stats`). Add
-`integrations/<tool>/`.
+<!-- Which tool, and which MemoryWhale seam it uses (stdio MCP, CLI, gateway). -->
+`<tool>` should get an `integrations/<tool>/` guide. If it can run a local
+stdio MCP server, it can use MemoryWhale's six tools (`recent_errors`,
+`search_memory`, `get_context`, `remember`, `similar_failures`, `stats`).
+If it does not speak MCP, say which seam it uses instead.
 
 ## Why it's a good first issue
 Docs + config only, mirroring an existing folder (e.g. `integrations/codex/`).
@@ -35,12 +35,15 @@ copy another client’s commands or paths; verify them against the tool’s
 current documentation.
 
 ## What to do
-1. Create `integrations/<tool>/` with a config snippet registering a stdio
-   server whose command is `mw-mcp`.
+1. Create `integrations/<tool>/`. If the client speaks stdio MCP, include a
+   config snippet whose command is `mw-mcp`. If it does not, document the
+   actual seam (CLI plugin, hosted gateway, PR workflow, or similar) and skip
+   an `mw-mcp` registration.
 2. **Verify the exact config format/location against the tool's current docs** —
    don't assume; formats change between versions.
-3. Add a `README.md` using `integrations/TEMPLATE.md`: declare verified
-   capabilities, register the server, include the `mw-mcp`-on-PATH note,
-   document `MEMORYWHALE_DATA_DIR` for a non-default DB, and distinguish MCP
-   access from automatic execution capture.
+3. Add a `README.md` using `integrations/TEMPLATE.md`. For MCP clients, declare
+   verified capabilities, register the server, include the `mw-mcp`-on-PATH
+   note, document `MEMORYWHALE_DATA_DIR` for a non-default DB, and distinguish
+   MCP access from automatic execution capture. For other clients, write
+   "Not applicable" plus a reason on sections that do not apply.
 4. List the tool in `integrations/README.md`.

--- a/.github/ISSUE_TEMPLATE/integration_request.md
+++ b/.github/ISSUE_TEMPLATE/integration_request.md
@@ -16,6 +16,24 @@ labels: documentation, good first issue
 Docs + config only, mirroring an existing folder (e.g. `integrations/codex/`).
 No Rust.
 
+## Canonical guide structure
+
+Follow [integrations/TEMPLATE.md](../../integrations/TEMPLATE.md). Every
+README must use these headings, in this order:
+
+1. Status
+2. Requirements
+3. Setup
+4. Verify
+5. Available capabilities
+6. Example prompt
+7. Troubleshooting
+8. Uninstall
+
+Write "Not applicable" plus a reason when a section does not apply. Do not
+copy another client’s commands or paths; verify them against the tool’s
+current documentation.
+
 ## What to do
 1. Create `integrations/<tool>/` with a config snippet registering a stdio
    server whose command is `mw-mcp`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,9 @@ cargo run -p memorywhale-cli --bin mw-remember -- --help
 
 6. Keep integrations thin.
    Integrations configure an external client at the `mw-mcp` or CLI seam. Use
-   [integrations/TEMPLATE.md](integrations/TEMPLATE.md), declare only verified
+   [integrations/TEMPLATE.md](integrations/TEMPLATE.md) so every guide has
+   Status, Requirements, Setup, Verify, Available capabilities, Example
+   prompt, Troubleshooting, and Uninstall. Declare only verified
    capabilities, and do not describe MCP access as automatic execution capture.
 
 ## Pull Request Checklist
@@ -135,3 +137,4 @@ cargo run -p memorywhale-cli --bin mw-remember -- --help
 - `cargo test -p memorywhale-core -p memorywhale-cli` passes when Rust code changes.
 - `cargo build --workspace` passes for workspace changes.
 - Documentation is updated for user-facing behavior.
+- New or updated client guides follow [integrations/TEMPLATE.md](integrations/TEMPLATE.md).

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -101,6 +101,23 @@ without inventing a shell command or exit code.
 
 ## Adding or updating an integration
 
-Use [`TEMPLATE.md`](TEMPLATE.md). Verify the current client configuration from
-an authoritative source, declare capabilities from repository evidence, and
-keep client-specific behavior out of MemoryWhale core.
+Every guide under this directory follows the same eight headings, in this
+order:
+
+1. Status
+2. Requirements
+3. Setup
+4. Verify
+5. Available capabilities
+6. Example prompt
+7. Troubleshooting
+8. Uninstall
+
+Copy [`TEMPLATE.md`](TEMPLATE.md). Keep those headings even when a section is
+not applicable. Put client-specific detail in subsections, not extra required
+top-level headings. Verify the current client configuration from an
+authoritative source, declare capabilities from repository evidence, and keep
+client-specific behavior out of MemoryWhale core.
+
+The GitHub [integration request](../.github/ISSUE_TEMPLATE/integration_request.md)
+template points at the same standard.

--- a/integrations/TEMPLATE.md
+++ b/integrations/TEMPLATE.md
@@ -8,6 +8,18 @@ Client-specific details belong under these headings as subsections. Do not
 add extra required top-level headings. Do not copy setup from another guide;
 verify commands and paths against the client's current documentation.
 
+Authoring checklist. Check these items, then leave them out of the published
+README so a copy of this file still has exactly eight headings.
+
+- [ ] Headings match this template, in this order.
+- [ ] Setup and Verify were checked against current client docs, not another
+      MemoryWhale guide.
+- [ ] Capabilities match repository evidence.
+- [ ] Automatic capture is claimed only when a verified hook or equivalent
+      exists.
+- [ ] Uninstall does not delete the MemoryWhale database.
+- [ ] The client is listed in [README.md](README.md).
+
 ## Status
 
 State whether the configuration is verified and against which client version
@@ -53,14 +65,3 @@ Cover PATH, restart, configuration location, and data-directory issues.
 ## Uninstall
 
 Explain how to remove client configuration without deleting MemoryWhale data.
-
-## Contribution checklist
-
-- [ ] Headings match this template, in this order.
-- [ ] Setup and Verify were checked against current client docs, not another
-      MemoryWhale guide.
-- [ ] Capabilities match repository evidence.
-- [ ] Automatic capture is claimed only when a verified hook or equivalent
-      exists.
-- [ ] Uninstall does not delete the MemoryWhale database.
-- [ ] The client is listed in [README.md](README.md).

--- a/integrations/TEMPLATE.md
+++ b/integrations/TEMPLATE.md
@@ -1,19 +1,33 @@
 # <Client> + MemoryWhale
 
-Use this structure for every client integration. Remove placeholder text, but
-keep each heading; write “Not applicable” when the client does not support a
-capability.
+Use this structure for every client integration. Keep these eight headings,
+in this order. Remove placeholder text. Write "Not applicable" plus a one-line
+reason when the client does not support a section.
+
+Client-specific details belong under these headings as subsections. Do not
+add extra required top-level headings. Do not copy setup from another guide;
+verify commands and paths against the client's current documentation.
 
 ## Status
 
-State whether the configuration is verified and against which client version or
-documentation date.
+State whether the configuration is verified and against which client version
+or documentation date. Link the authoritative pages you used.
 
 ## Requirements
 
 List MemoryWhale, client, PATH, platform, and feature requirements.
 
-## Capabilities
+## Setup
+
+Show the exact configuration path and the minimal configuration. Link the
+authoritative client documentation used to verify it.
+
+## Verify
+
+Give a deterministic transport or tool-discovery check, plus any client UI
+or CLI command that proves the server is connected.
+
+## Available capabilities
 
 | Capability | Available |
 | --- | --- |
@@ -21,36 +35,32 @@ List MemoryWhale, client, PATH, platform, and feature requirements.
 | Automatic execution capture | Yes / No / Unverified |
 | Memory-use guidance | Yes / No / Unverified |
 
-## Setup
-
-Show the exact configuration path and minimal configuration. Link the
-authoritative client documentation used to verify it.
-
-## Verify
-
-Give a deterministic transport or tool-discovery check.
-
-## How to use
-
-Explain when a person or client should use the integration.
+Declare only what this repository demonstrates. MCP access is not automatic
+execution capture. List the MemoryWhale tools the client actually exposes, or
+state that tool discovery was not verified.
 
 ## Example prompt
 
 > Use MemoryWhale to check whether I encountered a similar failure before.
 
-## Automatic capture
-
-State exactly what is and is not captured. MCP access alone is not automatic
-capture.
-
-## Limitations
-
-List client-specific gaps without inferring unsupported behavior.
+Replace this with a client-specific prompt when the client needs different
+wording. If the client is not an agent, write “Not applicable” and say why.
 
 ## Troubleshooting
 
 Cover PATH, restart, configuration location, and data-directory issues.
 
-## Remove integration
+## Uninstall
 
 Explain how to remove client configuration without deleting MemoryWhale data.
+
+## Contribution checklist
+
+- [ ] Headings match this template, in this order.
+- [ ] Setup and Verify were checked against current client docs, not another
+      MemoryWhale guide.
+- [ ] Capabilities match repository evidence.
+- [ ] Automatic capture is claimed only when a verified hook or equivalent
+      exists.
+- [ ] Uninstall does not delete the MemoryWhale database.
+- [ ] The client is listed in [README.md](README.md).

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -19,14 +19,6 @@ The hook and skill are optional repository-provided components.
 - A local checkout of this repository to copy the skill (only for manual
   setup; `mw integrate claude` needs no checkout).
 
-## Capabilities
-
-| Capability | Available |
-| --- | --- |
-| MCP memory access | Yes |
-| Automatic execution capture | Yes, optional `PostToolUse` and `PostToolUseFailure` hooks for Bash calls |
-| Memory-use guidance | Yes, optional skill |
-
 ## Setup
 
 From any machine with MemoryWhale installed:
@@ -132,7 +124,13 @@ capture, ask Claude Code to run a unique successful command such as
 mw search "memorywhale-hook-check"
 ```
 
-## How to use
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | Yes, optional `PostToolUse` and `PostToolUseFailure` hooks for Bash calls |
+| Memory-use guidance | Yes, optional skill |
 
 The MCP server lets Claude read prior failures and explicitly save lessons. The
 skill prompts Claude to consult those tools when a failure may have happened
@@ -142,13 +140,7 @@ successful Bash commands Claude runs, even when no MCP tool is called.
 The skill falls back to `mw context`, `mw search`, and `mw remember` when the
 MCP server is not connected, so each component can be installed separately.
 
-## Example prompt
-
-> Use MemoryWhale to check whether I encountered a similar failure before.
-> Explain the relevant saved evidence before suggesting a fix, then remember
-> the root cause after it is verified.
-
-## Automatic capture
+### Automatic capture
 
 `mw-remember --from-hook claude` receives Claude Code's hook JSON on standard input.
 For each `Bash` call, it records the command, working directory, output, and
@@ -161,7 +153,7 @@ The hook is registered for both events so successful and failed Bash commands
 are captured. Commands run in an ordinary terminal are captured only through
 MemoryWhale's normal terminal capture paths.
 
-## Limitations
+### Limitations
 
 - The bundled hook captures only the Bash tool.
 - Each output stream is truncated to 20,000 characters by the hook.
@@ -169,6 +161,12 @@ MemoryWhale's normal terminal capture paths.
 - Guidance helps Claude choose when to use memory, but does not force a tool
   call on every failure.
 - Secret redaction reduces accidental retention but is not a security boundary.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+> Explain the relevant saved evidence before suggesting a fix, then remember
+> the root cause after it is verified.
 
 ## Troubleshooting
 
@@ -186,7 +184,7 @@ MemoryWhale's normal terminal capture paths.
   own health. If `MEMORYWHALE_DATA_DIR` is set, ensure Claude Code and your
   shell use the same value. `CLAUDE_CONFIG_DIR` is honored.
 
-## Remove integration
+## Uninstall
 
 ```bash
 mw integrate claude --revert

--- a/integrations/claude-desktop/README.md
+++ b/integrations/claude-desktop/README.md
@@ -1,18 +1,29 @@
-# Claude Desktop integration
+# Claude Desktop + MemoryWhale
 
-[Claude Desktop](https://claude.ai/download) is Anthropic's desktop app and the
-reference MCP host. Point it at MemoryWhale's MCP server and it gets the four
-tools: `recent_errors`, `search_memory`, `get_context`, `remember`.
+[Claude Desktop](https://claude.ai/download) is Anthropic's desktop app and an
+MCP host. Point it at MemoryWhale's MCP server to use the local memory tools.
+This is the desktop chat app. For the Claude Code CLI, see
+[`../claude-code/`](../claude-code/).
 
-(This is the desktop app. For the Claude Code CLI, see
-[`../claude-code/`](../claude-code/).)
+## Status
 
-## Connect the MCP server
+Verified against the Model Context Protocol
+[local stdio server guide](https://modelcontextprotocol.io/docs/develop/connect-local-servers)
+on 2026-08-29. That page documents the macOS and Windows config paths below.
+Claude Desktop reads MCP config at launch.
 
-Edit Claude Desktop's config file:
+## Requirements
 
-- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+- MemoryWhale installed with `mw-mcp` on `PATH`.
+- Claude Desktop installed.
+- A full quit and reopen after editing the config file.
+
+## Setup
+
+Edit Claude Desktop's config file. Anthropic's local-server documentation lists:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 
 Add the `memorywhale` entry from
 [`claude_desktop_config.json`](claude_desktop_config.json):
@@ -28,15 +39,53 @@ Add the `memorywhale` entry from
 ```
 
 If the file already has an `mcpServers` object, add `memorywhale` alongside your
-other servers rather than replacing it. Then **fully restart Claude Desktop**
-(quit and reopen) — it reads MCP config only at launch.
+other servers rather than replacing it. Then fully restart Claude Desktop (quit
+and reopen). It reads MCP config only at launch.
 
 `mw-mcp` must be on `PATH` (the standard MemoryWhale install); otherwise use its
 absolute path as `command`. For a non-default database add
 `"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`. After restart, the tools
-appear under the 🔌/tools menu in the composer.
+appear under the tools menu in the composer.
 
-## Without the MCP server
+## Verify
 
-The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
-`mw remember "…"`.
+```bash
+command -v mw-mcp
+```
+
+Quit and reopen Claude Desktop, then confirm `memorywhale` appears in the tools
+menu with the six MemoryWhale tools. If the server is missing, the config file
+was not found or was invalid JSON.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | No |
+
+The six tools are `recent_errors`, `search_memory`, `get_context`, `remember`,
+`similar_failures`, and `stats`. MCP access is not automatic capture. Commands
+run outside MemoryWhale's terminal capture are not recorded.
+
+Without the MCP server, the `mw` CLI still works: `mw context --last-error`,
+`mw search "…"`, `mw remember "…"`.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+
+## Troubleshooting
+
+- Run `command -v mw-mcp` in a terminal. If Claude Desktop was started from a
+  GUI, it may not see a shell-only `PATH`; use the absolute path as `command`.
+- Validate the JSON and restart Claude Desktop after every edit.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in the server `env`.
+- Run `mw doctor` to check the MemoryWhale install.
+
+## Uninstall
+
+Delete the `memorywhale` entry from `mcpServers` in
+`claude_desktop_config.json` and fully restart Claude Desktop. This does not
+delete the MemoryWhale database.

--- a/integrations/claude-desktop/README.md
+++ b/integrations/claude-desktop/README.md
@@ -53,6 +53,9 @@ appear under the tools menu in the composer.
 command -v mw-mcp
 ```
 
+On Windows PowerShell use `Get-Command mw-mcp`; in Command Prompt use
+`where.exe mw-mcp`.
+
 Quit and reopen Claude Desktop, then confirm `memorywhale` appears in the tools
 menu with the six MemoryWhale tools. If the server is missing, the config file
 was not found or was invalid JSON.

--- a/integrations/cline/README.md
+++ b/integrations/cline/README.md
@@ -9,9 +9,11 @@ Verified against Cline's
 [MCP overview](https://docs.cline.bot/mcp/mcp-overview) and
 [configuring MCP servers](https://docs.cline.bot/mcp/configuring-mcp-servers)
 documentation on 2026-08-29. The IDE opens MCP settings from the Cline panel
-(MCP Servers → Configure MCP Servers). CLI config is documented at
-`~/.cline/data/settings/cline_mcp_settings.json`. Local servers use `command`
-under a `mcpServers` object.
+(MCP Servers → Configure MCP Servers); that file lives under the editor's
+globalStorage, not under `~/.cline/`. CLI config is
+`~/.cline/data/settings/cline_mcp_settings.json`. Cline's MCP page still lists
+`~/.cline/mcp.json`; the CLI does not read that file. Local servers use
+`command` under a `mcpServers` object.
 
 ## Requirements
 
@@ -43,7 +45,7 @@ file this install actually uses.
 Typical VS Code global-storage locations, if you need to find the file by
 hand:
 
-```
+```text
 ~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json   # macOS
 ~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json                       # Linux
 %APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json                        # Windows
@@ -76,6 +78,9 @@ Add to a `.clinerules` file (or Cline's custom instructions):
 command -v mw-mcp
 ```
 
+On Windows PowerShell use `Get-Command mw-mcp`; in Command Prompt use
+`where.exe mw-mcp`.
+
 In the Cline MCP panel, confirm `memorywhale` is enabled and lists the six
 tools: `recent_errors`, `search_memory`, `get_context`, `remember`,
 `similar_failures`, and `stats`. From the CLI, `cline mcp` can list servers.
@@ -98,7 +103,8 @@ MCP access is not automatic execution capture. Without the MCP server, the
 
 ## Troubleshooting
 
-- Run `command -v mw-mcp` from the environment that launches Cline.
+- Confirm `mw-mcp` is on `PATH` from the environment that launches Cline
+  (`command -v mw-mcp`, or `Get-Command` / `where.exe` on Windows).
 - Edit the file the Cline UI opened, not a guessed path.
 - Restart Cline after changing MCP settings if tools do not appear.
 - If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in `env`.

--- a/integrations/cline/README.md
+++ b/integrations/cline/README.md
@@ -1,14 +1,29 @@
-# Cline integration
+# Cline + MemoryWhale
 
-[Cline](https://github.com/cline/cline) (the autonomous coding agent for VS Code)
-supports MCP servers, so it gets MemoryWhale's four tools: `recent_errors`,
-`search_memory`, `get_context`, `remember`.
+[Cline](https://github.com/cline/cline) supports local stdio MCP servers, so it
+can use MemoryWhale's six local memory tools.
 
-## Connect the MCP server
+## Status
 
-In VS Code, click the **Cline** icon → open the menu (top-right of the Cline
-panel) → **MCP Servers** → **Configure MCP Servers**. That opens Cline's
-`cline_mcp_settings.json`. Add the `memorywhale` entry from
+Verified against Cline's
+[MCP overview](https://docs.cline.bot/mcp/mcp-overview) and
+[configuring MCP servers](https://docs.cline.bot/mcp/configuring-mcp-servers)
+documentation on 2026-08-29. The IDE opens MCP settings from the Cline panel
+(MCP Servers → Configure MCP Servers). CLI config is documented at
+`~/.cline/data/settings/cline_mcp_settings.json`. Local servers use `command`
+under a `mcpServers` object.
+
+## Requirements
+
+- MemoryWhale installed with `mw-mcp` on `PATH`.
+- Cline (VS Code/compatible extension or Cline CLI).
+
+## Setup
+
+### IDE
+
+In the editor, click the Cline icon → MCP Servers → Configure MCP Servers.
+That opens Cline's MCP settings JSON. Add the `memorywhale` entry from
 [`mcp_settings.json`](mcp_settings.json):
 
 ```json
@@ -22,9 +37,11 @@ panel) → **MCP Servers** → **Configure MCP Servers**. That opens Cline's
 ```
 
 If the file already has an `mcpServers` object, add `memorywhale` alongside your
-other servers rather than replacing it.
+other servers rather than replacing it. Prefer the Cline UI; it points at the
+file this install actually uses.
 
-The file lives under VS Code's global storage (path may vary by OS/version):
+Typical VS Code global-storage locations, if you need to find the file by
+hand:
 
 ```
 ~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json   # macOS
@@ -32,22 +49,63 @@ The file lives under VS Code's global storage (path may vary by OS/version):
 %APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json                        # Windows
 ```
 
-Prefer editing through the Cline UI (above) — it points at the right file.
+### CLI
+
+```bash
+cline mcp add memorywhale -- mw-mcp
+```
+
+That writes `~/.cline/data/settings/cline_mcp_settings.json`.
+
 `mw-mcp` must be on `PATH` (the standard MemoryWhale install); otherwise use its
 absolute path as `command`. For a non-default database add
 `"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`.
 
-## Tell it when to reach for the memory
+### Memory-use guidance
 
-The MCP server gives Cline the *tools*; a rule teaches it *when*. Add to a
-`.clinerules` file (or Cline's custom instructions):
+Add to a `.clinerules` file (or Cline's custom instructions):
 
 > When a build/test/deploy fails, before proposing a fix, use `search_memory`
 > or `recent_errors` (MemoryWhale MCP) to check whether this failure has a known
 > cause or a saved lesson. Once you've figured out why something failed or how a
 > fix worked, use `remember` to save that conclusion.
 
-## Without the MCP server
+## Verify
 
-The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+```bash
+command -v mw-mcp
+```
+
+In the Cline MCP panel, confirm `memorywhale` is enabled and lists the six
+tools: `recent_errors`, `search_memory`, `get_context`, `remember`,
+`similar_failures`, and `stats`. From the CLI, `cline mcp` can list servers.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, via `.clinerules` |
+
+MCP access is not automatic execution capture. Without the MCP server, the
+`mw` CLI still works: `mw context --last-error`, `mw search "…"`,
 `mw remember "…"`.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+
+## Troubleshooting
+
+- Run `command -v mw-mcp` from the environment that launches Cline.
+- Edit the file the Cline UI opened, not a guessed path.
+- Restart Cline after changing MCP settings if tools do not appear.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in `env`.
+- Run `mw doctor` to check the MemoryWhale install.
+
+## Uninstall
+
+Delete the `memorywhale` entry from Cline's MCP settings (IDE Configure MCP
+Servers, or `cline mcp` delete). Remove any `.clinerules` instruction you
+added. This does not delete the MemoryWhale database.

--- a/integrations/cliproxyapi/README.md
+++ b/integrations/cliproxyapi/README.md
@@ -50,15 +50,6 @@ them.
     settings.
 - CLIProxyAPI installed and running with at least one `api-keys` entry.
 
-## Capabilities
-
-| Capability | Available |
-| --- | --- |
-| MCP memory access | No — CLIProxyAPI is not an MCP client; compose through an agent |
-| Automatic execution capture | No — comes from the agent's hooks, not the proxy |
-| Memory-use guidance | No — configure guidance in the agent, not the proxy |
-| Model-provider consolidation | Yes — one local endpoint, multiple upstream accounts |
-
 ## Setup
 
 ### 1. Start CLIProxyAPI
@@ -78,7 +69,7 @@ api-keys:
 ### 2. Point the coding agent at CLIProxyAPI
 
 Configure the agent's model base URL to the local proxy and use a key from
-CLIProxyAPI's `api-keys`. Export that key once as `CLIPROXY_API_KEY` — it is
+CLIProxyAPI's `api-keys`. Export that key once as `CLIPROXY_API_KEY`. It is
 what the verification step below authenticates with, independent of protocol.
 If you already have provider base URLs or keys set, save their values (and
 whether each was set at all) first so they can be restored on removal:
@@ -117,7 +108,7 @@ the exact endpoint paths each protocol exposes.
 
 ### 3. Keep `mw-mcp` configured in the same agent
 
-This step is unchanged from the agent's normal MemoryWhale setup — the proxy
+This step is unchanged from the agent's normal MemoryWhale setup. The proxy
 does not replace it. For example, in Claude Code:
 
 ```bash
@@ -163,7 +154,16 @@ tools. If model calls fail but `mw doctor` passes, the problem is on the proxy
 side; if model calls work but memory tools are missing, re-check the agent's
 MCP configuration.
 
-## How to use
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | No, CLIProxyAPI is not an MCP client; compose through an agent |
+| Automatic execution capture | No, comes from the agent's hooks, not the proxy |
+| Memory-use guidance | No, configure guidance in the agent, not the proxy |
+| Model-provider consolidation | Yes, one local endpoint, multiple upstream accounts |
+
+### How to use
 
 Use this stack when you want:
 
@@ -172,22 +172,15 @@ Use this stack when you want:
 - your existing agent's MemoryWhale memory to keep working unchanged.
 
 Use plain provider keys instead when you have only one account and no routing
-needs — a proxy in the middle adds a hop without benefit.
+needs. A proxy in the middle adds a hop without benefit.
 
-## Example prompt
-
-No prompt changes are needed; memory behavior lives in the agent's
-configuration, not the proxy. A normal memory-aware prompt still works:
-
-> Use MemoryWhale to check whether I encountered a similar failure before.
-
-## Automatic capture
+### Automatic capture
 
 Automatic capture is unchanged and comes from the agent's hooks (for example,
 Claude Code's `PostToolUse` hook), not from CLIProxyAPI. The proxy only sees
 model requests and cannot record terminal commands or sessions.
 
-## Limitations
+### Limitations
 
 - CLIProxyAPI does not provide MCP memory access. Any guide or matrix claim of
   direct `mw-mcp` ↔ CLIProxyAPI connectivity would be false.
@@ -200,6 +193,13 @@ model requests and cannot record terminal commands or sessions.
 - If you bind CLIProxyAPI beyond loopback, its endpoints are only as safe as
   the `api-keys` you configure. Keep `host` on loopback unless you need LAN
   access, and treat keys in `config.yaml` as secrets.
+
+## Example prompt
+
+No prompt changes are needed; memory behavior lives in the agent's
+configuration, not the proxy. A normal memory-aware prompt still works:
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
 
 ## Troubleshooting
 
@@ -214,10 +214,10 @@ model requests and cannot record terminal commands or sessions.
   authenticated accounts; see its routing docs (`round-robin`,
   `fill-first`, session affinity) rather than MemoryWhale's.
 
-## Remove integration
+## Uninstall
 
 Stop CLIProxyAPI, then undo **both** the base-URL and key overrides you set in
-step 2 — leaving `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` pointing at the proxy key
+step 2. Leaving `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` pointing at the proxy key
 breaks direct provider authentication. Remove the overrides first, then
 restore only what was actually set before:
 
@@ -248,8 +248,8 @@ fi
 Run setup and removal in the same shell (or persist the `OLD_*` values
 securely) so the restore state is available. If you persisted the proxy URL in
 the agent's own configuration (Codex's `config.toml`, OpenCode's
-`opencode.json`, Continue's `config.yaml`), remove or restore that entry too —
-otherwise model calls keep targeting `127.0.0.1:8317` after the proxy stops.
+`opencode.json`, Continue's `config.yaml`), remove or restore that entry too.
+Otherwise model calls keep targeting `127.0.0.1:8317` after the proxy stops.
 Direct-provider fallback then works when direct provider access is already
 configured. `mw-mcp` memory continues to work unchanged, and removing
 CLIProxyAPI never deletes MemoryWhale data.

--- a/integrations/codewhale/README.md
+++ b/integrations/codewhale/README.md
@@ -2,8 +2,8 @@
 
 [CodeWhale](https://github.com/Hmbown/CodeWhale) is an open-source terminal
 coding agent written in Rust: TUI, headless `codewhale exec`, and a local web
-client, with per-role model fleets. It is an MCP host — local stdio MCP servers
-configured in its MCP file become tools the agent can call — so `mw-mcp` plugs
+client, with per-role model fleets. It is an MCP host. Local stdio MCP servers
+configured in its MCP file become tools the agent can call, so `mw-mcp` plugs
 in directly.
 
 ## Status
@@ -19,14 +19,6 @@ active development; check that file if a field or command changes.
   `docs/INSTALL.md`).
 - A model that supports tool calling (CodeWhale supports 30+ providers and
   local servers; tool calling is a model capability).
-
-## Capabilities
-
-| Capability | Available |
-| --- | --- |
-| MCP memory access | Yes |
-| Automatic execution capture | No |
-| Memory-use guidance | Via roles / constitution standing instructions |
 
 ## Setup
 
@@ -96,7 +88,7 @@ codewhale-tui mcp tools memorywhale
 `mcp list` should show `memorywhale`; `mcp tools memorywhale` should discover
 the six MemoryWhale tools. After editing the MCP file, run `/mcp reload` in the
 TUI (no restart needed). Headless `codewhale exec` surfaces do **not** hot
-reload — restart the process after config changes.
+reload. Restart the process after config changes.
 
 CodeWhale exposes MCP tools to the model under a server-name prefix
 (`mcp_<server>_<tool>`), so the tools appear as `mcp_memorywhale_search_memory`
@@ -115,27 +107,35 @@ The six tools:
 - `similar_failures`
 - `stats`
 
-An empty store is valid — the tools return empty results, not errors.
+An empty store is valid. The tools return empty results, not errors.
 
-## How to use
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Via roles / constitution standing instructions |
+
+### How to use
 
 Use retrieval when a build, test, or deployment failure may have happened
 before. Once the cause or fix is confirmed, use `remember` to save the lesson
 so future CodeWhale sessions (or any other agent sharing the store) can find
 it. CodeWhale roles and the constitution carry standing instructions, so a
 role can be told to consult MemoryWhale before debugging and to record
-verified fixes — see CodeWhale's `docs/FLEET.md` and `docs/CONFIGURATION.md`.
+verified fixes. See CodeWhale's `docs/FLEET.md` and `docs/CONFIGURATION.md`.
 
-## Automatic capture
+### Automatic capture
 
 MCP access is not automatic execution capture. Commands CodeWhale runs are
-recorded by MemoryWhale only through the normal capture paths — `mw-run --`,
+recorded by MemoryWhale only through the normal capture paths: `mw-run --`,
 `mw-remember`, `mw --notes "project:…"` session recording, or an installed
 shell hook. CodeWhale has its own lifecycle hooks (`docs/HOOKS.md`), but none
 is verified to write into MemoryWhale; do not assume capture without one of
 the paths above.
 
-## Limitations
+### Limitations
 
 - The model must support tool calling; not every local model does.
 - MCP tools consume context; CodeWhale's docs recommend enabling only the
@@ -143,7 +143,7 @@ the paths above.
 - Secret redaction on capture reduces accidental retention but is not a
   security boundary.
 
-## Security
+### Security
 
 `mw-mcp` is read-mostly: of its six tools, `remember` is the only one that
 writes, and it saves a single note. The other five only read. Review the
@@ -152,6 +152,12 @@ before connecting a store that contains sensitive output. Note that these MCP
 tool permissions are separate from process-level filesystem permissions: the
 OS user that spawns `mw-mcp` remains the file-level trust boundary.
 `MEMORYWHALE_DATA_DIR` selects a store; it is not an access-control mechanism.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I have encountered a similar build failure
+> before. Search for `openssl` and explain which saved evidence is relevant
+> before suggesting a fix.
 
 ## Troubleshooting
 
@@ -164,11 +170,11 @@ OS user that spawns `mw-mcp` remains the file-level trust boundary.
   `mcp_config_path` / `DEEPSEEK_MCP_CONFIG` override).
 - Run `mw doctor` to verify the MemoryWhale data directory and database.
 
-## Remove integration
+## Uninstall
 
 Remove the `"memorywhale"` entry from `~/.codewhale/mcp.json` (or run
 `codewhale-tui mcp remove memorywhale`, or `/mcp remove memorywhale` in the
 TUI), then run `/mcp reload` in each TUI session. Running headless
-`codewhale exec` processes do not hot-reload MCP configuration — restart them
+`codewhale exec` processes do not hot-reload MCP configuration. Restart them
 after removing the entry. This does not delete the MemoryWhale database; use
 `mw rm` or the documented retention commands for data lifecycle.

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,12 +1,24 @@
-# Codex CLI integration
+# Codex CLI + MemoryWhale
 
-OpenAI's Codex CLI supports MCP servers via its TOML config, so it gets
-MemoryWhale's four tools: `recent_errors`, `search_memory`, `get_context`,
-`remember`.
+OpenAI's Codex CLI supports MCP servers via TOML config, so it can use
+MemoryWhale's six local memory tools.
 
-## Connect the MCP server
+## Status
 
-Add the block from [`config.toml`](config.toml) to **`~/.codex/config.toml`**:
+Verified against OpenAI's [Codex MCP](https://developers.openai.com/codex/mcp)
+documentation on 2026-08-29. User config is `~/.codex/config.toml`. Trusted
+projects may also use `.codex/config.toml`. Each server is a
+`[mcp_servers.<name>]` table with `command` for stdio. The TUI lists servers
+with `/mcp`.
+
+## Requirements
+
+- MemoryWhale installed with `mw-mcp` on `PATH`.
+- Codex CLI (or the Codex IDE extension, which opens the same `config.toml`).
+
+## Setup
+
+Add the block from [`config.toml`](config.toml) to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.memorywhale]
@@ -15,11 +27,10 @@ command = "mw-mcp"
 
 `mw-mcp` must be on `PATH` (standard MemoryWhale install); otherwise use its
 absolute path. For a non-default database add
-`env = { MEMORYWHALE_DATA_DIR = "/path/to/dir" }`. (Codex's MCP config key has
-been `mcp_servers` — if a newer version differs, check `codex --help` / its
-config docs; `command = "mw-mcp"` is the same regardless.)
+`env = { MEMORYWHALE_DATA_DIR = "/path/to/dir" }`. The top-level key is
+`mcp_servers`, not `mcpServers`.
 
-## Tell it when to reach for the memory
+### Memory-use guidance
 
 Codex reads an `AGENTS.md` at your repo root. Add:
 
@@ -28,5 +39,43 @@ Codex reads an `AGENTS.md` at your repo root. Add:
 > cause or a saved lesson. Once you've figured out why something failed or how a
 > fix worked, use `remember` to save that conclusion.
 
-Without the MCP server, the `mw` CLI still works: `mw context --last-error`,
-`mw search "…"`, `mw remember "…"`.
+## Verify
+
+```bash
+command -v mw-mcp
+```
+
+In the Codex TUI, run `/mcp` and confirm `memorywhale` is active. You should
+see the six tools: `recent_errors`, `search_memory`, `get_context`, `remember`,
+`similar_failures`, and `stats`.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, via `AGENTS.md` |
+
+MCP access is not automatic execution capture. Without the MCP server, the
+`mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+`mw remember "…"`.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+
+## Troubleshooting
+
+- Run `command -v mw-mcp` from the environment that launches Codex.
+- Confirm you edited `[mcp_servers.memorywhale]`, not an `mcpServers` JSON
+  block from another client.
+- Restart Codex after editing `config.toml`.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in `env`.
+- Run `mw doctor` to check the MemoryWhale install.
+
+## Uninstall
+
+Delete the `[mcp_servers.memorywhale]` table from `~/.codex/config.toml` (and
+any project `.codex/config.toml`). Remove the `AGENTS.md` instruction if you
+added one. This does not delete the MemoryWhale database.

--- a/integrations/continue/README.md
+++ b/integrations/continue/README.md
@@ -1,14 +1,42 @@
-# Continue integration
+# Continue + MemoryWhale
 
-[Continue](https://github.com/continuedev/continue) (the open-source AI code
-assistant for VS Code and JetBrains) connects to MCP servers, so it gets
-MemoryWhale's four tools: `recent_errors`, `search_memory`, `get_context`,
-`remember`.
+[Continue](https://github.com/continuedev/continue) connects to MCP servers in
+agent mode, so it can use MemoryWhale's six local memory tools.
 
-## Connect the MCP server
+## Status
 
-Continue reads MCP servers from YAML. Add the `mcpServers` block from
-[`config.yaml`](config.yaml) to your global config at `~/.continue/config.yaml`:
+Verified against Continue's
+[MCP deep dive](https://docs.continue.dev/customize/deep-dives/mcp) and
+[config.yaml `mcpServers` reference](https://docs.continue.dev/reference/config)
+on 2026-08-29. The documented project layout is a YAML block under
+`.continue/mcpServers/`. A `mcpServers` list in `config.yaml` is still in the
+YAML reference.
+
+## Requirements
+
+- MemoryWhale installed with `mw-mcp` on `PATH`.
+- Continue in agent mode (MCP tools are not used outside agent mode).
+
+## Setup
+
+### Project MCP block (documented layout)
+
+Create `.continue/mcpServers/memorywhale.yaml` in the workspace:
+
+```yaml
+name: MemoryWhale
+version: 0.0.1
+schema: v1
+mcpServers:
+  - name: memorywhale
+    command: mw-mcp
+    args: []
+```
+
+### Global config.yaml
+
+You can instead add the `mcpServers` list from [`config.yaml`](config.yaml)
+to `~/.continue/config.yaml`:
 
 ```yaml
 mcpServers:
@@ -17,31 +45,63 @@ mcpServers:
     args: []
 ```
 
-`mcpServers` entries are **list items** — the leading `-` matters, and mixing
+`mcpServers` entries are list items. The leading `-` matters, and mixing
 tabs with spaces silently breaks YAML parsing. If you already have an
 `mcpServers:` list, add `memorywhale` as another item rather than replacing it.
-
-Alternatively, drop a standalone server file into `.continue/mcpServers/` inside
-a project.
 
 `mw-mcp` must be on `PATH` (the standard MemoryWhale install); otherwise use its
 absolute path as `command`. For a non-default database add an `env` map:
 `env: { MEMORYWHALE_DATA_DIR: "/path/to/dir" }`.
 
-Continue does not always pick up MCP edits live — run **Reload Window** (VS Code)
+Continue does not always pick up MCP edits live. Run Reload Window (VS Code)
 or reload the extension so it re-reads the config.
 
-## Tell it when to reach for the memory
+### Memory-use guidance
 
-The MCP server gives Continue the *tools*; a rule (Continue's rules / system
-message) teaches it *when*:
+A Continue rule / system message teaches the agent when to use the tools:
 
 > When a build/test/deploy fails, before proposing a fix, use `search_memory`
 > or `recent_errors` (MemoryWhale MCP) to check whether this failure has a known
 > cause or a saved lesson. Once you've figured out why something failed or how a
 > fix worked, use `remember` to save that conclusion.
 
-## Without the MCP server
+## Verify
 
-The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+```bash
+command -v mw-mcp
+```
+
+Switch Continue to agent mode and confirm the six tools:
+`recent_errors`, `search_memory`, `get_context`, `remember`,
+`similar_failures`, and `stats`.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, optional rule |
+
+MCP access is not automatic execution capture. Without the MCP server, the
+`mw` CLI still works: `mw context --last-error`, `mw search "…"`,
 `mw remember "…"`.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+
+## Troubleshooting
+
+- Confirm Continue is in agent mode.
+- Validate YAML (list dashes, no tabs).
+- Reload the window after editing config.
+- Run `command -v mw-mcp` from the environment Continue uses.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in `env`.
+- Run `mw doctor` to check the MemoryWhale install.
+
+## Uninstall
+
+Delete `.continue/mcpServers/memorywhale.yaml` and/or the `memorywhale` item
+from `mcpServers` in `~/.continue/config.yaml`. Remove any rule you added.
+Reload Continue. This does not delete the MemoryWhale database.

--- a/integrations/crowclaw/README.md
+++ b/integrations/crowclaw/README.md
@@ -1,14 +1,26 @@
-# CrowClaw integration
+# CrowClaw + MemoryWhale
 
-[CrowClaw](https://github.com/subinium/CrowClaw) is a TypeScript agent runtime,
-and its agents connect to MCP servers — so it gets MemoryWhale's four tools:
-`recent_errors`, `search_memory`, `get_context`, `remember`.
+[CrowClaw](https://github.com/subinium/CrowClaw) agents connect to MCP servers,
+so they can use MemoryWhale's six local memory tools.
 
-## Connect the MCP server
+## Status
+
+Verified against the custom-server shape shipped in
+[`server.json`](server.json) and CrowClaw's dashboard MCP add flow as
+documented in this repository on 2026-08-29. Custom (non-preset) servers take
+`name`, `command`, `args`, and `custom: true`. Definitions persist under
+`~/.crowclaw/`. Tool discovery is `GET /api/mcp/servers/memorywhale/tools`.
+
+## Requirements
+
+- MemoryWhale installed with `mw-mcp` on `PATH`.
+- CrowClaw with the dashboard or access to its MCP REST API.
+
+## Setup
 
 CrowClaw supports custom (non-preset) MCP servers. Add MemoryWhale as one.
 
-**From the dashboard:** open the CrowClaw dashboard → **MCP** → **Add server**,
+**From the dashboard:** open the CrowClaw dashboard → MCP → Add server,
 and enter:
 
 | Field | Value |
@@ -17,7 +29,7 @@ and enter:
 | Command | `mw-mcp` |
 | Args | *(none)* |
 
-**Or via the REST API** the dashboard uses — post the block from
+**Or via the REST API** the dashboard uses. Post the block from
 [`server.json`](server.json) to `/api/mcp/servers`:
 
 ```json
@@ -34,26 +46,59 @@ Either way the definition is persisted under `~/.crowclaw/`. `mw-mcp` must be on
 `command`. For a non-default database add
 `"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`.
 
-Verify the server answers and its tools were discovered:
+### Memory-use guidance
 
-```
-GET /api/mcp/servers/memorywhale/tools
-```
-
-(or use the dashboard's per-server reconnect/tools view). You should see the
-four tools listed.
-
-## Tell it when to reach for the memory
-
-The MCP server gives CrowClaw the *tools*; a preset's `systemPromptAppend` (or
-your agent's system prompt) teaches it *when* to reach for them:
+A preset's `systemPromptAppend` (or your agent's system prompt) teaches it
+when to reach for the tools:
 
 > When a build/test/deploy fails, before proposing a fix, use `search_memory`
 > or `recent_errors` (MemoryWhale MCP) to check whether this failure has a known
 > cause or a saved lesson. Once you've figured out why something failed or how a
 > fix worked, use `remember` to save that conclusion.
 
-## Without the MCP server
+## Verify
 
-The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+```bash
+command -v mw-mcp
+```
+
+Then confirm tools were discovered:
+
+```
+GET /api/mcp/servers/memorywhale/tools
+```
+
+(or use the dashboard's per-server reconnect/tools view). You should see the
+six tools: `recent_errors`, `search_memory`, `get_context`, `remember`,
+`similar_failures`, and `stats`.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, via system prompt |
+
+MCP access is not automatic execution capture. Without the MCP server, the
+`mw` CLI still works: `mw context --last-error`, `mw search "…"`,
 `mw remember "…"`.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+
+## Troubleshooting
+
+- Run `command -v mw-mcp` from the environment CrowClaw's runtime uses.
+- Reconnect the server in the dashboard if the add succeeded but tools are
+  empty.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in `env`.
+- Run `mw doctor` to check the MemoryWhale install.
+
+## Uninstall
+
+Remove the `memorywhale` server from the CrowClaw dashboard MCP page, or
+delete the matching custom-server definition under `~/.crowclaw/`. Remove any
+system-prompt instruction you added. This does not delete the MemoryWhale
+database.

--- a/integrations/crowclaw/README.md
+++ b/integrations/crowclaw/README.md
@@ -64,7 +64,7 @@ command -v mw-mcp
 
 Then confirm tools were discovered:
 
-```
+```http
 GET /api/mcp/servers/memorywhale/tools
 ```
 

--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -1,17 +1,30 @@
-# Cursor integration
+# Cursor + MemoryWhale
 
-Give Cursor's AI the same access to your MemoryWhale memory that Claude Code
-gets: it can read what already failed and write down what it figured out. Two
-pieces — an MCP server and a Rule.
+Give Cursor's agent the same local MemoryWhale tools: it can read what already
+failed and write down what it figured out. Two pieces, an MCP server and a Rule.
 
-## 1. Connect the MCP server
+## Status
 
-`mw-mcp` is a Model Context Protocol server (`recent_errors`, `search_memory`,
-`get_context`, `remember`). Point Cursor at it via `mcp.json`:
+Verified against Cursor's [MCP](https://cursor.com/docs/context/mcp) and
+[CLI MCP](https://cursor.com/docs/cli/mcp) documentation on 2026-08-29.
+Project config is `.cursor/mcp.json`. User config is `~/.cursor/mcp.json`.
+Both files are merged; a duplicate name in the project file wins.
 
-- **This project only:** copy [`mcp.json`](mcp.json) to `.cursor/mcp.json` in
+## Requirements
+
+- MemoryWhale installed with `mw-mcp` on `PATH`.
+- Cursor (editor or CLI `agent`).
+- Optional: the repository Rule file [`memorywhale.mdc`](memorywhale.mdc).
+
+## Setup
+
+### Connect the MCP server
+
+`mw-mcp` is a local stdio MCP server. Point Cursor at it via `mcp.json`:
+
+- This project only: copy [`mcp.json`](mcp.json) to `.cursor/mcp.json` in
   your project root.
-- **Every project:** put the same JSON in `~/.cursor/mcp.json`.
+- Every project: put the same JSON in `~/.cursor/mcp.json`.
 
 ```json
 {
@@ -27,26 +40,68 @@ pieces — an MCP server and a Rule.
 its absolute path as `command`. To point at a non-default database, add
 `"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`.
 
-Then in Cursor: **Settings → MCP** should show `memorywhale` with its four tools
-enabled.
+### Add the Rule
 
-## 2. Add the Rule (the "when to use it" part)
-
-The MCP server gives Cursor the *tools*; this Rule teaches it *when* to reach
+The MCP server gives Cursor the tools; this Rule teaches it when to reach
 for them (recurring failures, "how did we fix this last time", and saving a
 conclusion once a fix is found).
 
-- **This project only:** copy [`memorywhale.mdc`](memorywhale.mdc) to
+- This project only: copy [`memorywhale.mdc`](memorywhale.mdc) to
   `.cursor/rules/memorywhale.mdc`.
-- **Every project:** add it via Cursor **Settings → Rules → User Rules**.
+- Every project: add it via Cursor Settings → Rules → User Rules.
 
-It's an "Agent Requested" rule (`alwaysApply: false`), so Cursor pulls it in
-only when the description matches what you're doing — no wasted context on
-unrelated work.
+It is an "Agent Requested" rule (`alwaysApply: false`), so Cursor pulls it in
+only when the description matches what you're doing.
 
-## Without the MCP server
+## Verify
+
+```bash
+command -v mw-mcp
+```
+
+In the editor, open Settings → MCP and confirm `memorywhale` is listed. From
+the Cursor CLI, which uses the same config:
+
+```bash
+agent mcp list
+agent mcp list-tools memorywhale
+```
+
+You should see the six tools: `recent_errors`, `search_memory`, `get_context`,
+`remember`, `similar_failures`, and `stats`.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, optional Rule |
+
+MCP access is not automatic execution capture. Cursor-run commands are recorded
+only through MemoryWhale's normal terminal capture, `mw-run`, or `mw-remember`.
 
 The Rule falls back to the `mw` CLI, so even with only the binaries installed,
 Cursor can run `mw context --last-error` / `mw search "…"` / `mw remember "…"`.
-And with no editor integration at all, `mw ask` packages the last failure onto
+With no editor integration at all, `mw ask` packages the last failure onto
 your clipboard for any chat.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+
+## Troubleshooting
+
+- Run `command -v mw-mcp` in the environment that launches Cursor. Use an
+  absolute `command` if the GUI `PATH` differs from your shell.
+- Confirm you edited `.cursor/mcp.json` or `~/.cursor/mcp.json`, not some other
+  client's file.
+- Restart Cursor or reload MCP if the server does not appear.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in the server `env`.
+- Run `mw doctor` to check the MemoryWhale install.
+
+## Uninstall
+
+Delete the `memorywhale` entry from `.cursor/mcp.json` and/or
+`~/.cursor/mcp.json`. Remove `.cursor/rules/memorywhale.mdc` or the matching
+user Rule. Restart Cursor. This does not delete the MemoryWhale database.

--- a/integrations/gemini-cli/README.md
+++ b/integrations/gemini-cli/README.md
@@ -81,7 +81,9 @@ MCP access is not automatic execution capture. Without the MCP server, the
 
 - Run `command -v mw-mcp` from the environment that launches Gemini CLI.
 - Confirm `mcpServers` is valid JSON and restart the CLI.
-- If `/mcp list` shows Disconnected, the binary is missing from `PATH`.
+- If `/mcp list` shows Disconnected, run `gemini mcp list` and read the
+  reported error. Check `PATH`, the `command` and `args` in settings, and
+  whether `mw-mcp` starts on its own. A missing binary is only one cause.
 - If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in `env`.
 - Run `mw doctor` to check the MemoryWhale install.
 

--- a/integrations/gemini-cli/README.md
+++ b/integrations/gemini-cli/README.md
@@ -1,17 +1,30 @@
-# Gemini CLI integration
+# Gemini CLI + MemoryWhale
 
-Google's [Gemini CLI](https://github.com/google-gemini/gemini-cli) is a terminal
-AI agent that connects to MCP servers — so it gets MemoryWhale's four tools:
-`recent_errors`, `search_memory`, `get_context`, `remember`. It's a
-terminal/dev-loop agent, the same world MemoryWhale's memory is about.
+Google's [Gemini CLI](https://github.com/google-gemini/gemini-cli) connects to
+MCP servers, so it can use MemoryWhale's six local memory tools.
 
-## Connect the MCP server
+## Status
+
+Verified against Gemini CLI's
+[MCP setup tutorial](https://geminicli.com/docs/cli/tutorials/mcp-setup/)
+and the project's
+[MCP server docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)
+on 2026-08-29. Servers go in `mcpServers` inside `~/.gemini/settings.json` or
+`.gemini/settings.json`. Stdio servers use `command`. `/mcp list` shows
+connection status.
+
+## Requirements
+
+- MemoryWhale installed with `mw-mcp` on `PATH`.
+- Gemini CLI installed.
+
+## Setup
 
 Add the `memorywhale` entry from [`settings.json`](settings.json) to your Gemini
 CLI settings:
 
-- **Every project:** `~/.gemini/settings.json`
-- **This project only:** `.gemini/settings.json` in the project root
+- Every project: `~/.gemini/settings.json`
+- This project only: `.gemini/settings.json` in the project root
 
 ```json
 {
@@ -28,20 +41,53 @@ other servers rather than replacing it. `mw-mcp` must be on `PATH` (the standard
 MemoryWhale install); otherwise use its absolute path as `command`. For a
 non-default database add `"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`.
 
-Verify inside Gemini CLI with the `/mcp` command — `memorywhale` should list its
-four tools.
+### Memory-use guidance
 
-## Tell it when to reach for the memory
-
-The MCP server gives Gemini CLI the *tools*; a `GEMINI.md` instruction (in your
-project or `~/.gemini/`) teaches it *when*:
+A `GEMINI.md` instruction (in your project or `~/.gemini/`) teaches the CLI
+when to use the tools:
 
 > When a build/test/deploy fails, before proposing a fix, use `search_memory`
 > or `recent_errors` (MemoryWhale MCP) to check whether this failure has a known
 > cause or a saved lesson. Once you've figured out why something failed or how a
 > fix worked, use `remember` to save that conclusion.
 
-## Without the MCP server
+## Verify
 
-The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+```bash
+command -v mw-mcp
+```
+
+Restart Gemini CLI and run `/mcp list`. `memorywhale` should show as connected
+with the six tools: `recent_errors`, `search_memory`, `get_context`,
+`remember`, `similar_failures`, and `stats`.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, via `GEMINI.md` |
+
+MCP access is not automatic execution capture. Without the MCP server, the
+`mw` CLI still works: `mw context --last-error`, `mw search "…"`,
 `mw remember "…"`.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+
+## Troubleshooting
+
+- Run `command -v mw-mcp` from the environment that launches Gemini CLI.
+- Confirm `mcpServers` is valid JSON and restart the CLI.
+- If `/mcp list` shows Disconnected, the binary is missing from `PATH`.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in `env`.
+- Run `mw doctor` to check the MemoryWhale install.
+
+## Uninstall
+
+Delete the `memorywhale` entry from `mcpServers` in
+`~/.gemini/settings.json` and/or `.gemini/settings.json`. Remove any
+`GEMINI.md` instruction you added. Restart Gemini CLI. This does not delete
+the MemoryWhale database.

--- a/integrations/generic-mcp/README.md
+++ b/integrations/generic-mcp/README.md
@@ -1,23 +1,16 @@
-# Generic stdio MCP integration
+# Generic stdio MCP + MemoryWhale
 
 ## Status
 
 Supported interface contract for any MCP client that can launch a local stdio
-server.
+server. Tool names and transport checks follow the
+[MCP reference](../../docs/reference/mcp.md).
 
 ## Requirements
 
 - MemoryWhale installed.
 - `mw-mcp` available on the `PATH` seen by the client.
 - A client that supports local stdio MCP servers.
-
-## Capabilities
-
-| Capability | Available |
-| --- | --- |
-| MCP memory read/write | Yes |
-| Automatic execution capture | No |
-| Memory-use guidance | Client-specific |
 
 ## Setup
 
@@ -49,16 +42,20 @@ See the [protocol compatibility reference](../../docs/reference/mcp.md#protocol-
 Then verify tool discovery in the client. The authoritative tool descriptions
 are in the [MCP reference](../../docs/reference/mcp.md).
 
-## How to use
+## Available capabilities
 
-Ask the client:
-
-> Use MemoryWhale to check whether I have encountered a similar failure before.
-
-## Automatic capture
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Client-specific |
 
 The generic MCP connection does not record normal terminal or agent commands.
 Use MemoryWhale's terminal capture or a verified client-specific hook.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I have encountered a similar failure before.
 
 ## Troubleshooting
 
@@ -67,7 +64,7 @@ Use MemoryWhale's terminal capture or a verified client-specific hook.
 - If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in the server entry.
 - Run `mw doctor` to verify the local installation.
 
-## Remove integration
+## Uninstall
 
 Delete the `memorywhale` server entry from the client's MCP configuration and
 restart the client. This does not delete the local MemoryWhale database.

--- a/integrations/goose/README.md
+++ b/integrations/goose/README.md
@@ -1,17 +1,31 @@
-# Goose integration
+# Goose + MemoryWhale
 
-[Goose](https://github.com/block/goose) is Block's on-machine AI agent (CLI +
-desktop). It calls MCP servers "extensions", so it gets MemoryWhale's four
-tools: `recent_errors`, `search_memory`, `get_context`, `remember`. Goose is a
-terminal/dev-loop agent — the same world MemoryWhale's memory is about.
+[Goose](https://github.com/block/goose) calls MCP servers "extensions", so it
+can use MemoryWhale's six local memory tools.
 
-## Connect the MCP server (recommended: the wizard)
+## Status
+
+Verified against Goose's
+[Using extensions](https://goose-docs.ai/docs/getting-started/using-extensions)
+and [configuration files](https://goose-docs.ai/docs/guides/config-files)
+documentation on 2026-08-29. Desktop setup is Add custom extension (Standard
+IO). File setup is `~/.config/goose/config.yaml` under `extensions:`, with
+`type: stdio` and `cmd`.
+
+## Requirements
+
+- MemoryWhale installed with `mw-mcp` on `PATH`.
+- Goose CLI or desktop.
+
+## Setup
+
+### Wizard (recommended)
 
 ```bash
 goose configure
 ```
 
-Choose **Add Extension → Command-line Extension**, then:
+Choose Add Extension → Command-line Extension, then:
 
 | Prompt | Value |
 | --- | --- |
@@ -19,10 +33,9 @@ Choose **Add Extension → Command-line Extension**, then:
 | Command | `mw-mcp` |
 | Timeout | `300` (default) |
 
-The wizard writes the entry for you (no hand-editing). In the desktop app the
-same lives under **Settings → Extensions → Add**.
+In the desktop app the same lives under Settings → Extensions → Add.
 
-## Or edit the config directly
+### Config file
 
 Add this under `extensions:` in `~/.config/goose/config.yaml`
 ([`config.yaml`](config.yaml)):
@@ -45,17 +58,53 @@ extensions:
 absolute path as `cmd`. For a non-default database, add
 `MEMORYWHALE_DATA_DIR` to `envs` (e.g. `envs: { MEMORYWHALE_DATA_DIR: "/path/to/dir" }`).
 
-## Tell it when to reach for the memory
+### Memory-use guidance
 
-The extension gives Goose the *tools*; a hint in your `.goosehints` (or the
-session's system prompt) teaches it *when*:
+A hint in `.goosehints` (or the session system prompt) teaches Goose when to
+use the tools:
 
 > When a build/test/deploy fails, before proposing a fix, use `search_memory`
 > or `recent_errors` (MemoryWhale MCP) to check whether this failure has a known
 > cause or a saved lesson. Once you've figured out why something failed or how a
 > fix worked, use `remember` to save that conclusion.
 
-## Without the MCP server
+## Verify
 
-The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+```bash
+command -v mw-mcp
+```
+
+Start a Goose session and confirm the `memorywhale` extension is enabled with
+the six tools: `recent_errors`, `search_memory`, `get_context`, `remember`,
+`similar_failures`, and `stats`.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, optional `.goosehints` |
+
+MCP access is not automatic execution capture. Without the MCP server, the
+`mw` CLI still works: `mw context --last-error`, `mw search "…"`,
 `mw remember "…"`.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+
+## Troubleshooting
+
+- Run `command -v mw-mcp` from the environment that launches Goose.
+- Confirm `type: stdio` and `cmd: mw-mcp` (Goose uses `cmd`, not `command`).
+- Restart Goose after editing `config.yaml`.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in `envs`.
+- Run `mw doctor` to check the MemoryWhale install.
+
+## Uninstall
+
+Disable or delete the `memorywhale` extension in `goose configure` / the
+desktop Extensions UI, or remove the `memorywhale:` block from
+`~/.config/goose/config.yaml`. Remove any `.goosehints` line you added. This
+does not delete the MemoryWhale database.

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,10 +1,16 @@
-# Hermes Agent integration
+# Hermes Agent + MemoryWhale
 
 [Hermes Agent](https://github.com/NousResearch/hermes-agent) can run local
 stdio MCP servers. Hermes remains the agent runtime; `mw-mcp` contributes
 MemoryWhale's persistent developer-memory tools.
 
-## Prerequisites
+## Status
+
+Hermes Agent can run local stdio MCP servers. MemoryWhale connects as `mw-mcp`.
+Hermes MCP configuration details are maintained in the
+[official Hermes documentation](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/mcp.md).
+
+## Requirements
 
 Install both `hermes` and MemoryWhale, then confirm the MCP binary is on
 `PATH`:
@@ -17,7 +23,7 @@ command -v mw-mcp
 If `mw-mcp` is not on `PATH`, use its absolute path in the command below or in
 the configuration file.
 
-## Connect MemoryWhale
+## Setup
 
 The MemoryWhale CLI can update Hermes' configuration safely while preserving
 existing settings and MCP servers:
@@ -73,7 +79,7 @@ without being told the internal name. The six MemoryWhale tools are:
 - `similar_failures`
 - `stats`
 
-## Verify the integration
+## Verify
 
 Ask Hermes:
 
@@ -87,7 +93,18 @@ directly with the current protocol revision:
 printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}' | mw-mcp
 ```
 
-## Using Kimi K3 through Hermes
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Example prompt |
+
+MCP access is not automatic capture. The six tools above read and write the
+local MemoryWhale store when Hermes calls them.
+
+### Using Kimi K3 through Hermes
 
 Kimi K3 is a model, not an MCP client. If the Hermes model provider you use
 offers Kimi K3, select it through Hermes' model configuration and keep the
@@ -117,6 +134,11 @@ The exact Kimi model identifier and credentials depend on the provider. Do not
 configure the model process itself to launch `mw-mcp`; Hermes owns that
 connection.
 
+## Example prompt
+
+> Use MemoryWhale to check whether I have encountered a similar build failure
+> before.
+
 ## Troubleshooting
 
 - If no tools appear, restart Hermes after adding the server and confirm
@@ -130,3 +152,10 @@ connection.
 
 Hermes MCP configuration details are maintained in the
 [official Hermes documentation](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/mcp.md).
+
+## Uninstall
+
+Delete the `memorywhale` entry from `~/.hermes/config.yaml` (or `$HERMES_HOME`)
+and restart Hermes. If `mcp_servers` has other servers, remove only
+`memorywhale`. This does not delete MemoryWhale's database or any captured
+records.

--- a/integrations/jan/README.md
+++ b/integrations/jan/README.md
@@ -19,14 +19,6 @@ desktop UI details may change.
 - Optional: a deliberate `MEMORYWHALE_DATA_DIR` value if Jan should use a
   non-default store.
 
-## Capabilities
-
-| Capability | Available |
-| --- | --- |
-| MCP memory access | Yes |
-| Automatic execution capture | No |
-| Memory-use guidance | No built-in Jan-specific guidance; use the example prompt below |
-
 ## Setup
 
 1. Confirm that the server works in the same environment Jan will use:
@@ -78,13 +70,21 @@ If Jan shows the server but does not call tools, select a model with tool-callin
 support and check Jan's MCP permissions. An empty MemoryWhale store is valid;
 `stats` should report zero records rather than a connection failure.
 
-## How to use
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | No built-in Jan-specific guidance; use the example prompt below |
+
+### How to use
 
 Use retrieval when a build, test, or deployment failure may have happened
 before. Once the cause or fix is confirmed, use `remember` to save the lesson so
 future sessions can find it.
 
-## Automatic capture
+### Automatic capture
 
 Jan's MCP connection does not automatically record Jan prompts, responses, or
 shell commands. MCP provides access to MemoryWhale's local memory and an
@@ -95,7 +95,7 @@ capture or an explicit wrapper such as:
 mw-run -- cargo test
 ```
 
-## Security and limitations
+### Security and limitations
 
 - `mw-mcp` is a local stdio process. Jan and the selected model can access the
   MemoryWhale store through its tools, so only connect stores you intend Jan to
@@ -108,6 +108,11 @@ mw-run -- cargo test
 - Read the canonical [local stdio trust model](../../docs/reference/mcp.md#trust-model)
   before connecting a sensitive store.
 
+## Example prompt
+
+> Use MemoryWhale to check whether I have seen this failure before. Search for
+> `openssl` and explain which saved evidence is relevant before suggesting a fix.
+
 ## Troubleshooting
 
 - Run `command -v mw-mcp` from the environment used to launch Jan.
@@ -118,7 +123,7 @@ mw-run -- cargo test
 - Run `mw doctor` and the direct JSON-RPC discovery command above.
 - Check that the model has tool calling enabled in Jan's model capabilities.
 
-## Remove integration
+## Uninstall
 
 Remove the `memorywhale` entry from **Settings → MCP Servers** and restart Jan.
 Removing the entry does not delete the MemoryWhale database or its captured

--- a/integrations/neovim/README.md
+++ b/integrations/neovim/README.md
@@ -1,9 +1,20 @@
-# Neovim plugin
+# Neovim + MemoryWhale
 
-`memorywhale.lua` brings MemoryWhale into the editor — four commands, no
-plugin manager required.
+`memorywhale.lua` brings MemoryWhale into the editor with four commands. It
+calls the `mw` CLI. It is not an MCP client.
 
-## Install
+## Status
+
+This plugin is the Lua module in this repository. There is no third-party
+Neovim MCP adapter documented here. Commands require `mw` on `$PATH`.
+
+## Requirements
+
+- MemoryWhale installed with `mw` on `$PATH`.
+- Neovim with Lua `init.lua`.
+- A checkout of this repository to copy `memorywhale.lua`.
+
+## Setup
 
 ```bash
 mkdir -p ~/.config/nvim/lua
@@ -20,26 +31,61 @@ vim.keymap.set("n", "<leader>mg", ":MwGitFix<CR>", { desc = "MemoryWhale: diagno
 vim.keymap.set("v", "<leader>mr", ":MwRemember<CR>", { desc = "MemoryWhale: remember selection" })
 ```
 
-## Commands
+`mw-git-fix.lua` (the earlier single-command module) still works, but
+`memorywhale.lua` includes `:MwGitFix` and supersedes it. Install one, not
+both.
+
+## Verify
+
+```bash
+command -v mw
+mw doctor
+```
+
+In Neovim, run `:MwSearch test` or `:MwAsk`. Each command reports clearly if
+`mw` is not found. `:MwAsk`, `:MwGitFix`, and `:MwSearch` open in a terminal
+split; `:MwRemember` runs inline and notifies the result.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | No; uses the CLI directly |
+| Automatic execution capture | No |
+| Memory-use guidance | Commands only |
 
 ```
 :MwAsk [question]      package the last failure (exact error + similar past
-                       failures + saved lessons) into a debugging prompt —
-                       clipboard filled, chatgpt.com opened; you paste.
+                       failures + saved lessons) into a debugging prompt.
+                       Clipboard filled, chatgpt.com opened; you paste.
 :MwGitFix [id]         diagnose the last failed git command (push rejected,
                        merge conflict, …) with the fix and your history.
 :MwSearch {text}       full-text search commands, output, notes, transcripts.
 :MwRemember {text}     save a lesson. With a visual selection and no args,
-                       remembers the selected lines — select an error or a
+                       remembers the selected lines. Select an error or a
                        fix in any buffer and save it in one keystroke.
 ```
 
-`:MwAsk`, `:MwGitFix`, and `:MwSearch` open in a terminal split; `:MwRemember`
-runs inline and notifies the result.
+The plugin does not register `mw-mcp` and does not record Neovim terminal jobs
+automatically.
 
-Requires `mw` on `$PATH` (the standard MemoryWhale install). Every command
-reports clearly if it isn't found.
+## Example prompt
 
-> `mw-git-fix.lua` (the earlier single-command module) still works, but
-> `memorywhale.lua` includes `:MwGitFix` and supersedes it — install one, not
-> both.
+Not applicable. Neovim is not an agent host here. Use `:MwAsk` to package the
+last failure for an external chat, or `:MwSearch` / `:MwRemember` in the
+editor.
+
+## Troubleshooting
+
+- Run `command -v mw` from the same environment as Neovim. GUI Neovim often
+  has a shorter `PATH` than your shell; fix that or wrap `mw` with an absolute
+  path in your own config.
+- Confirm `require("memorywhale").setup()` runs from `init.lua`.
+- Run `mw doctor` if search or remember return empty or missing-database
+  errors.
+
+## Uninstall
+
+Remove `require("memorywhale").setup()` and any keymaps from `init.lua`, then
+delete `~/.config/nvim/lua/memorywhale.lua`. This does not delete the
+MemoryWhale database.

--- a/integrations/neovim/README.md
+++ b/integrations/neovim/README.md
@@ -54,7 +54,7 @@ split; `:MwRemember` runs inline and notifies the result.
 | Automatic execution capture | No |
 | Memory-use guidance | Commands only |
 
-```
+```text
 :MwAsk [question]      package the last failure (exact error + similar past
                        failures + saved lessons) into a debugging prompt.
                        Clipboard filled, chatgpt.com opened; you paste.

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,19 +1,33 @@
-# OpenClaw integration
+# OpenClaw + MemoryWhale
 
 [OpenClaw](https://github.com/openclaw/openclaw) agents connect to MCP servers,
-so they get MemoryWhale's four tools: `recent_errors`, `search_memory`,
-`get_context`, `remember`.
+so they can use MemoryWhale's six local memory tools.
 
-## Connect the MCP server
+## Status
 
-`mw-mcp` is a Model Context Protocol server over stdio. Register it with the CLI:
+Verified against OpenClaw's
+[MCP tools](https://github.com/openclaw/openclaw/blob/main/docs/tools/mcp.md)
+documentation on 2026-08-29. Stdio servers are added with
+`openclaw mcp add … --command`. Saving a definition is not enough;
+`openclaw mcp doctor <name> --probe` checks reachability. Config lives under
+`mcp.servers` in `~/.openclaw/openclaw.json` (JSON5).
+
+## Requirements
+
+- MemoryWhale installed with `mw-mcp` on `PATH`.
+- OpenClaw CLI (and a running Gateway if you expect a live agent to pick up
+  the server).
+
+## Setup
+
+Register the server with the CLI:
 
 ```bash
 openclaw mcp add memorywhale --command mw-mcp
 openclaw mcp doctor memorywhale --probe
 ```
 
-The probe matters — saving a definition proves nothing about reachability.
+The probe matters. Saving a definition proves nothing about reachability.
 
 Or write it straight into config. Merge the block from
 [`openclaw.mcp.json5`](openclaw.mcp.json5) into `~/.openclaw/openclaw.json`
@@ -34,19 +48,61 @@ absolute path as `command`. For a non-default database add
 `env: { MEMORYWHALE_DATA_DIR: "/path/to/dir" }`. A running Gateway may need a
 restart or runtime reload before it picks up a config-file change.
 
-## Tell it when to reach for the memory
+You can also add a stdio server from Control UI Settings → MCP → Add server.
 
-The MCP server gives OpenClaw the *tools*; a workspace instruction teaches it
-*when* to reach for them. OpenClaw agents read an `AGENTS.md` from their
-workspace (default `~/.openclaw/workspace/AGENTS.md`). Add:
+### Memory-use guidance
+
+OpenClaw agents read an `AGENTS.md` from their workspace (default
+`~/.openclaw/workspace/AGENTS.md`). Add:
 
 > When a build/test/deploy fails, before proposing a fix, use `search_memory`
 > or `recent_errors` (MemoryWhale MCP) to check whether this failure has a known
 > cause or a saved lesson. Once you've figured out why something failed or how a
 > fix worked, use `remember` to save that conclusion.
 
-## Without the MCP server
+## Verify
 
-The `mw` CLI still works: `mw context --last-error`, `mw search "…"`,
-`mw remember "…"`. And with no integration at all, `mw ask` packages the last
+```bash
+command -v mw-mcp
+openclaw mcp doctor memorywhale --probe
+```
+
+The probe should show the six tools: `recent_errors`, `search_memory`,
+`get_context`, `remember`, `similar_failures`, and `stats`.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, via workspace `AGENTS.md` |
+
+MCP access is not automatic execution capture. Without the MCP server, the
+`mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+`mw remember "…"`. With no integration at all, `mw ask` packages the last
 failure onto your clipboard for any chat.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+
+## Troubleshooting
+
+- Run `command -v mw-mcp` from the environment that launches OpenClaw.
+- If `mcp add` succeeded but tools are missing, run
+  `openclaw mcp doctor memorywhale --probe` and restart the Gateway.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in the server `env`.
+- Run `mw doctor` to check the MemoryWhale install.
+
+## Uninstall
+
+Remove the server from Control UI Settings → MCP, or:
+
+```bash
+openclaw mcp unset memorywhale
+```
+
+Delete the `memorywhale` key from `mcp.servers` if you added it by hand.
+Remove any `AGENTS.md` instruction you added. This does not delete the
+MemoryWhale database.

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -19,14 +19,6 @@ versions; check those pages if a field is rejected.
 - A model that supports tool calling (MCP tools are ordinary tools from the
   model's perspective).
 
-## Capabilities
-
-| Capability | Available |
-| --- | --- |
-| MCP memory access | Yes |
-| Automatic execution capture | No |
-| Memory-use guidance | Example prompt (OpenCode rules can carry standing instructions) |
-
 ## Setup
 
 OpenCode reads a merged JSON config from `~/.config/opencode/opencode.json`
@@ -50,7 +42,7 @@ Add MemoryWhale as a local stdio server:
 
 Notes, from OpenCode's documented local-server options:
 
-- `command` is an **array** — the command and its arguments as one list. If
+- `command` is an **array**, the command and its arguments as one list. If
   `mw-mcp` is not on the `PATH` OpenCode sees, use its absolute path:
   `"command": ["/usr/local/bin/mw-mcp"]`.
 - To use a non-default MemoryWhale store, set the environment under
@@ -72,7 +64,7 @@ Notes, from OpenCode's documented local-server options:
 
 - `"enabled": false` disables a server without removing it.
 - If other MCP servers are already configured, add the `"memorywhale"` key
-  alongside them — do not replace the existing entries.
+  alongside them. Do not replace the existing entries.
 
 ## Verify
 
@@ -101,26 +93,34 @@ MemoryWhale tools appear as:
 - `similar_failures`
 - `stats`
 
-An empty store is valid — the tools return empty results, not errors. `stats`
+An empty store is valid. The tools return empty results, not errors. `stats`
 on a fresh store reports zero records.
 
-## OpenCode Go
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Example prompt (OpenCode rules can carry standing instructions) |
+
+### OpenCode Go
 
 OpenCode Go is a low-cost model subscription inside OpenCode, not a separate
 client. It changes which models are available; it does not change MCP
 configuration. The setup above works the same whether the selected model comes
 from OpenCode Go (GLM, Kimi, DeepSeek, …), any other provider, or a local
-server — as long as the model supports tool calling.
+server, as long as the model supports tool calling.
 
-## Automatic capture
+### Automatic capture
 
 MCP access is not automatic execution capture. Commands OpenCode runs are
-recorded by MemoryWhale only through the normal capture paths — `mw-run --`,
+recorded by MemoryWhale only through the normal capture paths: `mw-run --`,
 `mw-remember`, `mw --notes "project:…"` session recording, or an installed
 shell hook. MCP lets the agent read memory and save lessons via `remember`
 when asked.
 
-## Limitations
+### Limitations
 
 - MCP tools consume model context; OpenCode's docs warn that many servers can
   exhaust the context window. MemoryWhale's six tools are small, but avoid
@@ -129,13 +129,19 @@ when asked.
 - Secret redaction on capture reduces accidental retention but is not a
   security boundary.
 
-## Security
+### Security
 
 `mw-mcp` is a local stdio process with full read/write access to the connected
 MemoryWhale database. Review the canonical
 [local stdio trust model](../../docs/reference/mcp.md#trust-model) before
 connecting a store that contains sensitive output. `MEMORYWHALE_DATA_DIR`
 selects a store; it is not an access-control mechanism.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I have encountered a similar build failure
+> before. Search for `openssl` and explain which saved evidence is relevant
+> before suggesting a fix.
 
 ## Troubleshooting
 
@@ -147,7 +153,7 @@ selects a store; it is not an access-control mechanism.
   or comment in strict tooling can break parsing.
 - Run `mw doctor` to verify the MemoryWhale data directory and database.
 
-## Remove integration
+## Uninstall
 
 Delete the `"memorywhale"` entry from `"mcp"` in `opencode.json` (global or
 project) and restart OpenCode. This does not delete the MemoryWhale database;

--- a/integrations/openrouter/README.md
+++ b/integrations/openrouter/README.md
@@ -3,10 +3,10 @@
 [OpenRouter](https://openrouter.ai) is a hosted API gateway that exposes
 hundreds of models from many providers behind a single OpenAI-compatible API
 and one key. `stealth/ox-alpha` is one such model slug. OpenAI-compatible
-clients can select any catalog model directly; Claude Code is the exception —
+clients can select any catalog model directly; Claude Code is the exception.
 OpenRouter guarantees it only with Anthropic's first-party providers, so other
 models there are best-effort. (Some clients qualify slugs with a provider
-prefix — for example OpenCode's `openrouter/stealth/ox-alpha` — but the API
+prefix, for example OpenCode's `openrouter/stealth/ox-alpha`, but the API
 model id itself is `stealth/ox-alpha`.)
 
 OpenRouter is a **model gateway**, not an MCP client for MemoryWhale. It does
@@ -32,8 +32,8 @@ Verified against OpenRouter's public documentation in August 2026:
   its own (model catalog, documentation search, test inference), but it
   provides no access to MemoryWhale.
 
-Model availability, pricing, and context limits for any slug — including
-`stealth/ox-alpha` — belong to the model's page on openrouter.ai and change
+Model availability, pricing, and context limits for any slug, including
+`stealth/ox-alpha`, belong to the model's page on openrouter.ai and change
 independently of MemoryWhale.
 
 ## Requirements
@@ -46,15 +46,6 @@ independently of MemoryWhale.
   base URL or the Anthropic environment variables shown below;
 - `jq` for the verification step below (not installed by default on macOS;
   `brew install jq`).
-
-## Capabilities
-
-| Capability | Available |
-| --- | --- |
-| MCP memory access | No — OpenRouter is not an MCP client for `mw-mcp`; compose through an agent |
-| Automatic execution capture | No — comes from the agent's hooks, not the gateway |
-| Memory-use guidance | No — configure guidance in the agent, not the gateway |
-| Multi-provider model access | Yes — one key, many models |
 
 ## Setup
 
@@ -81,19 +72,19 @@ best-effort basis through this endpoint.
 
 **OpenAI-compatible agents** (Continue, OpenCode, Codex CLI, …): set the base
 URL to `https://openrouter.ai/api/v1`, use the key as the API key, and select
-the model by its OpenRouter slug — for example `stealth/ox-alpha`. In clients
+the model by its OpenRouter slug, for example `stealth/ox-alpha`. In clients
 whose provider syntax requires a prefix, qualify it (OpenCode:
 `openrouter/stealth/ox-alpha`). The exact setting name depends on the agent
 (Continue uses `apiBase` on the model entry; OpenCode uses
 `provider.<id>.options.baseURL`; Codex CLI defines a custom provider in
-`~/.codex/config.toml` — a `[model_providers.openrouter]` block with
-`base_url = "https://openrouter.ai/api/v1"` and an `env_key` — selected via
+`~/.codex/config.toml`: a `[model_providers.openrouter]` block with
+`base_url = "https://openrouter.ai/api/v1"` and an `env_key`, selected via
 `model_provider` and `model`. Omit `wire_api`: current Codex CLI defaults to
 the Responses protocol, which is what OpenRouter's Codex endpoint speaks.)
 
 ### 3. Keep `mw-mcp` configured in the same agent
 
-This step is unchanged from the agent's normal MemoryWhale setup — the gateway
+This step is unchanged from the agent's normal MemoryWhale setup. The gateway
 does not replace it. For example, in Claude Code:
 
 ```bash
@@ -130,7 +121,16 @@ If model calls fail but the MemoryWhale checks pass, the problem is on the
 OpenRouter side (key, credits, or model slug). If model calls work but memory
 tools are missing in the agent, re-check its MCP configuration.
 
-## How to use
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | No, OpenRouter is not an MCP client for `mw-mcp`; compose through an agent |
+| Automatic execution capture | No, comes from the agent's hooks, not the gateway |
+| Memory-use guidance | No, configure guidance in the agent, not the gateway |
+| Multi-provider model access | Yes, one key, many models |
+
+### How to use
 
 Use this stack when you want:
 
@@ -139,23 +139,16 @@ Use this stack when you want:
   accounts;
 - your existing agent's MemoryWhale memory to keep working unchanged.
 
-Use direct provider keys instead when you only need one provider — the gateway
+Use direct provider keys instead when you only need one provider. The gateway
 adds a hop and a data processor without benefit in that case.
 
-## Example prompt
-
-No prompt changes are needed; memory behavior lives in the agent's
-configuration, not the gateway. A normal memory-aware prompt still works:
-
-> Use MemoryWhale to check whether I encountered a similar failure before.
-
-## Automatic capture
+### Automatic capture
 
 Automatic capture comes from the agent's hooks (for example, Claude Code's
 `PostToolUse` hook), not from OpenRouter. The gateway only sees model requests
 and cannot record terminal commands or sessions.
 
-## Limitations
+### Limitations
 
 - OpenRouter does not provide MCP memory access. Its own MCP server serves
   OpenRouter's catalog and documentation; claims of direct
@@ -171,6 +164,13 @@ and cannot record terminal commands or sessions.
 - Routing quality (tool use, long context) varies by upstream provider for the
   same slug; OpenRouter's own docs recommend pinning providers where tool-use
   reliability matters.
+
+## Example prompt
+
+No prompt changes are needed; memory behavior lives in the agent's
+configuration, not the gateway. A normal memory-aware prompt still works:
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
 
 ## Troubleshooting
 
@@ -188,7 +188,7 @@ and cannot record terminal commands or sessions.
 - **Memory tools missing:** an agent MCP configuration issue, not a gateway
   issue. Run `mw doctor` and re-check the agent's `mw-mcp` registration.
 
-## Remove integration
+## Uninstall
 
 Stop exporting the OpenRouter variables (and remove any persisted provider
 entries you added in the agent's config, restoring the direct-provider

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -19,15 +19,7 @@ software and review them before installing.
 - A shell environment where Pi and MemoryWhale use the intended
   `MEMORYWHALE_DATA_DIR`, if a non-default store is needed.
 
-## Capabilities
-
-| Capability | Available |
-| --- | --- |
-| MCP memory access | Unverified; no native Pi MCP setup is documented here |
-| Automatic execution capture | No |
-| Memory-use guidance | Yes, through a Pi project instruction or extension |
-
-## Setup: use the CLI today
+## Setup
 
 MemoryWhale can be used with Pi without a Pi-specific plugin. Capture a command
 explicitly, then give Pi the retrieved context:
@@ -45,7 +37,7 @@ For a different store, set the variable in the same shell environment:
 MEMORYWHALE_DATA_DIR=/path/to/store mw context --last-error
 ```
 
-## Optional Pi guidance
+### Optional Pi guidance
 
 Pi supports project-local extensions and other project resources. Add a short
 instruction to the project guidance you already use, or create a trusted Pi
@@ -72,20 +64,32 @@ An empty store may return an empty context. That is expected. If you later add
 an MCP adapter, verify its tool discovery separately and use the canonical
 [MCP reference](../../docs/reference/mcp.md) for the six MemoryWhale tools.
 
-## Automatic capture
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Unverified; no native Pi MCP setup is documented here |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, through a Pi project instruction or extension |
+
+### Automatic capture
 
 This integration does not automatically record Pi prompts, responses, or shell
 commands. `mw-run` captures an explicitly wrapped command; normal terminal
 capture and supported hooks remain separate. MCP access, if added through a
 third-party adapter, would provide memory access rather than automatic capture.
 
-## Limitations
+### Limitations
 
 - There is no verified native Pi-to-`mw-mcp` configuration in this repository.
 - The CLI workflow requires copying or piping context into Pi.
 - Pi project extensions execute with broad local permissions; only install
   extensions you trust.
 - MemoryWhale does not silently synchronize the local database.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
 
 ## Troubleshooting
 
@@ -94,7 +98,7 @@ third-party adapter, would provide memory access rather than automatic capture.
 - Set `MEMORYWHALE_DATA_DIR` explicitly when selecting a non-default store.
 - Run `mw doctor` before debugging a missing or empty store.
 
-## Remove integration
+## Uninstall
 
 Remove any Pi-specific instruction or extension you added. This does not delete
 the MemoryWhale database; use the documented `mw rm` or retention commands for

--- a/integrations/pullfrog/README.md
+++ b/integrations/pullfrog/README.md
@@ -33,15 +33,6 @@ Official references:
 - A ChatGPT/Codex subscription or another provider configured in Pullfrog.
 - A deliberate review-only policy if Pullfrog must not push commits.
 
-## Capabilities
-
-| Capability | Available |
-| --- | --- |
-| MCP memory access | No — external `mw-mcp` attachment is not documented or verified |
-| Automatic execution capture | No |
-| Memory-use guidance | No verified MemoryWhale-specific guidance |
-| PR review automation | Yes, when enabled in the Pullfrog console |
-
 ## Setup
 
 ### 1. Install the GitHub App
@@ -163,7 +154,16 @@ For review automation, open a test PR and verify in GitHub that Pullfrog adds a
 review or a Pullfrog status/check. A manual `@pullfrog` comment is a separate
 interactive trigger and does not prove that automatic review-on-PR is enabled.
 
-## How to use
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | No, external `mw-mcp` attachment is not documented or verified |
+| Automatic execution capture | No |
+| Memory-use guidance | No verified MemoryWhale-specific guidance |
+| PR review automation | Yes, when enabled in the Pullfrog console |
+
+### How to use
 
 Use Pullfrog for GitHub-native work:
 
@@ -181,17 +181,7 @@ mw search "linker error"
 mw remember "the linker failed because ..."
 ```
 
-## Example prompt
-
-For a review-only Pullfrog run, configure review instructions such as:
-
-> Review this pull request for correctness, security, data-integrity, and test
-> coverage. Comment with actionable findings only. Do not modify files, push
-> commits, open branches, or implement fixes.
-
-This prompt does not grant Pullfrog access to MemoryWhale's local database.
-
-## Pullfrog event archive
+### Pullfrog event archive
 
 The repository also contains `.github/workflows/pullfrog-memory.yml`. After a
 workflow named `Pullfrog` completes, it records an allowlisted metadata summary
@@ -231,7 +221,7 @@ the developer's local SQLite database, and each artifact has a 14-day retention
 period. Review GitHub artifact access and retention policies before treating the
 archive as long-term history.
 
-## Automatic capture
+### Automatic capture
 
 Pullfrog does not automatically capture local MemoryWhale terminal sessions.
 Its GitHub Actions runs can inspect the repository, pull requests, and CI
@@ -239,7 +229,7 @@ through Pullfrog's built-in tools, but those tools are not the six MemoryWhale
 MCP tools and do not provide access to the developer's local
 `memorywhale.sqlite3`.
 
-## MemoryWhale MCP integration status
+### MemoryWhale MCP integration status
 
 Pullfrog's public tools documentation describes its built-in GitHub and CI MCP
 tools. It does not document a configuration field for arbitrary external MCP
@@ -253,7 +243,7 @@ Do not add an invented `mcpServers`, `MCP_SERVERS`, or similar setting to a
 Pullfrog workflow. A future supported custom-MCP feature could make this a thin
 integration; update this guide only after verifying the official configuration.
 
-## Limitations and privacy
+### Limitations and privacy
 
 - Pullfrog runs through GitHub and the selected model provider. Code, diffs,
   issue text, and review context may leave the local machine according to
@@ -267,6 +257,16 @@ integration; update this guide only after verifying the official configuration.
 - Review-only configuration is a policy setting, not a technical guarantee
   against every possible workflow or manually triggered action; keep workflow
   permissions least-privilege.
+
+## Example prompt
+
+For a review-only Pullfrog run, configure review instructions such as:
+
+> Review this pull request for correctness, security, data-integrity, and test
+> coverage. Comment with actionable findings only. Do not modify files, push
+> commits, open branches, or implement fixes.
+
+This prompt does not grant Pullfrog access to MemoryWhale's local database.
 
 ## Troubleshooting
 
@@ -283,7 +283,7 @@ integration; update this guide only after verifying the official configuration.
 - Pullfrog review status and MemoryWhale MCP status are independent; a healthy
   Pullfrog review does not prove `mw-mcp` is connected.
 
-## Remove integration
+## Uninstall
 
 Disable review automations in the Pullfrog console, then uninstall the Pullfrog
 GitHub App or remove `wuisabel-gif/MemWhale` from its repository access list.

--- a/integrations/rho/README.md
+++ b/integrations/rho/README.md
@@ -23,14 +23,6 @@ The hook and skill are optional repository-provided components.
 - A local checkout of this repository to copy the skill (only for manual
   setup; `mw integrate rho` needs no checkout).
 
-## Capabilities
-
-| Capability | Available |
-| --- | --- |
-| MCP memory access | Yes |
-| Automatic execution capture | Yes, optional `after_tool_use` hook for bash and powershell |
-| Memory-use guidance | Yes, optional skill |
-
 ## Setup
 
 From any machine with MemoryWhale installed:
@@ -152,7 +144,15 @@ rho mcp show memorywhale
 In Rho, run `/mcp` and confirm `memorywhale` is listed, and `/skills` for the
 skill. `/hooks` should show `user:memorywhale-record` as active.
 
-## How to use
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | Yes, optional `after_tool_use` hook for bash and powershell |
+| Memory-use guidance | Yes, optional skill |
+
+### How to use
 
 The MCP server lets Rho read prior failures and explicitly save lessons. The
 skill prompts Rho to consult those tools when a failure may have happened
@@ -162,13 +162,7 @@ bash and powershell tool calls when the event payload includes command text.
 The skill falls back to `mw context`, `mw search`, and `mw remember` when the
 MCP server is not connected, so each component can be installed separately.
 
-## Example prompt
-
-> Use MemoryWhale to check whether I encountered a similar failure before.
-> Explain the relevant saved evidence before suggesting a fix, then remember
-> the root cause after it is verified.
-
-## Automatic capture
+### Automatic capture
 
 `mw-remember --from-hook rho` receives Rho's hook JSON on standard input. It
 matches `after_tool_use` for `bash` and `powershell`, then records command
@@ -189,7 +183,7 @@ complete evidence.
 Commands run in an ordinary terminal are captured only through MemoryWhale's
 normal terminal capture paths. MCP access alone is not automatic capture.
 
-## How Rho sessions and MemoryWhale differ
+### How Rho sessions and MemoryWhale differ
 
 Rho keeps its own saved session transcripts in `~/.rho/sessions/` and may
 compact or summarize them. MemoryWhale stores durable evidence in its own
@@ -199,7 +193,7 @@ MemoryWhale data survives Rho restarts and machine transfers. Use `mw agent`
 or `mw context` to bridge a Rho session into MemoryWhale when you want the
 evidence to outlive the current session.
 
-## Limitations
+### Limitations
 
 - The bundled hook captures only bash and powershell.
 - `before_tool_use` is not used, because a crash or timeout there denies the
@@ -209,6 +203,12 @@ evidence to outlive the current session.
 - Guidance helps Rho choose when to use memory, but does not force a tool call
   on every failure.
 - Secret redaction reduces accidental retention but is not a security boundary.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+> Explain the relevant saved evidence before suggesting a fix, then remember
+> the root cause after it is verified.
 
 ## Troubleshooting
 
@@ -228,7 +228,7 @@ evidence to outlive the current session.
 - `RHO_HOME` moves the whole Rho directory, including `hooks.toml`,
   `config.toml`, and `skills/`.
 
-## Remove integration
+## Uninstall
 
 ```bash
 mw integrate rho --revert

--- a/integrations/vscode/README.md
+++ b/integrations/vscode/README.md
@@ -1,13 +1,27 @@
-# VS Code (GitHub Copilot) integration
+# VS Code (GitHub Copilot) + MemoryWhale
 
-Copilot's **agent mode** supports MCP servers, so it can query your MemoryWhale
-memory with the same four tools Claude Code and Cursor get: `recent_errors`,
-`search_memory`, `get_context`, `remember`.
+Copilot's agent mode supports MCP servers, so it can query your MemoryWhale
+store with the six `mw-mcp` tools.
 
-## Connect the MCP server
+## Status
 
-Copy [`mcp.json`](mcp.json) to **`.vscode/mcp.json`** in your workspace (or add
-the same block to your user `settings.json` under `"mcp"`):
+Verified against VS Code's
+[Add and manage MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers)
+and [MCP configuration reference](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration)
+on 2026-08-29. Workspace config is `.vscode/mcp.json` under a `servers` object.
+A `"type": "stdio"` field is documented for local servers.
+
+## Requirements
+
+- MemoryWhale installed with `mw-mcp` on `PATH`.
+- VS Code with GitHub Copilot Chat, using Agent mode.
+- A model that can call tools.
+
+## Setup
+
+Copy [`mcp.json`](mcp.json) to `.vscode/mcp.json` in your workspace (or add
+the same block through **MCP: Open User Configuration** for a user-level
+server):
 
 ```json
 {
@@ -24,20 +38,56 @@ the same block to your user `settings.json` under `"mcp"`):
 absolute path. To point at a non-default database, add
 `"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`.
 
-Open the Copilot Chat view, switch to **Agent** mode, and MemoryWhale's tools
-appear in the tools picker. (VS Code's exact MCP config key has shifted across
-versions — if `"servers"` isn't recognized, check your version's "MCP servers"
-docs; the `command: mw-mcp` part is the same everywhere.)
-
-## Tell it when to reach for the memory
+### Memory-use guidance
 
 Add this to `.github/copilot-instructions.md` (repo-wide) so Copilot uses the
-tools proactively:
+tools when debugging:
 
 > When a build/test/deploy fails, before proposing a fix, call `search_memory`
 > or `recent_errors` to check whether this failure has a known cause or a saved
-> lesson. Once you've figured out *why* something failed or *how* a fix worked,
+> lesson. Once you've figured out why something failed or how a fix worked,
 > call `remember` to save that conclusion for next time.
 
-Without the MCP server, the `mw` CLI still works: `mw context --last-error`,
-`mw search "…"`, `mw remember "…"`.
+## Verify
+
+```bash
+command -v mw-mcp
+```
+
+Open `.vscode/mcp.json` and use the CodeLens Start control on the `memorywhale`
+server if VS Code shows one. Then open Copilot Chat, switch to Agent mode, and
+confirm the six MemoryWhale tools in the tools picker:
+`recent_errors`, `search_memory`, `get_context`, `remember`,
+`similar_failures`, and `stats`.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, via Copilot instructions |
+
+MCP access is not automatic execution capture. Without the MCP server, the
+`mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+`mw remember "…"`.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+
+## Troubleshooting
+
+- Run `command -v mw-mcp` from the same environment VS Code uses. Remote
+  windows need MemoryWhale on the remote, or a workspace MCP config that
+  runs there.
+- Confirm the file uses `"servers"` (VS Code), not `"mcpServers"`.
+- Reload the window after editing `mcp.json`.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in the server `env`.
+- Run `mw doctor` to check the MemoryWhale install.
+
+## Uninstall
+
+Delete the `memorywhale` entry from `.vscode/mcp.json` or the user MCP
+configuration. Remove any Copilot instruction you added. This does not delete
+the MemoryWhale database.

--- a/integrations/windsurf/README.md
+++ b/integrations/windsurf/README.md
@@ -1,13 +1,29 @@
-# Windsurf integration
+# Windsurf + MemoryWhale
 
-Windsurf (Cascade) supports MCP servers, so it gets MemoryWhale's four tools:
-`recent_errors`, `search_memory`, `get_context`, `remember`.
+Windsurf Cascade supports MCP servers, so it can use MemoryWhale's six local
+memory tools.
 
-## Connect the MCP server
+## Status
 
-Merge [`mcp_config.json`](mcp_config.json) into Windsurf's MCP config at
-**`~/.codeium/windsurf/mcp_config.json`** (or use the **Cascade → MCP →
-Configure / "Add Server"** UI, which edits the same file):
+Verified against Windsurf's
+[Cascade MCP](https://docs.windsurf.com/plugins/cascade/mcp) documentation on
+2026-08-29. That page documents editing `mcp_config.json` under
+`~/.codeium/mcp_config.json`, with a `mcpServers` object and a `command` for
+stdio servers. Add servers from Settings → Tools → Windsurf Settings → Add
+Server, or via View Raw Config. Press refresh after saving.
+
+Some Windsurf UI builds still open `~/.codeium/windsurf/mcp_config.json`. Use
+the file the UI opens. The `mcpServers` / `command` schema is the same.
+
+## Requirements
+
+- MemoryWhale installed with `mw-mcp` on `PATH`.
+- Windsurf with Cascade MCP enabled.
+
+## Setup
+
+Merge [`mcp_config.json`](mcp_config.json) into the MCP config file the UI
+opens, or add the server through Cascade → MCP → Add Server:
 
 ```json
 {
@@ -21,12 +37,12 @@ Configure / "Add Server"** UI, which edits the same file):
 
 `mw-mcp` must be on `PATH` (standard MemoryWhale install); otherwise use its
 absolute path. For a non-default database add
-`"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`. After saving, hit the
-refresh/reload in the MCP panel so Cascade picks up the server.
+`"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`. After saving, hit refresh
+in the MCP panel so Cascade picks up the server.
 
-## Tell it when to reach for the memory
+### Memory-use guidance
 
-Add a Windsurf Rule (**Customizations → Rules**, or a `.windsurf/rules/`
+Add a Windsurf Rule (Customizations → Rules, or a `.windsurf/rules/`
 file):
 
 > When a build/test/deploy fails, before proposing a fix, use `search_memory`
@@ -34,5 +50,42 @@ file):
 > lesson. Once you've figured out why something failed or how a fix worked, use
 > `remember` to save that conclusion.
 
-Without the MCP server, the `mw` CLI still works: `mw context --last-error`,
-`mw search "…"`, `mw remember "…"`.
+## Verify
+
+```bash
+command -v mw-mcp
+```
+
+Refresh the MCP panel and confirm `memorywhale` is active with the six tools:
+`recent_errors`, `search_memory`, `get_context`, `remember`,
+`similar_failures`, and `stats`.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, optional Rule |
+
+MCP access is not automatic execution capture. Without the MCP server, the
+`mw` CLI still works: `mw context --last-error`, `mw search "…"`,
+`mw remember "…"`.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+
+## Troubleshooting
+
+- Run `command -v mw-mcp` in the environment that launches Windsurf. Use an
+  absolute `command` if needed.
+- Edit the config file the UI actually opened, then press refresh.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in the server `env`.
+- Run `mw doctor` to check the MemoryWhale install.
+
+## Uninstall
+
+Delete the `memorywhale` entry from `mcp_config.json` and refresh or restart
+Cascade. Remove any Windsurf Rule you added. This does not delete the
+MemoryWhale database.

--- a/integrations/zed/README.md
+++ b/integrations/zed/README.md
@@ -1,12 +1,24 @@
-# Zed integration
+# Zed + MemoryWhale
 
-Zed supports custom MCP servers, so its Agent Panel can use MemoryWhale's four
-tools: `recent_errors`, `search_memory`, `get_context`, and `remember`.
+Zed supports custom MCP servers, so its Agent Panel can use MemoryWhale's six
+local memory tools.
 
-## Connect the MCP server
+## Status
 
-Open **Settings → AI → MCP Servers** and choose **Add Server → Add Local
-Server**, or run `agent: open settings` and open the JSON settings file. Merge
+Verified against Zed's [Model Context Protocol](https://zed.dev/docs/ai/mcp)
+documentation on 2026-08-29. Custom servers are added from Settings → AI →
+MCP Servers (or `agent: open settings`), and they write `context_servers`
+entries in the settings file. Local servers use `command`, `args`, and `env`.
+
+## Requirements
+
+- MemoryWhale installed with `mw-mcp` on `PATH`.
+- Zed with the Agent Panel.
+
+## Setup
+
+Open Settings → AI → MCP Servers and choose Add Server → Add Local
+Server, or run `agent: open settings` and open the JSON settings file. Merge
 the [`settings.json`](settings.json) example into your existing settings:
 
 ```json
@@ -25,11 +37,7 @@ the [`settings.json`](settings.json) example into your existing settings:
 absolute path. For a non-default database, add
 `"env": { "MEMORYWHALE_DATA_DIR": "/path/to/dir" }`.
 
-After saving, open the Agent Panel settings and confirm that `memorywhale` has
-a green running indicator. Zed's canonical custom-server documentation is
-[Model Context Protocol](https://zed.dev/docs/ai/mcp).
-
-## Tell the agent when to reach for memory
+### Memory-use guidance
 
 Add this to your project or user rules:
 
@@ -37,5 +45,42 @@ Add this to your project or user rules:
 > before proposing a fix. After finding the cause or a working fix, use
 > `remember` to save the conclusion.
 
-Without the MCP server, the CLI remains available: `mw context --last-error`,
-`mw search "…"`, and `mw remember "…"`.
+## Verify
+
+```bash
+command -v mw-mcp
+```
+
+After saving, open the Agent Panel settings and confirm that `memorywhale` has
+a green running indicator. The six tools are `recent_errors`, `search_memory`,
+`get_context`, `remember`, `similar_failures`, and `stats`.
+
+## Available capabilities
+
+| Capability | Available |
+| --- | --- |
+| MCP memory access | Yes |
+| Automatic execution capture | No |
+| Memory-use guidance | Yes, optional rules |
+
+MCP access is not automatic execution capture. Without the MCP server, the CLI
+remains available: `mw context --last-error`, `mw search "…"`, and
+`mw remember "…"`.
+
+## Example prompt
+
+> Use MemoryWhale to check whether I encountered a similar failure before.
+
+## Troubleshooting
+
+- Run `command -v mw-mcp` from the environment Zed launches from.
+- Confirm the settings key is `context_servers`, not `mcpServers`.
+- If the server stays red, open `zed: open log` and look for context-server
+  errors.
+- If the wrong database opens, set `MEMORYWHALE_DATA_DIR` in `env`.
+- Run `mw doctor` to check the MemoryWhale install.
+
+## Uninstall
+
+Delete the `memorywhale` entry from `context_servers` in Zed settings. Remove
+any rule you added. This does not delete the MemoryWhale database.

--- a/integrations/zed/README.md
+++ b/integrations/zed/README.md
@@ -18,8 +18,9 @@ entries in the settings file. Local servers use `command`, `args`, and `env`.
 ## Setup
 
 Open Settings → AI → MCP Servers and choose Add Server → Add Local
-Server, or run `agent: open settings` and open the JSON settings file. Merge
-the [`settings.json`](settings.json) example into your existing settings:
+Server, or run `agent: open settings` to stay in that UI. To edit the JSON
+settings file, run `zed: open settings file` and merge the
+[`settings.json`](settings.json) example into your existing settings:
 
 ```json
 {


### PR DESCRIPTION
## What this changes

Standardizes every client guide under `integrations/` onto one heading order, and points the integration request template at that structure.

Closes https://github.com/wuisabel-gif/MemWhale/issues/144

## Why it matters

The guides had grown independently. Missing verify, capability, troubleshooting, or uninstall steps made the MCP contract look like a pile of snippets. A shared outline keeps client differences explicit without inventing capture or tools a client does not have.

## What's in it

- Canonical structure in `integrations/TEMPLATE.md`: Status, Requirements, Setup, Verify, Available capabilities, Example prompt, Troubleshooting, Uninstall
- The same outline in `integrations/README.md`, `CONTRIBUTING.md`, and `.github/ISSUE_TEMPLATE/integration_request.md`
- Every current `integrations/*/README.md` migrated to that outline
- Client-specific setup kept and checked against current client docs where the old guides were snippets (Cursor, VS Code, Windsurf, Zed, Codex, Continue, Goose, Gemini CLI, Cline, Claude Desktop, OpenClaw)
- `mw-mcp` tool lists updated from four tools to six where the old text was stale
- Extra client material (hooks, limitations, security, event archives) folded under Available capabilities rather than dropped

## Verification

- Walked every `integrations/*/README.md` and confirmed the eight H2 headings appear in the required order, with no extra required H2s
- Docs-only change; no `npm` or Cargo test run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized integration guides with consistent headings, setup, verification, capabilities, troubleshooting, and uninstall guidance.
  * Updated supported integration documentation with current configuration paths, commands, requirements, and six available MCP tools where applicable.
  * Clarified custom database settings, memory usage, automatic-capture limitations, platform-specific configuration, and non-MCP workflows.
  * Improved contribution and integration request guidance to support verified, consistent documentation across MCP and non-MCP integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->