### PR TITLE
feat(capture): persist structured agent provenance

### DIFF
--- a/crates/mw-cli/src/agent_hook.rs
+++ b/crates/mw-cli/src/agent_hook.rs
@@ -105,6 +105,7 @@ fn claude(payload: &serde_json::Map<String, Value>) -> Option<CommandRecord> {
         notes: "agent:claude-code".to_string(),
         command_parts: vec![command],
         capture_kind: "full".to_string(),
+        agent: Some(Agent::Claude.as_str().to_string()),
     })
 }
 
@@ -201,6 +202,7 @@ fn rho(payload: &Value) -> Option<CommandRecord> {
             vec![command]
         },
         capture_kind: "full".to_string(),
+        agent: Some(Agent::Rho.as_str().to_string()),
     })
 }
 
@@ -420,6 +422,7 @@ mod tests {
         assert_eq!(record.stdout, "ok");
         assert_eq!(record.exit_code, Some(0));
         assert_eq!(record.notes, "agent:claude-code");
+        assert_eq!(record.agent.as_deref(), Some("claude"));
     }
 
     #[test]
@@ -478,6 +481,7 @@ mod tests {
         assert!(record.exit_code.is_none());
         assert!(record.notes.contains("status:failed"));
         assert!(record.notes.contains("command:unknown"));
+        assert_eq!(record.agent.as_deref(), Some("rho"));
     }
 
     #[test]

--- a/crates/mw-cli/src/bin/mw-remember.rs
+++ b/crates/mw-cli/src/bin/mw-remember.rs
@@ -91,6 +91,7 @@ fn run() -> Result<(), String> {
             notes,
             command_parts,
             capture_kind,
+            agent: None,
         })?;
     if let Some(run_id) = run_id {
         println!("remembered command run #{run_id}");

--- a/crates/mw-cli/src/bin/mw-run.rs
+++ b/crates/mw-cli/src/bin/mw-run.rs
@@ -194,8 +194,8 @@ fn remember_command(
         "
         INSERT INTO command_runs
             (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at,
-             error_fingerprint, repository_id, repository_name, worktree_root)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+             agent, error_fingerprint, repository_id, repository_name, worktree_root)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9, ?10, ?11, ?12)
         ",
         params![
             command,

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -4443,6 +4443,8 @@ mod tests {
     use std::io::Cursor;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    static IMPORT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn mcp_probe_accepts_discovery_and_tools_list() {
         let output = concat!(
@@ -4524,6 +4526,7 @@ mod tests {
     }
     #[test]
     fn import_redacts_split_secret_argv_and_survives_malformed_json() {
+        let _env_guard = IMPORT_ENV_LOCK.lock().unwrap();
         let previous_data_dir = env::var_os("MEMORYWHALE_DATA_DIR");
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -4639,6 +4642,7 @@ mod tests {
 
     #[test]
     fn import_validates_agent_provenance_and_fills_legacy_duplicate() {
+        let _env_guard = IMPORT_ENV_LOCK.lock().unwrap();
         let previous_data_dir = env::var_os("MEMORYWHALE_DATA_DIR");
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -2051,7 +2051,7 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
         let c = src_columns(&conn, "command_runs");
         if c.contains("command") && c.contains("argv_json") && c.contains("created_at") {
             let sql = format!(
-                "SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM src.command_runs s",
+                "SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM src.command_runs s",
                 sel(&c, "command", "''"),
                 sel(&c, "argv_json", "'[]'"),
                 sel(&c, "cwd", "NULL"),
@@ -2060,6 +2060,7 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
                 sel(&c, "stderr", "''"),
                 sel(&c, "notes", "''"),
                 sel(&c, "created_at", "''"),
+                sel(&c, "agent", "NULL"),
                 sel(&c, "repository_id", "NULL"),
                 sel(&c, "repository_name", "NULL"),
                 sel(&c, "worktree_root", "NULL")
@@ -2073,6 +2074,7 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
                 String,
                 String,
                 String,
+                Option<String>,
                 Option<String>,
                 Option<String>,
                 Option<String>,
@@ -2094,6 +2096,7 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
                         r.get(8)?,
                         r.get(9)?,
                         r.get(10)?,
+                        r.get(11)?,
                     ))
                 });
                 let rows = mapped
@@ -2111,6 +2114,7 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
                 stderr,
                 notes,
                 created_at,
+                agent,
                 repository_id,
                 repository_name,
                 worktree_root,
@@ -2143,8 +2147,8 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
                     conn.execute(
                         "INSERT INTO command_runs
                             (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at,
-                             repository_id, repository_name, worktree_root)
-                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                             agent, repository_id, repository_name, worktree_root)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
                         params![
                             command,
                             argv_json,
@@ -2154,6 +2158,7 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
                             stderr,
                             notes,
                             created_at,
+                            agent,
                             repository_id,
                             repository_name,
                             worktree_root

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -2136,6 +2136,13 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
                 let stdout = memorywhale_cli::sanitize_capture(&stdout);
                 let stderr = memorywhale_cli::sanitize_capture(&stderr);
                 let notes = memorywhale_cli::sanitize_capture(&notes);
+                // Imported provenance is untrusted data. Keep only identifiers
+                // produced by a verified hook boundary; never persist arbitrary
+                // source text (which could contain a token or forged identity).
+                let agent = agent
+                    .as_deref()
+                    .and_then(memorywhale_cli::agent_hook::Agent::parse)
+                    .map(|agent| agent.as_str().to_string());
                 let exists: i64 = conn
                     .query_row(
                         "SELECT COUNT(*) FROM command_runs WHERE command = ?1 AND argv_json = ?2 AND created_at = ?3",
@@ -2158,13 +2165,23 @@ fn import_sqlite(src: &std::path::Path) -> Result<(), String> {
                             stderr,
                             notes,
                             created_at,
-                            agent,
+                            agent.as_deref(),
                             repository_id,
                             repository_name,
                             worktree_root
                         ],
                     )
                     .map_err(|err| format!("failed to merge command run: {err}"))?;
+                } else if agent.is_some() {
+                    // A legacy duplicate may predate structured provenance.
+                    // Fill only NULL so a trusted existing attribution wins.
+                    conn.execute(
+                        "UPDATE command_runs SET agent = ?1
+                         WHERE command = ?2 AND argv_json = ?3 AND created_at = ?4
+                           AND agent IS NULL",
+                        params![agent.as_deref(), command, argv_json, created_at],
+                    )
+                    .map_err(|err| format!("failed to merge command provenance: {err}"))?;
                 }
             }
         }
@@ -4618,5 +4635,102 @@ mod tests {
 
         drop(conn);
         // env + temp dirs are restored by the Cleanup guard on drop
+    }
+
+    #[test]
+    fn import_validates_agent_provenance_and_fills_legacy_duplicate() {
+        let previous_data_dir = env::var_os("MEMORYWHALE_DATA_DIR");
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dest = env::temp_dir().join(format!("mw-import-agent-{unique}"));
+        let src_dir = env::temp_dir().join(format!("mw-import-agent-src-{unique}"));
+        fs::create_dir_all(&dest).unwrap();
+        fs::create_dir_all(&src_dir).unwrap();
+        env::set_var("MEMORYWHALE_DATA_DIR", &dest);
+
+        struct Cleanup {
+            previous_data_dir: Option<std::ffi::OsString>,
+            dest: std::path::PathBuf,
+            src_dir: std::path::PathBuf,
+        }
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                if let Some(value) = self.previous_data_dir.take() {
+                    env::set_var("MEMORYWHALE_DATA_DIR", value);
+                } else {
+                    env::remove_var("MEMORYWHALE_DATA_DIR");
+                }
+                let _ = fs::remove_dir_all(&self.dest);
+                let _ = fs::remove_dir_all(&self.src_dir);
+            }
+        }
+        let _cleanup = Cleanup {
+            previous_data_dir,
+            dest: dest.clone(),
+            src_dir: src_dir.clone(),
+        };
+
+        let dest_conn = open_session_db().unwrap();
+        dest_conn
+            .execute(
+                "INSERT INTO command_runs
+                 (command, argv_json, created_at, agent)
+                 VALUES ('duplicate', '[\"duplicate\"]', '2026-01-01T00:00:00Z', NULL)",
+                [],
+            )
+            .unwrap();
+        drop(dest_conn);
+
+        let src_db = src_dir.join("memorywhale.sqlite3");
+        let src_conn = Connection::open(&src_db).unwrap();
+        src_conn
+            .execute_batch(
+                "CREATE TABLE command_runs (
+                    id INTEGER PRIMARY KEY,
+                    command TEXT NOT NULL,
+                    argv_json TEXT NOT NULL,
+                    cwd TEXT,
+                    exit_code INTEGER,
+                    stdout TEXT DEFAULT '',
+                    stderr TEXT DEFAULT '',
+                    notes TEXT DEFAULT '',
+                    created_at TEXT NOT NULL,
+                    agent TEXT
+                );
+                INSERT INTO command_runs
+                    (command, argv_json, created_at, agent)
+                VALUES
+                    ('claude-run', '[\"claude-run\"]', '2026-01-02T00:00:00Z', 'claude'),
+                    ('rho-run', '[\"rho-run\"]', '2026-01-03T00:00:00Z', 'rho'),
+                    ('forged-run', '[\"forged-run\"]', '2026-01-04T00:00:00Z', 'not-a-supported-agent'),
+                    ('secret-run', '[\"secret-run\"]', '2026-01-05T00:00:00Z', 'sk-live-secret'),
+                    ('duplicate', '[\"duplicate\"]', '2026-01-01T00:00:00Z', 'rho');",
+            )
+            .unwrap();
+        drop(src_conn);
+
+        import_sqlite(&src_db).unwrap();
+
+        let conn = Connection::open(dest.join("memorywhale.sqlite3")).unwrap();
+        let mut stmt = conn
+            .prepare("SELECT command, agent FROM command_runs ORDER BY command")
+            .unwrap();
+        let rows: Vec<(String, Option<String>)> = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert_eq!(
+            rows,
+            vec![
+                ("claude-run".to_string(), Some("claude".to_string())),
+                ("duplicate".to_string(), Some("rho".to_string())),
+                ("forged-run".to_string(), None),
+                ("rho-run".to_string(), Some("rho".to_string())),
+                ("secret-run".to_string(), None),
+            ]
+        );
     }
 }

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -132,7 +132,7 @@ const BOOKMARKS_BASE: &str = "CREATE TABLE IF NOT EXISTS bookmarks (
      CREATE INDEX IF NOT EXISTS idx_bookmarks_created_at ON bookmarks(created_at);";
 
 /// Schema version `migrate` brings a database up to.
-pub const LATEST_SCHEMA_VERSION: i64 = 9;
+pub const LATEST_SCHEMA_VERSION: i64 = 10;
 
 /// Apply numbered schema migrations to a MemoryWhale database. Idempotent and
 /// cheap (a `user_version` check), so callers run it before touching bookmarks.
@@ -163,6 +163,10 @@ pub const LATEST_SCHEMA_VERSION: i64 = 9;
 /// Migration 6 — memory lifecycle: adds `status` and `superseded_by_id` to
 /// bookmarks. Existing memories remain active; stale and superseded memories
 /// retain their evidence while leaving normal retrieval.
+///
+/// Migration 10 — structured command provenance: adds nullable `agent` to
+/// `command_runs`. Existing command runs remain NULL because their capture
+/// client is not known retroactively.
 pub fn migrate(conn: &Connection) -> Result<(), String> {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |r| r.get(0))
@@ -267,6 +271,11 @@ pub fn migrate(conn: &Connection) -> Result<(), String> {
         backfill_repository_identities(conn)?;
         conn.execute_batch("PRAGMA user_version = 9;")
             .map_err(|e| format!("failed to migrate repository identities: {e}"))?;
+    }
+    if version < 10 {
+        ensure_agent(conn)?;
+        conn.execute_batch("PRAGMA user_version = 10;")
+            .map_err(|e| format!("failed to migrate command agent provenance: {e}"))?;
     }
     Ok(())
 }
@@ -416,6 +425,16 @@ pub fn ensure_capture_kind(conn: &Connection) -> Result<(), String> {
             "capture_kind",
             "TEXT NOT NULL DEFAULT 'full'",
         )?;
+    }
+    Ok(())
+}
+
+/// Add `command_runs.agent` if the table exists and lacks it. The field is
+/// deliberately nullable: only verified Claude/Rho hook captures know their
+/// client, while ordinary terminal and manual captures stay NULL.
+pub fn ensure_agent(conn: &Connection) -> Result<(), String> {
+    if table_exists(conn, "command_runs")? {
+        add_column_if_missing(conn, "command_runs", "agent", "TEXT")?;
     }
     Ok(())
 }

--- a/crates/mw-cli/src/remember.rs
+++ b/crates/mw-cli/src/remember.rs
@@ -17,6 +17,9 @@ pub struct CommandRecord {
     pub notes: String,
     pub command_parts: Vec<String>,
     pub capture_kind: String,
+    /// Controlled provenance for verified agent hooks; ordinary captures use
+    /// `None` and persist SQL NULL.
+    pub agent: Option<String>,
 }
 
 /// Persist one command run. Returns `Ok(None)` when capture is off for `cwd`.
@@ -52,8 +55,8 @@ pub fn remember_command(mut record: CommandRecord) -> Result<Option<i64>, String
         "
         INSERT INTO command_runs
             (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at,
-             capture_kind, repository_id, repository_name, worktree_root)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+             capture_kind, agent, repository_id, repository_name, worktree_root)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
         ",
         params![
             command,
@@ -65,6 +68,7 @@ pub fn remember_command(mut record: CommandRecord) -> Result<Option<i64>, String
             crate::sanitize_capture(&record.notes),
             created_at,
             record.capture_kind,
+            record.agent,
             repository.as_ref().map(|repo| repo.id.as_str()),
             repository.as_ref().map(|repo| repo.name.as_str()),
             repository.as_ref().map(|repo| repo.worktree_root.as_str())

--- a/crates/mw-cli/src/storage.rs
+++ b/crates/mw-cli/src/storage.rs
@@ -55,6 +55,7 @@ pub fn initialize(conn: &Connection) -> Result<(), String> {
             stderr TEXT NOT NULL DEFAULT '',
             notes TEXT NOT NULL DEFAULT '',
             created_at TEXT NOT NULL,
+            agent TEXT,
             capture_kind TEXT NOT NULL DEFAULT 'full',
             error_fingerprint TEXT,
             repository_id TEXT,
@@ -245,6 +246,15 @@ mod tests {
             )
             .unwrap();
         assert_eq!(lifecycle, ("active".to_string(), None));
+        let legacy_agent: Option<String> = conn
+            .query_row("SELECT agent FROM command_runs WHERE id = 12", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert!(
+            legacy_agent.is_none(),
+            "upgraded rows preserve NULL agent provenance"
+        );
 
         for (table, expected) in [
             ("sessions", 1_i64),
@@ -332,6 +342,15 @@ mod tests {
                 assert_eq!(exists, 1, "missing {table}.{column}");
             }
         }
+        let agent_decl: (String, String, i64) = conn
+            .query_row(
+                "SELECT name, type, \"notnull\" FROM pragma_table_info('command_runs')
+                 WHERE name = 'agent'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(agent_decl, ("agent".to_string(), "TEXT".to_string(), 0));
     }
 
     #[test]
@@ -364,5 +383,11 @@ mod tests {
             )
             .unwrap();
         assert_eq!(capture_kind, "full");
+        let agent: Option<String> = conn
+            .query_row("SELECT agent FROM command_runs WHERE id = 1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert!(agent.is_none(), "legacy command rows default to NULL agent");
     }
 }

--- a/crates/mw-cli/tests/agent_hook.rs
+++ b/crates/mw-cli/tests/agent_hook.rs
@@ -56,13 +56,14 @@ fn from_hook_records_a_claude_bash_payload() {
     );
 
     let conn = memorywhale_cli::storage::open_path(&data_dir.join("memorywhale.sqlite3")).unwrap();
-    let command: String = conn
+    let (agent, command): (Option<String>, String) = conn
         .query_row(
-            "SELECT command FROM command_runs WHERE notes LIKE '%agent:claude-code%'",
+            "SELECT agent, command FROM command_runs WHERE notes LIKE '%agent:claude-code%'",
             [],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .unwrap();
+    assert_eq!(agent.as_deref(), Some("claude"));
     assert_eq!(command, "cargo test --from-hook-claude");
 }
 
@@ -85,18 +86,103 @@ fn from_hook_records_a_rho_failure_without_command_text() {
     assert!(output.status.success(), "{output:?}");
 
     let conn = memorywhale_cli::storage::open_path(&data_dir.join("memorywhale.sqlite3")).unwrap();
-    let (command, exit_code, notes): (String, Option<i64>, String) = conn
+    let (agent, command, exit_code, notes): (Option<String>, String, Option<i64>, String) = conn
         .query_row(
-            "SELECT command, exit_code, notes FROM command_runs",
+            "SELECT agent, command, exit_code, notes FROM command_runs",
             [],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )
         .unwrap();
+    assert_eq!(agent.as_deref(), Some("rho"));
     assert_eq!(command, "[rho:after_tool_use]");
     assert!(exit_code.is_none());
     assert!(notes.contains("agent:rho"), "{notes}");
     assert!(notes.contains("status:failed"), "{notes}");
     assert!(notes.contains("command:unknown"), "{notes}");
+}
+
+#[test]
+fn repeated_claude_hook_writes_keep_each_row_attributed() {
+    let data_dir = sandbox("claude-repeated");
+    let payload = r#"{
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "cwd": "/work",
+        "tool_input": {"command": "cargo test --repeated"},
+        "tool_response": {"stdout": "ok", "stderr": ""}
+    }"#;
+
+    for _ in 0..2 {
+        let output = remember_from_hook(&data_dir, "claude", payload);
+        assert!(output.status.success(), "{output:?}");
+    }
+
+    let conn = memorywhale_cli::storage::open_path(&data_dir.join("memorywhale.sqlite3")).unwrap();
+    let (rows, attributed): (i64, i64) = conn
+        .query_row(
+            "SELECT COUNT(*), COUNT(agent) FROM command_runs",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!((rows, attributed), (2, 2));
+}
+
+#[test]
+fn manual_capture_keeps_agent_null() {
+    let data_dir = sandbox("manual");
+    let output = Command::new(env!("CARGO_BIN_EXE_mw-remember"))
+        .args([
+            "--cwd",
+            "/work",
+            "--exit-code",
+            "0",
+            "--stdout",
+            "manual stdout",
+            "--stderr",
+            "manual stderr",
+            "--notes",
+            "manual capture",
+            "--",
+            "cargo",
+            "test",
+        ])
+        .env("MEMORYWHALE_DATA_DIR", &data_dir)
+        .env("PATH", "")
+        .output()
+        .expect("run manual mw-remember capture");
+    assert!(output.status.success(), "{output:?}");
+
+    let conn = memorywhale_cli::storage::open_path(&data_dir.join("memorywhale.sqlite3")).unwrap();
+    let (agent, cwd, exit_code, stdout, stderr, notes): (
+        Option<String>,
+        Option<String>,
+        Option<i64>,
+        String,
+        String,
+        String,
+    ) = conn
+        .query_row(
+            "SELECT agent, cwd, exit_code, stdout, stderr, notes FROM command_runs",
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert!(agent.is_none());
+    assert_eq!(cwd.as_deref(), Some("/work"));
+    assert_eq!(exit_code, Some(0));
+    assert_eq!(stdout, "manual stdout");
+    assert_eq!(stderr, "manual stderr");
+    assert!(notes.contains("manual capture"));
 }
 
 #[test]

--- a/crates/mw-cli/tests/shell_hooks.rs
+++ b/crates/mw-cli/tests/shell_hooks.rs
@@ -134,6 +134,18 @@ fn hook_records_command_cwd_and_exit_code() {
         "wrong cwd {:?} in {rows:?}",
         hit.1
     );
+    let conn = rusqlite::Connection::open(home.join("data/memorywhale.sqlite3")).unwrap();
+    let agent: Option<String> = conn
+        .query_row(
+            "SELECT agent FROM command_runs WHERE command = ?1",
+            [&hit.0],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        agent.is_none(),
+        "normal terminal hook rows stay unattributed"
+    );
 }
 
 #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -239,7 +239,8 @@ fn init_connection() -> anyhow::Result<Connection> {
             stdout TEXT NOT NULL DEFAULT '',
             stderr TEXT NOT NULL DEFAULT '',
             notes TEXT NOT NULL DEFAULT '',
-            created_at TEXT NOT NULL
+            created_at TEXT NOT NULL,
+            agent TEXT
         );
 
         CREATE TABLE IF NOT EXISTS command_arguments (
@@ -732,8 +733,8 @@ fn save_command_run(
         "
         INSERT INTO command_runs
             (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at,
-             repository_id, repository_name, worktree_root)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+             agent, repository_id, repository_name, worktree_root)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9, ?10, ?11)
         ",
         params![
             command,


### PR DESCRIPTION
Implements issue #247 and the storage foundation for Agent-Native Memory.

## Changes

- Adds nullable `command_runs.agent` through schema migration 10.
- Preserves existing rows as `NULL`.
- Claude hook captures persist `agent=claude`.
- Rho hook captures persist `agent=rho`.
- Manual, shell-hook, mw-run, and desktop terminal captures remain `NULL`.
- Imports preserve agent metadata when present and safely default it for older databases.
- Existing redaction, command/session provenance, cwd, exit code, stdout, and stderr behavior remains unchanged.

## Verification

- CLI all-target tests
- Claude/Rho hook tests
- shell-hook tests
- storage migration tests
- formatting and Clippy with `-D warnings`
- diff check

Follow-up interface work is tracked in #248 and the handoff demo in #249.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command history now records whether a command was captured from Claude or Rho hooks.
  * Imported command history preserves agent attribution when available.
* **Bug Fixes**
  * Existing and manually captured commands remain correctly marked as having no agent attribution.
  * Database upgrades retain existing command history while adding support for agent metadata.
* **Tests**
  * Added coverage for agent attribution across hooks, imports, upgrades, and standard shell captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->