### PR TITLE
feat(retrieval): expose structured agent provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "memorywhale-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/memorywhale-core/Cargo.toml
+++ b/crates/memorywhale-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorywhale-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Explainable retrieval for MemoryWhale: a MemoryEngine interface, a built-in scorer that ranks memories with per-signal reasons, and an optional MemPalace backend over MCP."
 license = "MIT"

--- a/crates/memorywhale-core/README.md
+++ b/crates/memorywhale-core/README.md
@@ -25,6 +25,7 @@ let memories = vec![
         importance: 0.55,
         tags: vec!["db".into()],
         embedding: None,
+        agent: None,
     },
     // ...more memories
 ];

--- a/crates/memorywhale-core/examples/benchmark.rs
+++ b/crates/memorywhale-core/examples/benchmark.rs
@@ -307,6 +307,7 @@ fn main() -> anyhow::Result<()> {
             importance: m.importance,
             tags: m.tags.clone(),
             embedding: None,
+            agent: None,
         })
         .collect();
 

--- a/crates/memorywhale-core/examples/embed.rs
+++ b/crates/memorywhale-core/examples/embed.rs
@@ -25,6 +25,7 @@ fn main() {
                 importance,
                 tags: tags.iter().map(|s| s.to_string()).collect(),
                 embedding: None, // lexical/BM25 path — no embeddings needed
+                agent: None,
             }
         };
 

--- a/crates/memorywhale-core/examples/eval.rs
+++ b/crates/memorywhale-core/examples/eval.rs
@@ -172,6 +172,7 @@ fn main() -> anyhow::Result<()> {
             importance: m.importance,
             tags: m.tags.clone(),
             embedding: None,
+            agent: None,
         })
         .collect();
 

--- a/crates/memorywhale-core/examples/recall.rs
+++ b/crates/memorywhale-core/examples/recall.rs
@@ -23,6 +23,7 @@ fn main() {
         importance,
         tags: tags.iter().map(|s| s.to_string()).collect(),
         embedding: None,
+        agent: None,
     };
 
     let memories = vec![

--- a/crates/memorywhale-core/src/engine.rs
+++ b/crates/memorywhale-core/src/engine.rs
@@ -468,6 +468,7 @@ fn map_hits(payload: &str, query: &Query) -> anyhow::Result<Vec<ScoredMemory>> {
                     })
                     .unwrap_or_default(),
                 embedding: None,
+                agent: h.get("agent").and_then(Value::as_str).map(str::to_string),
             };
             ScoredMemory {
                 memory,
@@ -657,6 +658,7 @@ mod tests {
                 importance: 0.98,
                 tags: vec!["rust".into()],
                 embedding: None,
+                agent: None,
             },
             Memory {
                 id: 7,
@@ -667,6 +669,7 @@ mod tests {
                 importance: 0.01,
                 tags: vec![],
                 embedding: None,
+                agent: None,
             },
             Memory {
                 id: 22,
@@ -677,6 +680,7 @@ mod tests {
                 importance: 0.6,
                 tags: vec!["rust".into(), "tokio".into()],
                 embedding: None,
+                agent: None,
             },
         ]
     }
@@ -736,6 +740,7 @@ mod tests {
             importance: 0.5,
             tags: vec![],
             embedding: None,
+            agent: None,
         }]);
         let query = Query::new("cache-invalidation-token", now());
         let before = engine.explain(1, &query).unwrap();
@@ -781,6 +786,7 @@ mod tests {
             importance: 0.5,
             tags: vec!["single-flight".to_string()],
             embedding: None,
+            agent: None,
         }]);
         let barrier = Arc::new(Barrier::new(8));
         let threads: Vec<_> = (0..8)
@@ -845,6 +851,7 @@ mod tests {
                 importance: 0.0,
                 tags: vec!["flaky".into()],
                 embedding: None,
+                agent: None,
             },
             Memory {
                 id: 2,
@@ -857,6 +864,7 @@ mod tests {
                 importance: 0.0,
                 tags: vec![],
                 embedding: None,
+                agent: None,
             },
         ];
         let eng = BuiltinEngine::new(mems);

--- a/crates/memorywhale-core/src/lib.rs
+++ b/crates/memorywhale-core/src/lib.rs
@@ -29,6 +29,7 @@
 //!     importance: 0.6,
 //!     tags: vec!["rust".into(), "tokio".into()],
 //!     embedding: None,
+//!     agent: None,
 //! }];
 //! let engine = BuiltinEngine::new(mems);
 //! let hits = engine.retrieve(&Query::new("async runtime", now), 5);
@@ -66,6 +67,7 @@ pub mod engine;
 mod mcp;
 pub mod policy;
 pub mod privacy;
+pub mod provenance;
 pub mod scorer;
 pub mod sqlite;
 
@@ -91,6 +93,10 @@ pub struct Memory {
     /// similarity is semantic (cosine); otherwise it falls back to lexical.
     #[serde(default)]
     pub embedding: Option<Vec<f32>>,
+    /// Producing agent for structured command captures. `None` represents a
+    /// terminal/manual record, including legacy rows with unknown provenance.
+    #[serde(default)]
+    pub agent: Option<String>,
 }
 
 /// A retrieval request plus the context that makes scoring explainable.
@@ -219,6 +225,10 @@ impl ScoredMemory {
             m.last_used.date_naive(),
             m.mentions,
             m.importance
+        ));
+        out.push_str(&format!(
+            "  agent: {}\n",
+            provenance::label(m.agent.as_deref())
         ));
         if !m.tags.is_empty() {
             out.push_str(&format!("  links: {}\n", m.tags.join(", ")));

--- a/crates/memorywhale-core/src/provenance.rs
+++ b/crates/memorywhale-core/src/provenance.rs
@@ -1,0 +1,31 @@
+//! Canonical producing-agent vocabulary shared by storage, retrieval, and
+//! interface renderers.
+
+pub const AGENT_CLAUDE: &str = "claude";
+pub const AGENT_RHO: &str = "rho";
+pub const AGENT_TERMINAL: &str = "terminal";
+pub const SUPPORTED_AGENTS: [&str; 3] = [AGENT_CLAUDE, AGENT_RHO, AGENT_TERMINAL];
+
+/// Render structured storage metadata without inspecting notes or payloads.
+/// NULL is the deliberate terminal/manual representation.
+pub fn label(agent: Option<&str>) -> &'static str {
+    match agent {
+        None => AGENT_TERMINAL,
+        Some(AGENT_CLAUDE) => AGENT_CLAUDE,
+        Some(AGENT_RHO) => AGENT_RHO,
+        Some(_) => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_only_structured_values_and_null() {
+        assert_eq!(label(Some(AGENT_CLAUDE)), AGENT_CLAUDE);
+        assert_eq!(label(Some(AGENT_RHO)), AGENT_RHO);
+        assert_eq!(label(None), AGENT_TERMINAL);
+        assert_eq!(label(Some("agent:claude")), "unknown");
+    }
+}

--- a/crates/memorywhale-core/src/provenance.rs
+++ b/crates/memorywhale-core/src/provenance.rs
@@ -6,6 +6,12 @@ pub const AGENT_RHO: &str = "rho";
 pub const AGENT_TERMINAL: &str = "terminal";
 pub const SUPPORTED_AGENTS: [&str; 3] = [AGENT_CLAUDE, AGENT_RHO, AGENT_TERMINAL];
 
+/// Whether a stored optional value is one of the canonical agent identifiers.
+/// NULL is valid and means terminal/manual or legacy provenance.
+pub fn is_valid(agent: Option<&str>) -> bool {
+    matches!(agent, None | Some(AGENT_CLAUDE) | Some(AGENT_RHO))
+}
+
 /// Render structured storage metadata without inspecting notes or payloads.
 /// NULL is the deliberate terminal/manual representation.
 pub fn label(agent: Option<&str>) -> &'static str {

--- a/crates/memorywhale-core/src/scorer.rs
+++ b/crates/memorywhale-core/src/scorer.rs
@@ -340,6 +340,7 @@ mod tests {
             importance,
             tags: tags.iter().map(|s| s.to_string()).collect(),
             embedding: None,
+            agent: None,
         }
     }
 

--- a/crates/memorywhale-core/src/sqlite.rs
+++ b/crates/memorywhale-core/src/sqlite.rs
@@ -320,6 +320,7 @@ fn documents(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
                 importance: 0.5,
                 tags: vec!["document".into(), source_type],
                 embedding: None,
+                agent: None,
             }
         })
         .collect())
@@ -328,22 +329,44 @@ fn documents(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
 /// Command runs (both). Reinforcement = how often the same command recurs;
 /// failures are more important than successes.
 fn command_runs(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
-    let rows = load_rows(
-        conn,
-        "command_runs",
-        "SELECT id, command, argv_json, notes, stderr, exit_code, created_at FROM command_runs",
-        |r| {
-            Ok((
-                r.get::<_, i64>(0)?,
-                r.get::<_, String>(1)?,
-                r.get::<_, String>(2)?,
-                r.get::<_, String>(3)?,
-                r.get::<_, String>(4)?,
-                r.get::<_, Option<i64>>(5)?,
-                r.get::<_, String>(6)?,
-            ))
-        },
-    )?;
+    let Some(columns) = table_columns(conn, "command_runs")? else {
+        return Ok(Vec::new());
+    };
+    let has_agent = columns
+        .iter()
+        .any(|column| column.eq_ignore_ascii_case("agent"));
+    // `agent` was added after command_runs first shipped. Select a typed NULL
+    // for old databases instead of making the otherwise usable source fail.
+    let agent_column = if has_agent { "agent" } else { "NULL" };
+    let sql = format!(
+        "SELECT id, command, argv_json, notes, stderr, exit_code, created_at, {agent_column}
+         FROM command_runs"
+    );
+    let rows = load_rows_existing(conn, "command_runs", &sql, |r| {
+        Ok((
+            r.get::<_, i64>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+            r.get::<_, String>(3)?,
+            r.get::<_, String>(4)?,
+            r.get::<_, Option<i64>>(5)?,
+            r.get::<_, String>(6)?,
+            r.get::<_, Option<String>>(7)?,
+        ))
+    })?;
+    for (row, (_, _, _, _, _, _, _, agent)) in rows.iter().enumerate() {
+        if let Some(agent) = agent.as_deref() {
+            if !matches!(
+                agent,
+                crate::provenance::AGENT_CLAUDE | crate::provenance::AGENT_RHO
+            ) {
+                return Err(LoadError::unsupported_schema(
+                    "command_runs",
+                    format!("unsupported agent value {agent:?} in row {}", row + 1),
+                ));
+            }
+        }
+    }
     let mut counts: HashMap<String, u32> = HashMap::new();
     for (_, cmd, ..) in &rows {
         *counts.entry(cmd.to_lowercase()).or_insert(0) += 1;
@@ -351,7 +374,7 @@ fn command_runs(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
     Ok(rows
         .into_iter()
         .map(
-            |(id, command, argv_json, notes, stderr, exit_code, created)| {
+            |(id, command, argv_json, notes, stderr, exit_code, created, agent)| {
                 let when = parse_ts(&created);
                 let ok = exit_code == Some(0);
                 Memory {
@@ -370,6 +393,7 @@ fn command_runs(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
                         if ok { "ok".into() } else { "error".into() },
                     ],
                     embedding: None,
+                    agent,
                 }
             },
         )
@@ -418,6 +442,7 @@ fn agent_turns(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
                 importance,
                 tags: vec!["conversation".into(), direction],
                 embedding: None,
+                agent: None,
             }
         })
         .collect())
@@ -475,6 +500,7 @@ fn bookmarks(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
                 importance: 0.55,
                 tags: vec!["note".into()],
                 embedding: None,
+                agent: None,
             }
         })
         .collect())
@@ -513,6 +539,7 @@ fn sessions(conn: &Connection) -> Result<Vec<Memory>, LoadError> {
                 importance: 0.5,
                 tags: vec!["session".into()],
                 embedding: None,
+                agent: None,
             })
         })
         .collect())
@@ -567,6 +594,49 @@ mod tests {
             .find(|m| decode_id(m.id) == (Source::Command, 1))
             .unwrap();
         assert_eq!(cmd.mentions, 2);
+        assert_eq!(cmd.agent, None);
+    }
+
+    #[test]
+    fn loads_agent_column_and_keeps_legacy_rows_nullable() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE command_runs (
+                 id INTEGER PRIMARY KEY, command TEXT, argv_json TEXT,
+                 notes TEXT, stderr TEXT, exit_code INTEGER, created_at TEXT, agent TEXT
+             );
+             INSERT INTO command_runs VALUES
+               (1, 'claude-run', '[\"claude-run\"]', '', '', 0,
+                '2026-01-01T00:00:00Z', 'claude'),
+               (2, 'rho-run', '[\"rho-run\"]', '', '', 0,
+                '2026-01-02T00:00:00Z', 'rho'),
+               (3, 'manual-run', '[\"manual-run\"]', 'agent:claude', '', 0,
+                '2026-01-03T00:00:00Z', NULL);",
+        )
+        .unwrap();
+        let mems = load_memories(&conn).unwrap();
+        let agent_for = |id| {
+            mems.iter()
+                .find(|m| decode_id(m.id) == (Source::Command, id))
+        };
+        assert_eq!(agent_for(1).unwrap().agent.as_deref(), Some("claude"));
+        assert_eq!(agent_for(2).unwrap().agent.as_deref(), Some("rho"));
+        // A note-looking string in notes is not provenance.
+        assert_eq!(agent_for(3).unwrap().agent, None);
+
+        let legacy = Connection::open_in_memory().unwrap();
+        legacy
+            .execute_batch(
+                "CREATE TABLE command_runs (
+                     id INTEGER PRIMARY KEY, command TEXT, argv_json TEXT,
+                     notes TEXT, stderr TEXT, exit_code INTEGER, created_at TEXT
+                 );
+                 INSERT INTO command_runs VALUES
+                   (1, 'legacy', '[\"legacy\"]', '', '', 0, '2026-01-01T00:00:00Z');",
+            )
+            .unwrap();
+        let legacy_mems = load_memories(&legacy).unwrap();
+        assert_eq!(legacy_mems[0].agent, None);
     }
 
     #[test]

--- a/crates/mw-cli/Cargo.toml
+++ b/crates/mw-cli/Cargo.toml
@@ -22,7 +22,7 @@ getrandom = "0.2"
 # MCP server, with a builtin fallback when that server is unreachable.
 # `version` (alongside `path`) is required so `cargo publish` can resolve the
 # dependency from crates.io — publish memorywhale-core first, then this crate.
-memorywhale-core = { path = "../memorywhale-core", version = "0.4.0", features = ["mempalace"] }
+memorywhale-core = { path = "../memorywhale-core", version = "0.5.0", features = ["mempalace"] }
 regex = "1"
 # Pure-Rust interactive terminal UI (`mw tui`) — no system libraries, so it
 # keeps the bare-machine / Jetson build story intact. Bundles crossterm.

--- a/crates/mw-cli/src/agent_hook.rs
+++ b/crates/mw-cli/src/agent_hook.rs
@@ -31,8 +31,8 @@ impl Agent {
 
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Claude => "claude",
-            Self::Rho => "rho",
+            Self::Claude => memorywhale_core::provenance::AGENT_CLAUDE,
+            Self::Rho => memorywhale_core::provenance::AGENT_RHO,
         }
     }
 }

--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -611,6 +611,13 @@ fn api_command(raw_id: &str) -> (&'static str, String) {
     else {
         return api_error("404 Not Found", "not_found", "command was not found");
     };
+    if !memorywhale_core::provenance::is_valid(agent.as_deref()) {
+        return api_error(
+            "500 Internal Server Error",
+            "invalid_provenance",
+            "stored command provenance is invalid",
+        );
+    }
     let argv = serde_json::from_str::<Value>(&argv_json).unwrap_or(Value::Null);
     (
         "200 OK",
@@ -1295,6 +1302,9 @@ fn dashboard(raw_path: &str) -> String {
         }) {
             for row in iter.flatten() {
                 let (id, cmd, argv_json, code, at, notes, agent) = row;
+                if !memorywhale_core::provenance::is_valid(agent.as_deref()) {
+                    continue;
+                }
                 let day = fmt_date(&at);
                 if day != cur_date {
                     if !cur_date.is_empty() {
@@ -1647,6 +1657,9 @@ fn search_results(conn: &Connection, query: &str) -> String {
         }) {
             for row in iter.flatten() {
                 let (id, cmd, argv_json, code, at, notes, stdout, stderr, agent) = row;
+                if !memorywhale_core::provenance::is_valid(agent.as_deref()) {
+                    continue;
+                }
                 if !agent_matches(agent.as_deref(), &agents) {
                     continue;
                 }
@@ -1717,6 +1730,9 @@ fn search_results(conn: &Connection, query: &str) -> String {
             ))
         }) {
             for (id, label, cwd, created_at) in iter.flatten() {
+                if !agent_matches(None, &agents) {
+                    continue;
+                }
                 out.push_str(&format!(
                     "<div class=\"row\"><span class=\"badge sess\">mark</span><span class=\"cmd\">#{id}</span><span class=\"when\">{}</span><span class=\"note\">{} {}</span></div>\n",
                     esc(&fmt_datetime(&created_at)),
@@ -1989,6 +2005,9 @@ fn project_page(raw_name: &str) -> String {
             ))
         }) {
             for (id, cmd, argv_json, code, at, notes, agent) in it.flatten() {
+                if !memorywhale_core::provenance::is_valid(agent.as_deref()) {
+                    continue;
+                }
                 if project_of(&notes).as_deref() != Some(name.as_str()) {
                     continue;
                 }
@@ -2096,6 +2115,9 @@ fn repo_page(raw_id: &str, worktree: Option<String>, query: &str) -> String {
             for (id, cmd, argv_json, code, at, notes, cwd, agent, repo_id, _, worktree_root) in
                 it.flatten()
             {
+                if !memorywhale_core::provenance::is_valid(agent.as_deref()) {
+                    continue;
+                }
                 if repo_id.as_deref() != Some(repository_id.as_str())
                     || worktree
                         .as_deref()
@@ -2259,6 +2281,9 @@ fn command_page(id: i64) -> Result<String, String> {
         .map_err(|e| format!("read command run: {e}"))?
         .ok_or_else(|| format!("no command run #{id}"))?;
     let (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at, agent) = row;
+    if !memorywhale_core::provenance::is_valid(agent.as_deref()) {
+        return Err("invalid stored agent provenance".to_string());
+    }
     let argv: Vec<String> =
         serde_json::from_str(&argv_json).unwrap_or_else(|_| vec![command.clone()]);
     let ok = exit_code == Some(0);
@@ -2646,6 +2671,9 @@ fn runs_page(raw: &str) -> String {
             ))
         }) {
             for (id, argv_json, code, at, notes, agent) in it.flatten() {
+                if !memorywhale_core::provenance::is_valid(agent.as_deref()) {
+                    continue;
+                }
                 let ok = code == Some(0);
                 body.push_str(&format!(
                     "<a class=\"row\" href=\"/command/{id}\"><span class=\"badge {}\">{}</span>\

--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -444,6 +444,30 @@ fn api_limit(raw_path: &str) -> Result<usize, (&'static str, String)> {
     Ok(limit)
 }
 
+fn api_agent_filters(raw_path: &str) -> Result<Vec<String>, (&'static str, String)> {
+    let Some(value) = query_param(raw_path, "agent") else {
+        return Ok(Vec::new());
+    };
+    let term = format!("agent:{value}");
+    memorywhale_cli::parse_search_filters(&[term.as_str()])
+        .map(|(filters, _)| filters.agents)
+        .map_err(|error| api_error("400 Bad Request", "invalid_agent", &error))
+}
+
+fn inline_agent_filters(query: &str) -> Result<(String, Vec<String>), String> {
+    let mut text = Vec::new();
+    let mut agents = Vec::new();
+    for term in query.split_whitespace() {
+        if term.starts_with("agent:") {
+            let (filters, _) = memorywhale_cli::parse_search_filters(&[term])?;
+            agents.extend(filters.agents);
+        } else {
+            text.push(term);
+        }
+    }
+    Ok((text.join(" "), agents))
+}
+
 fn api_search(raw_path: &str) -> (&'static str, String) {
     let query = query_param(raw_path, "q").unwrap_or_default();
     if query.trim().is_empty() {
@@ -453,6 +477,14 @@ fn api_search(raw_path: &str) -> (&'static str, String) {
         Ok(limit) => limit,
         Err(response) => return response,
     };
+    let (search_query, mut agents) = match inline_agent_filters(&query) {
+        Ok(filters) => filters,
+        Err(error) => return api_error("400 Bad Request", "invalid_agent", &error),
+    };
+    match api_agent_filters(raw_path) {
+        Ok(mut explicit) => agents.append(&mut explicit),
+        Err(response) => return response,
+    }
     let conn = match api_open() {
         Ok(conn) => conn,
         Err(response) => return response,
@@ -463,10 +495,15 @@ fn api_search(raw_path: &str) -> (&'static str, String) {
             return api_error("503 Service Unavailable", "memory_load", &error.to_string())
         }
     };
+    let filters = memorywhale_cli::SearchFilters {
+        agents,
+        ..Default::default()
+    };
+    let memories = memorywhale_cli::filter_memories(memories, &filters);
     let engine = memorywhale_core::engine::BuiltinEngine::new(memories);
     let hits = memorywhale_core::engine::MemoryEngine::retrieve(
         &engine,
-        &memorywhale_core::Query::new(&query, Utc::now()),
+        &memorywhale_core::Query::new(&search_query, Utc::now()),
         limit,
     );
     let results: Vec<Value> = hits
@@ -474,12 +511,15 @@ fn api_search(raw_path: &str) -> (&'static str, String) {
         .map(|hit| {
             let reasons = hit.reasons();
             let (source, source_id) = memorywhale_core::sqlite::decode_id(hit.memory.id);
+            let agent = hit.memory.agent.clone();
             json!({
                 "id": hit.memory.id,
                 "source": source.tag(),
                 "source_id": source_id,
                 "command_id": (source == memorywhale_core::sqlite::Source::Command)
                     .then_some(source_id),
+                "agent": agent,
+                "agent_label": memorywhale_core::provenance::label(hit.memory.agent.as_deref()),
                 "score": hit.score,
                 "memory": hit.memory,
                 "signals": hit.signals,
@@ -526,6 +566,7 @@ type ApiCommandRow = (
     String,
     String,
     String,
+    Option<String>,
 );
 
 fn api_command(raw_id: &str) -> (&'static str, String) {
@@ -542,7 +583,7 @@ fn api_command(raw_id: &str) -> (&'static str, String) {
     };
     let row: Option<ApiCommandRow> = match conn
         .query_row(
-            "SELECT command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at
+            "SELECT command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at, agent
                  FROM command_runs WHERE id = ?1",
             params![id],
             |row| {
@@ -555,6 +596,7 @@ fn api_command(raw_id: &str) -> (&'static str, String) {
                     row.get(5)?,
                     row.get(6)?,
                     row.get(7)?,
+                    row.get(8)?,
                 ))
             },
         )
@@ -565,7 +607,8 @@ fn api_command(raw_id: &str) -> (&'static str, String) {
             return api_error("500 Internal Server Error", "database", &error.to_string())
         }
     };
-    let Some((command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at)) = row else {
+    let Some((command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at, agent)) = row
+    else {
         return api_error("404 Not Found", "not_found", "command was not found");
     };
     let argv = serde_json::from_str::<Value>(&argv_json).unwrap_or(Value::Null);
@@ -580,7 +623,9 @@ fn api_command(raw_id: &str) -> (&'static str, String) {
             "stdout": stdout,
             "stderr": stderr,
             "notes": notes,
-            "created_at": created_at
+            "created_at": created_at,
+            "agent": agent,
+            "agent_label": memorywhale_core::provenance::label(agent.as_deref())
         })),
     )
 }
@@ -1235,7 +1280,7 @@ fn dashboard(raw_path: &str) -> String {
     let mut gcount = 0usize;
     let mut first_group = true;
     if let Ok(mut stmt) = conn.prepare(
-        "SELECT id, command, argv_json, exit_code, created_at, notes FROM command_runs ORDER BY created_at DESC, id DESC LIMIT 200",
+        "SELECT id, command, argv_json, exit_code, created_at, notes, agent FROM command_runs ORDER BY created_at DESC, id DESC LIMIT 200",
     ) {
         if let Ok(iter) = stmt.query_map([], |r| {
             Ok((
@@ -1245,10 +1290,11 @@ fn dashboard(raw_path: &str) -> String {
                 r.get::<_, Option<i64>>(3)?,
                 r.get::<_, String>(4)?,
                 r.get::<_, String>(5)?,
+                r.get::<_, Option<String>>(6)?,
             ))
         }) {
             for row in iter.flatten() {
-                let (id, cmd, argv_json, code, at, notes) = row;
+                let (id, cmd, argv_json, code, at, notes, agent) = row;
                 let day = fmt_date(&at);
                 if day != cur_date {
                     if !cur_date.is_empty() {
@@ -1263,11 +1309,12 @@ fn dashboard(raw_path: &str) -> String {
                 let ok = code == Some(0);
                 group.push_str(&format!(
                     "<a class=\"row\" href=\"/command/{id}\"><span class=\"badge {}\">{}</span>\
-                     <span class=\"cmd\">{}</span><span class=\"when\">{}</span><span class=\"note\">{}</span></a>\n",
+                     <span class=\"cmd\">{}</span><span class=\"when\">{}</span>{}<span class=\"note\">{}</span></a>\n",
                     if ok { "ok" } else { "bad" },
                     match code { Some(c) => format!("exit {c}"), None => "—".into() },
                     esc_redacted(&full),
                     esc(&fmt_time(&at)),
+                    agent_badge(agent.as_deref()),
                     esc_redacted(&notes)
                 ));
                 gcount += 1;
@@ -1530,15 +1577,56 @@ fn project_of(notes: &str) -> Option<String> {
     re.captures(notes).map(|c| c[1].to_string())
 }
 
+fn agent_label(agent: Option<&str>) -> &'static str {
+    memorywhale_core::provenance::label(agent)
+}
+
+fn agent_badge(agent: Option<&str>) -> String {
+    format!(
+        "<span class=\"agent\">agent:{}</span>",
+        esc(agent_label(agent))
+    )
+}
+
+fn dashboard_search_terms(query: &str) -> Result<(String, Vec<String>), String> {
+    let mut text = Vec::new();
+    let mut agents = Vec::new();
+    for term in query.split_whitespace() {
+        if term.starts_with("agent:") {
+            let (filters, _) = memorywhale_cli::parse_search_filters(&[term])?;
+            agents.extend(filters.agents);
+        } else {
+            text.push(term);
+        }
+    }
+    Ok((text.join(" "), agents))
+}
+
+fn agent_matches(agent: Option<&str>, wanted: &[String]) -> bool {
+    wanted.is_empty()
+        || wanted
+            .iter()
+            .any(|value| agent_label(agent) == value.as_str())
+}
+
 // Count how many command runs + sessions belong to each project tag.
 fn search_results(conn: &Connection, query: &str) -> String {
-    let needle = format!("%{}%", query.trim());
+    let (text_query, agents) = match dashboard_search_terms(query) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            return format!(
+                "<h2>Search results</h2><div class=\"list\"><p class=\"empty\">{}</p></div>\n",
+                esc(&error)
+            )
+        }
+    };
+    let needle = format!("%{}%", text_query.trim());
     let mut out = String::new();
     let mut rows = 0;
     out.push_str("<h2>Search results</h2>\n<div class=\"list\">\n");
 
     if let Ok(mut stmt) = conn.prepare(
-        "SELECT id, command, argv_json, exit_code, created_at, notes, stdout, stderr
+        "SELECT id, command, argv_json, exit_code, created_at, notes, stdout, stderr, agent
          FROM command_runs
          WHERE command LIKE ?1 OR argv_json LIKE ?1 OR IFNULL(cwd, '') LIKE ?1
             OR stdout LIKE ?1 OR stderr LIKE ?1 OR notes LIKE ?1
@@ -1554,19 +1642,24 @@ fn search_results(conn: &Connection, query: &str) -> String {
                 r.get::<_, String>(5)?,
                 r.get::<_, String>(6)?,
                 r.get::<_, String>(7)?,
+                r.get::<_, Option<String>>(8)?,
             ))
         }) {
             for row in iter.flatten() {
-                let (id, cmd, argv_json, code, at, notes, stdout, stderr) = row;
+                let (id, cmd, argv_json, code, at, notes, stdout, stderr, agent) = row;
+                if !agent_matches(agent.as_deref(), &agents) {
+                    continue;
+                }
                 let ok = code == Some(0);
                 let tags = error_tags(&format!("{stdout}\n{stderr}"));
                 out.push_str(&format!(
                     "<a class=\"row\" href=\"/command/{id}\"><span class=\"badge {}\">{}</span>\
-                     <span class=\"cmd\">{}</span><span class=\"when\">{}</span><span class=\"note\">{} {}</span></a>\n",
+                     <span class=\"cmd\">{}</span><span class=\"when\">{}</span><span class=\"note\">{} {} {}</span></a>\n",
                     if ok { "ok" } else { "bad" },
                     match code { Some(c) => format!("exit {c}"), None => "—".into() },
                     esc_redacted(&full_command(&argv_json, &cmd)),
                     esc(&fmt_datetime(&at)),
+                    agent_badge(agent.as_deref()),
                     tag_pills(&tags),
                     esc_redacted(&notes)
                 ));
@@ -1595,6 +1688,9 @@ fn search_results(conn: &Connection, query: &str) -> String {
         }) {
             for row in iter.flatten() {
                 let (id, started_at, ended_at, bytes, notes, status, transcript) = row;
+                if !agents.is_empty() && !agents.iter().any(|wanted| wanted == agent_label(None)) {
+                    continue;
+                }
                 let tags = error_tags(&transcript);
                 let mut row_html = session_row(id, &started_at, &ended_at, bytes, &notes, &status);
                 if !tags.is_empty() {
@@ -1878,9 +1974,9 @@ fn project_page(raw_name: &str) -> String {
 
     let mut items: Vec<(String, String)> = Vec::new(); // (timestamp, row html)
 
-    if let Ok(mut stmt) = conn
-        .prepare("SELECT id, command, argv_json, exit_code, created_at, notes FROM command_runs")
-    {
+    if let Ok(mut stmt) = conn.prepare(
+        "SELECT id, command, argv_json, exit_code, created_at, notes, agent FROM command_runs",
+    ) {
         if let Ok(it) = stmt.query_map([], |r| {
             Ok((
                 r.get::<_, i64>(0)?,
@@ -1889,19 +1985,21 @@ fn project_page(raw_name: &str) -> String {
                 r.get::<_, Option<i64>>(3)?,
                 r.get::<_, String>(4)?,
                 r.get::<_, String>(5)?,
+                r.get::<_, Option<String>>(6)?,
             ))
         }) {
-            for (id, cmd, argv_json, code, at, notes) in it.flatten() {
+            for (id, cmd, argv_json, code, at, notes, agent) in it.flatten() {
                 if project_of(&notes).as_deref() != Some(name.as_str()) {
                     continue;
                 }
                 let ok = code == Some(0);
                 let row = format!(
                     "<a class=\"row\" href=\"/command/{id}\"><span class=\"badge {}\">{}</span>\
-                     <span class=\"cmd\">{}</span><span class=\"when\">{}</span><span class=\"note\">{}</span></a>",
+                     <span class=\"cmd\">{}</span><span class=\"when\">{}</span><span class=\"note\">{} {}</span></a>",
                     if ok { "ok" } else { "bad" },
                     match code { Some(c) => format!("exit {c}"), None => "—".into() },
-                    esc_redacted(&full_command(&argv_json, &cmd)), esc(&fmt_datetime(&at)), esc_redacted(&notes)
+                    esc_redacted(&full_command(&argv_json, &cmd)), esc(&fmt_datetime(&at)),
+                    agent_badge(agent.as_deref()), esc_redacted(&notes)
                 );
                 items.push((at, row));
             }
@@ -1976,7 +2074,7 @@ fn repo_page(raw_id: &str, worktree: Option<String>, query: &str) -> String {
     let mut items: Vec<(String, String)> = Vec::new(); // (timestamp, row html)
 
     if let Ok(mut stmt) = conn.prepare(
-        "SELECT id, command, argv_json, exit_code, created_at, notes, cwd,
+        "SELECT id, command, argv_json, exit_code, created_at, notes, cwd, agent,
                 repository_id, repository_name, worktree_root
          FROM command_runs",
     ) {
@@ -1992,9 +2090,10 @@ fn repo_page(raw_id: &str, worktree: Option<String>, query: &str) -> String {
                 r.get::<_, Option<String>>(7)?,
                 r.get::<_, Option<String>>(8)?,
                 r.get::<_, Option<String>>(9)?,
+                r.get::<_, Option<String>>(10)?,
             ))
         }) {
-            for (id, cmd, argv_json, code, at, notes, cwd, repo_id, _, worktree_root) in
+            for (id, cmd, argv_json, code, at, notes, cwd, agent, repo_id, _, worktree_root) in
                 it.flatten()
             {
                 if repo_id.as_deref() != Some(repository_id.as_str())
@@ -2011,10 +2110,11 @@ fn repo_page(raw_id: &str, worktree: Option<String>, query: &str) -> String {
                 let ok = code == Some(0);
                 let row = format!(
                     "<a class=\"row\" href=\"/command/{id}\"><span class=\"badge {}\">{}</span>\
-                     <span class=\"cmd\">{}</span><span class=\"when\">{}</span><span class=\"note\">{}</span></a>",
+                     <span class=\"cmd\">{}</span><span class=\"when\">{}</span>{}<span class=\"note\">{}</span></a>",
                     if ok { "ok" } else { "bad" },
                     match code { Some(c) => format!("exit {c}"), None => "—".into() },
-                    esc_redacted(&full_command(&argv_json, &cmd)), esc(&fmt_datetime(&at)), esc_redacted(&notes)
+                    esc_redacted(&full_command(&argv_json, &cmd)), esc(&fmt_datetime(&at)),
+                    agent_badge(agent.as_deref()), esc_redacted(&notes)
                 );
                 items.push((at, row));
             }
@@ -2138,7 +2238,7 @@ fn command_page(id: i64) -> Result<String, String> {
     let conn = open_db()?;
     let row = conn
         .query_row(
-            "SELECT command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at
+            "SELECT command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at, agent
              FROM command_runs WHERE id = ?1",
             params![id],
             |r| {
@@ -2151,13 +2251,14 @@ fn command_page(id: i64) -> Result<String, String> {
                     r.get::<_, String>(5)?,
                     r.get::<_, String>(6)?,
                     r.get::<_, String>(7)?,
+                    r.get::<_, Option<String>>(8)?,
                 ))
             },
         )
         .optional()
         .map_err(|e| format!("read command run: {e}"))?
         .ok_or_else(|| format!("no command run #{id}"))?;
-    let (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at) = row;
+    let (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at, agent) = row;
     let argv: Vec<String> =
         serde_json::from_str(&argv_json).unwrap_or_else(|_| vec![command.clone()]);
     let ok = exit_code == Some(0);
@@ -2183,6 +2284,10 @@ fn command_page(id: i64) -> Result<String, String> {
     if let Some(cwd) = &cwd {
         body.push_str(&format!("<div><span>cwd</span>{}</div>", esc(cwd)));
     }
+    body.push_str(&format!(
+        "<div><span>agent</span>{}</div>",
+        esc(agent_label(agent.as_deref()))
+    ));
     body.push_str(&format!(
         "<div><span>when</span>{}</div></div>\n",
         esc(&fmt_datetime(&created_at))
@@ -2528,7 +2633,7 @@ fn runs_page(raw: &str) -> String {
     body.push_str("<div class=\"list\">\n");
     let mut rows = 0;
     if let Ok(mut stmt) = conn.prepare(
-        "SELECT id, argv_json, exit_code, created_at, notes FROM command_runs WHERE command = ?1 ORDER BY id DESC",
+        "SELECT id, argv_json, exit_code, created_at, notes, agent FROM command_runs WHERE command = ?1 ORDER BY id DESC",
     ) {
         if let Ok(it) = stmt.query_map(params![name], |r| {
             Ok((
@@ -2537,16 +2642,18 @@ fn runs_page(raw: &str) -> String {
                 r.get::<_, Option<i64>>(2)?,
                 r.get::<_, String>(3)?,
                 r.get::<_, String>(4)?,
+                r.get::<_, Option<String>>(5)?,
             ))
         }) {
-            for (id, argv_json, code, at, notes) in it.flatten() {
+            for (id, argv_json, code, at, notes, agent) in it.flatten() {
                 let ok = code == Some(0);
                 body.push_str(&format!(
                     "<a class=\"row\" href=\"/command/{id}\"><span class=\"badge {}\">{}</span>\
-                     <span class=\"cmd\">{}</span><span class=\"when\">{}</span><span class=\"note\">{}</span></a>\n",
+                     <span class=\"cmd\">{}</span><span class=\"when\">{}</span><span class=\"note\">{} {}</span></a>\n",
                     if ok { "ok" } else { "bad" },
                     match code { Some(c) => format!("exit {c}"), None => "—".into() },
-                    esc_redacted(&full_command(&argv_json, &name)), esc(&fmt_datetime(&at)), esc_redacted(&notes)
+                    esc_redacted(&full_command(&argv_json, &name)), esc(&fmt_datetime(&at)),
+                    agent_badge(agent.as_deref()), esc_redacted(&notes)
                 ));
                 rows += 1;
             }

--- a/crates/mw-cli/src/bin/mw-serve.rs
+++ b/crates/mw-cli/src/bin/mw-serve.rs
@@ -1635,14 +1635,34 @@ fn search_results(conn: &Connection, query: &str) -> String {
     let mut rows = 0;
     out.push_str("<h2>Search results</h2>\n<div class=\"list\">\n");
 
-    if let Ok(mut stmt) = conn.prepare(
+    let mut command_sql = String::from(
         "SELECT id, command, argv_json, exit_code, created_at, notes, stdout, stderr, agent
          FROM command_runs
-         WHERE command LIKE ?1 OR argv_json LIKE ?1 OR IFNULL(cwd, '') LIKE ?1
-            OR stdout LIKE ?1 OR stderr LIKE ?1 OR notes LIKE ?1
-         ORDER BY id DESC LIMIT 40",
-    ) {
-        if let Ok(iter) = stmt.query_map(params![needle.as_str()], |r| {
+         WHERE (command LIKE ?1 OR argv_json LIKE ?1 OR IFNULL(cwd, '') LIKE ?1
+            OR stdout LIKE ?1 OR stderr LIKE ?1 OR notes LIKE ?1)
+           AND (agent IS NULL OR agent IN ('claude', 'rho'))",
+    );
+    let mut command_params = vec![needle.clone()];
+    if !agents.is_empty() {
+        let clauses: Vec<String> = agents
+            .iter()
+            .map(|agent| {
+                if agent == "terminal" {
+                    "agent IS NULL".to_string()
+                } else {
+                    command_params.push(agent.clone());
+                    format!("agent = ?{}", command_params.len())
+                }
+            })
+            .collect();
+        command_sql.push_str(" AND (");
+        command_sql.push_str(&clauses.join(" OR "));
+        command_sql.push(')');
+    }
+    command_sql.push_str(" ORDER BY id DESC LIMIT 40");
+
+    if let Ok(mut stmt) = conn.prepare(&command_sql) {
+        if let Ok(iter) = stmt.query_map(rusqlite::params_from_iter(command_params.iter()), |r| {
             Ok((
                 r.get::<_, i64>(0)?,
                 r.get::<_, String>(1)?,

--- a/crates/mw-cli/src/bin/mw-serve/styles.css
+++ b/crates/mw-cli/src/bin/mw-serve/styles.css
@@ -26,6 +26,7 @@ h2{font-size:.95rem;margin:1.8em 0 .6em;text-transform:uppercase;letter-spacing:
 .row .cmd{font:600 .95rem ui-monospace,monospace}
 .row .when{font:.78rem ui-monospace,monospace;color:var(--muted)}
 .row .note{font-size:.85rem;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.agent{font:600 .72rem ui-monospace,monospace;color:var(--azure);white-space:nowrap}
 .badge{display:inline-block;font:600 .72rem ui-monospace,monospace;padding:4px 10px;border-radius:999px;text-align:center}
 .badge.ok{background:#e6f6ef;color:var(--ok)}
 .badge.bad{background:#fceee7;color:var(--bad)}

--- a/crates/mw-cli/src/bin/mw-view.rs
+++ b/crates/mw-cli/src/bin/mw-view.rs
@@ -138,7 +138,7 @@ fn list_all() -> Result<(), String> {
 
     println!("\nCommand runs (open with `mw-view command <id>`):");
     let mut c = conn
-        .prepare("SELECT id, command, exit_code, created_at, notes FROM command_runs ORDER BY id DESC LIMIT 20")
+        .prepare("SELECT id, command, exit_code, created_at, notes, agent FROM command_runs ORDER BY id DESC LIMIT 20")
         .map_err(|e| format!("query command_runs: {e}"))?;
     let mut any2 = false;
     let rows = c
@@ -149,13 +149,17 @@ fn list_all() -> Result<(), String> {
                 r.get::<_, Option<i64>>(2)?,
                 r.get::<_, String>(3)?,
                 r.get::<_, String>(4)?,
+                r.get::<_, Option<String>>(5)?,
             ))
         })
         .map_err(|e| format!("read command_runs: {e}"))?;
     for row in rows {
-        let (id, cmd, code, at, notes) = row.map_err(|e| format!("row: {e}"))?;
+        let (id, cmd, code, at, notes, agent) = row.map_err(|e| format!("row: {e}"))?;
         let code = code.map(|c| c.to_string()).unwrap_or_else(|| "-".into());
-        println!("  #{id}\t{cmd}\texit {code}\t{at}\t{notes}");
+        println!(
+            "  #{id}\t{cmd}\texit {code}\t{at}\tagent: {}\t{notes}",
+            memorywhale_core::provenance::label(agent.as_deref())
+        );
         any2 = true;
     }
     if !any2 {
@@ -167,7 +171,7 @@ fn list_all() -> Result<(), String> {
 fn render_command(conn: &Connection, id: i64) -> Result<String, String> {
     let row = conn
         .query_row(
-            "SELECT command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at
+            "SELECT command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at, agent
              FROM command_runs WHERE id = ?1",
             params![id],
             |r| {
@@ -180,13 +184,14 @@ fn render_command(conn: &Connection, id: i64) -> Result<String, String> {
                     r.get::<_, String>(5)?,
                     r.get::<_, String>(6)?,
                     r.get::<_, String>(7)?,
+                    r.get::<_, Option<String>>(8)?,
                 ))
             },
         )
         .optional()
         .map_err(|e| format!("read command run: {e}"))?
         .ok_or_else(|| format!("no command run #{id}"))?;
-    let (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at) = row;
+    let (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at, agent) = row;
 
     let argv: Vec<String> =
         serde_json::from_str(&argv_json).unwrap_or_else(|_| vec![command.clone()]);
@@ -212,6 +217,10 @@ fn render_command(conn: &Connection, id: i64) -> Result<String, String> {
     if let Some(cwd) = &cwd {
         body.push_str(&format!("<div><span>cwd</span>{}</div>", esc(cwd)));
     }
+    body.push_str(&format!(
+        "<div><span>agent</span>{}</div>",
+        esc(memorywhale_core::provenance::label(agent.as_deref()))
+    ));
     body.push_str(&format!("<div><span>when</span>{}</div>", esc(&created_at)));
     body.push_str("</div>\n");
 

--- a/crates/mw-cli/src/bin/mw-view.rs
+++ b/crates/mw-cli/src/bin/mw-view.rs
@@ -155,6 +155,9 @@ fn list_all() -> Result<(), String> {
         .map_err(|e| format!("read command_runs: {e}"))?;
     for row in rows {
         let (id, cmd, code, at, notes, agent) = row.map_err(|e| format!("row: {e}"))?;
+        if !memorywhale_core::provenance::is_valid(agent.as_deref()) {
+            continue;
+        }
         let code = code.map(|c| c.to_string()).unwrap_or_else(|| "-".into());
         println!(
             "  #{id}\t{cmd}\texit {code}\t{at}\tagent: {}\t{notes}",
@@ -192,6 +195,9 @@ fn render_command(conn: &Connection, id: i64) -> Result<String, String> {
         .map_err(|e| format!("read command run: {e}"))?
         .ok_or_else(|| format!("no command run #{id}"))?;
     let (command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at, agent) = row;
+    if !memorywhale_core::provenance::is_valid(agent.as_deref()) {
+        return Err("invalid stored agent provenance".to_string());
+    }
 
     let argv: Vec<String> =
         serde_json::from_str(&argv_json).unwrap_or_else(|_| vec![command.clone()]);

--- a/crates/mw-cli/src/bin/mw.rs
+++ b/crates/mw-cli/src/bin/mw.rs
@@ -301,7 +301,7 @@ fn print_help() {
          mw import <bundle|sqlite> merge another machine's exported memory into this one\n\
          mw push <ssh-host>       send this machine's memory to a teammate (scp + remote mw import)\n\
          mw pull <ssh-host> [path] copy another machine's memory here and merge it (scp + import)\n\
-         mw search <text> [--explain] [tag:X] [source:command|session|note|document|conversation] [after:YYYY-MM-DD] [before:YYYY-MM-DD] [limit:N] [--project X] [--machine Y] [--since 7d]  rank commands, sessions, and notes by relevance (--explain shows why)\n\
+         mw search <text> [--explain] [tag:X] [source:command|session|note|document|conversation] [agent:claude|rho|terminal] [after:YYYY-MM-DD] [before:YYYY-MM-DD] [limit:N] [--project X] [--machine Y] [--since 7d]  rank commands, sessions, and notes by relevance (--explain shows why)\n\
          mw explain <id> [query]  show the per-signal score breakdown for one memory (ids come from `mw search`)\n\
          mw link <a> <b> [rel:<type>]  link two memories (default relation \"related\"); ids come from `mw search`\n\
          mw unlink <a> <b> [rel:<type>]  remove the link between two memories\n\
@@ -1349,7 +1349,7 @@ fn export_memory(args: &[String]) -> Result<(), String> {
     let mut sessions = Vec::new();
     let mut stmt = conn
         .prepare(
-            "SELECT id, command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at
+            "SELECT id, command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at, agent
              FROM command_runs
              WHERE ?1 IS NULL OR notes LIKE ?1
              ORDER BY id",
@@ -1367,16 +1367,18 @@ fn export_memory(args: &[String]) -> Result<(), String> {
                 r.get::<_, String>(6)?,
                 r.get::<_, String>(7)?,
                 r.get::<_, String>(8)?,
+                r.get::<_, Option<String>>(9)?,
             ))
         })
         .map_err(|err| format!("failed to export commands: {err}"))?;
     for row in rows {
-        let (id, command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at) =
+        let (id, command, argv_json, cwd, exit_code, stdout, stderr, notes, created_at, agent) =
             row.map_err(|err| format!("command row error: {err}"))?;
         let argv: Vec<String> = serde_json::from_str(&argv_json).unwrap_or_default();
         md.push_str(&format!(
-            "## Command #{id}: `{}`\n\n- when: `{created_at}`\n- cwd: `{}`\n- exit: `{:?}`\n- notes: {}\n\n```text\n{}\n{}\n```\n\n",
+            "## Command #{id}: `{}`\n\n- when: `{created_at}`\n- agent: `{}`\n- cwd: `{}`\n- exit: `{:?}`\n- notes: {}\n\n```text\n{}\n{}\n```\n\n",
             argv.join(" "),
+            memorywhale_core::provenance::label(agent.as_deref()),
             cwd.clone().unwrap_or_default(),
             exit_code,
             notes,
@@ -1392,7 +1394,8 @@ fn export_memory(args: &[String]) -> Result<(), String> {
             "stdout": stdout,
             "stderr": stderr,
             "notes": notes,
-            "created_at": created_at
+            "created_at": created_at,
+            "agent": agent
         }));
     }
 
@@ -2504,7 +2507,12 @@ fn print_external_hits(query: &str, hits: &[memorywhale_core::ScoredMemory], exp
             .chars()
             .take(100)
             .collect();
-        println!("{:>3}%  [mempalace] {}", sm.percent(), snippet);
+        println!(
+            "{:>3}%  [mempalace · {}] {}",
+            sm.percent(),
+            memorywhale_core::provenance::label(sm.memory.agent.as_deref()),
+            snippet
+        );
         if explain {
             for reason in sm.reasons() {
                 println!("      {reason}");
@@ -2707,16 +2715,17 @@ fn search_memory(args: &[String]) -> Result<(), String> {
         .map(|s| s.as_str())
         .filter(|a| *a != "--explain")
         .collect();
-    // Pull inline `tag:`/`source:`/`before:`/`after:`/`limit:` filters out of the
+    // Pull inline `tag:`/`source:`/`agent:`/`before:`/`after:`/`limit:` filters out of the
     // terms; whatever's left is the free-text query.
     let (filters, query) = memorywhale_cli::parse_search_filters(&terms)?;
     let has_filter = !filters.tags.is_empty()
         || !filters.sources.is_empty()
+        || !filters.agents.is_empty()
         || filters.before.is_some()
         || filters.after.is_some();
     if query.is_empty() && !has_filter {
         return Err(
-            "usage: mw search <text> [--explain] [tag:X] [source:command|session|note|document|conversation] [after:YYYY-MM-DD] [before:YYYY-MM-DD] [limit:N] [--project X] [--machine Y] [--since 7d]"
+            "usage: mw search <text> [--explain] [tag:X] [source:command|session|note|document|conversation] [agent:claude|rho|terminal] [after:YYYY-MM-DD] [before:YYYY-MM-DD] [limit:N] [--project X] [--machine Y] [--since 7d]"
                 .to_string(),
         );
     }
@@ -2725,17 +2734,19 @@ fn search_memory(args: &[String]) -> Result<(), String> {
     // ranks server-side over its own corpus, so the local scope filters don't
     // apply. If the server is unreachable we print a notice and fall through to
     // the builtin engine over local memory, so a misconfig never hard-fails.
-    if let Some(argv) = memorywhale_cli::mempalace_command() {
-        let (cmd, rest) = argv.split_first().expect("mempalace_command is non-empty");
-        let eng = memorywhale_core::engine::MemPalaceEngine::new(cmd.clone(), rest.to_vec())
-            .with_tool(memorywhale_cli::mempalace_search_tool());
-        match eng.try_retrieve(&memorywhale_core::Query::new(&query, Utc::now()), 20) {
-            Ok(hits) => {
-                print_external_hits(&query, &hits, explain);
-                return Ok(());
-            }
-            Err(e) => {
-                eprintln!("mw: mempalace unavailable ({e:#}); using the local engine");
+    if !has_filter {
+        if let Some(argv) = memorywhale_cli::mempalace_command() {
+            let (cmd, rest) = argv.split_first().expect("mempalace_command is non-empty");
+            let eng = memorywhale_core::engine::MemPalaceEngine::new(cmd.clone(), rest.to_vec())
+                .with_tool(memorywhale_cli::mempalace_search_tool());
+            match eng.try_retrieve(&memorywhale_core::Query::new(&query, Utc::now()), 20) {
+                Ok(hits) => {
+                    print_external_hits(&query, &hits, explain);
+                    return Ok(());
+                }
+                Err(e) => {
+                    eprintln!("mw: mempalace unavailable ({e:#}); using the local engine");
+                }
             }
         }
     }
@@ -2789,6 +2800,7 @@ fn search_memory(args: &[String]) -> Result<(), String> {
             .trim();
         let snippet: String = snippet.chars().take(100).collect();
         // Only remembered notes carry provenance — who wrote this lesson, and when.
+        let agent = memorywhale_core::provenance::label(sm.memory.agent.as_deref());
         let prov = match source {
             memorywhale_core::sqlite::Source::Note => note_provenance(&conn, real_id)
                 .map(|p| format!("  ({p})"))
@@ -2796,9 +2808,10 @@ fn search_memory(args: &[String]) -> Result<(), String> {
             _ => String::new(),
         };
         println!(
-            "{:>3}%  [{}] #{} {}{}{}",
+            "{:>3}%  [{} · {}] #{} {}{}{}",
             sm.percent(),
             source.tag(),
+            agent,
             sm.memory.id,
             snippet,
             action,
@@ -2908,17 +2921,25 @@ fn classify_git_failure(text: &str) -> Option<&'static GitPattern> {
 /// Diagnose the last failed `git` command (or a specific `command_run` id):
 /// what the error means, the fix, and whether this exact class of failure has
 /// come up before — in past command runs or a remembered lesson.
+type GitFailureRow = (
+    i64,
+    String,
+    Option<i64>,
+    String,
+    String,
+    String,
+    Option<String>,
+);
+
 fn git_fix_cmd(args: &[String]) -> Result<(), String> {
     let conn = open_session_db()?;
 
-    let row: Option<(i64, String, Option<i64>, String, String, String)> = if let Some(id_str) =
-        args.first()
-    {
+    let row: Option<GitFailureRow> = if let Some(id_str) = args.first() {
         let id: i64 = id_str
             .parse()
             .map_err(|_| format!("invalid id {id_str:?}"))?;
         match conn.query_row(
-            "SELECT id, argv_json, exit_code, stdout, stderr, created_at FROM command_runs WHERE id = ?1",
+            "SELECT id, argv_json, exit_code, stdout, stderr, created_at, agent FROM command_runs WHERE id = ?1",
             params![id],
             |r| {
                 Ok((
@@ -2928,6 +2949,7 @@ fn git_fix_cmd(args: &[String]) -> Result<(), String> {
                     r.get(3)?,
                     r.get(4)?,
                     r.get(5)?,
+                    r.get(6)?,
                 ))
             },
         ) {
@@ -2937,7 +2959,7 @@ fn git_fix_cmd(args: &[String]) -> Result<(), String> {
         }
     } else {
         conn.query_row(
-            "SELECT id, argv_json, exit_code, stdout, stderr, created_at FROM command_runs
+            "SELECT id, argv_json, exit_code, stdout, stderr, created_at, agent FROM command_runs
              WHERE command LIKE 'git%' AND exit_code IS NOT NULL AND exit_code != 0
              ORDER BY id DESC LIMIT 1",
             [],
@@ -2949,13 +2971,14 @@ fn git_fix_cmd(args: &[String]) -> Result<(), String> {
                     r.get(3)?,
                     r.get(4)?,
                     r.get(5)?,
+                    r.get(6)?,
                 ))
             },
         )
         .ok()
     };
 
-    let Some((id, argv_json, exit_code, stdout, stderr, created_at)) = row else {
+    let Some((id, argv_json, exit_code, stdout, stderr, created_at, agent)) = row else {
         println!(
             "mw: no recent failed git commands found.\n\
              Give a specific id with `mw git-fix <id>`, or make sure MemoryWhale is\n\
@@ -2967,9 +2990,10 @@ fn git_fix_cmd(args: &[String]) -> Result<(), String> {
 
     let argv: Vec<String> = serde_json::from_str(&argv_json).unwrap_or_default();
     println!(
-        "# git-fix: command_run #{id} — `{}` (exit {}, {created_at})\n",
+        "# git-fix: command_run #{id} — `{}` (exit {}, {created_at}, agent: {})\n",
         argv.join(" "),
-        exit_code.unwrap_or(-1)
+        exit_code.unwrap_or(-1),
+        memorywhale_core::provenance::label(agent.as_deref())
     );
 
     let haystack = format!("{stderr}\n{stdout}");
@@ -3127,7 +3151,7 @@ fn agent_cmd(args: &[String]) -> Result<(), String> {
     // A few recent failures for extra context.
     let mut stmt = conn
         .prepare(
-            "SELECT argv_json, exit_code, stderr, created_at FROM command_runs
+            "SELECT argv_json, exit_code, stderr, created_at, agent FROM command_runs
              WHERE exit_code IS NOT NULL AND exit_code != 0
              ORDER BY id DESC LIMIT 5",
         )
@@ -3139,22 +3163,25 @@ fn agent_cmd(args: &[String]) -> Result<(), String> {
                 r.get::<_, Option<i64>>(1)?,
                 r.get::<_, String>(2)?,
                 r.get::<_, String>(3)?,
+                r.get::<_, Option<String>>(4)?,
             ))
         })
         .map_err(|err| format!("failed to read command runs: {err}"))?;
     let mut any = false;
     for row in rows {
-        let (argv_json, code, stderr, at) = row.map_err(|err| format!("row error: {err}"))?;
+        let (argv_json, code, stderr, at, agent) =
+            row.map_err(|err| format!("row error: {err}"))?;
         if !any {
             println!("## Recent failed commands\n");
             any = true;
         }
         let argv: Vec<String> = serde_json::from_str(&argv_json).unwrap_or_default();
         println!(
-            "- `{}` (exit {}, {})",
+            "- `{}` (exit {}, {}, agent: {})",
             argv.join(" "),
             code.unwrap_or(-1),
-            at
+            at,
+            memorywhale_core::provenance::label(agent.as_deref())
         );
         let tail = stderr
             .lines()
@@ -3290,7 +3317,7 @@ fn ask_cmd(args: &[String]) -> Result<(), String> {
     // The most recent failed command.
     let failure = conn
         .query_row(
-            "SELECT id, argv_json, cwd, exit_code, stderr, stdout, notes, created_at
+            "SELECT id, argv_json, cwd, exit_code, stderr, stdout, notes, created_at, agent
              FROM command_runs
              WHERE exit_code IS NOT NULL AND exit_code != 0
              ORDER BY id DESC LIMIT 1",
@@ -3305,6 +3332,7 @@ fn ask_cmd(args: &[String]) -> Result<(), String> {
                     r.get::<_, String>(5)?,
                     r.get::<_, String>(6)?,
                     r.get::<_, String>(7)?,
+                    r.get::<_, Option<String>>(8)?,
                 ))
             },
         )
@@ -3319,7 +3347,7 @@ fn ask_cmd(args: &[String]) -> Result<(), String> {
 
     // Words to find related history/lessons: from the error tail + the question.
     let mut terms: Vec<String> = Vec::new();
-    if let Some((_, _, _, _, stderr, _, _, _)) = &failure {
+    if let Some((_, _, _, _, stderr, _, _, _, _)) = &failure {
         terms.extend(
             tail(stderr, 200)
                 .split(|c: char| !c.is_alphanumeric())
@@ -3338,7 +3366,14 @@ fn ask_cmd(args: &[String]) -> Result<(), String> {
     terms.dedup();
 
     // Similar past failures (FTS if available, else LIKE on the first term).
-    type SimilarFailure = (String, Option<i64>, String, Option<String>, String);
+    type SimilarFailure = (
+        String,
+        Option<i64>,
+        String,
+        Option<String>,
+        String,
+        Option<String>,
+    );
     let mut similar: Vec<SimilarFailure> = Vec::new();
     let exclude_id = failure.as_ref().map(|f| f.0).unwrap_or(-1);
     if !terms.is_empty() {
@@ -3353,6 +3388,7 @@ fn ask_cmd(args: &[String]) -> Result<(), String> {
                         r.get::<_, String>(2)?,
                         r.get::<_, Option<String>>(3)?,
                         r.get::<_, String>(4)?,
+                        r.get::<_, Option<String>>(5)?,
                     ))
                 }) {
                     out.extend(rows.flatten());
@@ -3367,7 +3403,7 @@ fn ask_cmd(args: &[String]) -> Result<(), String> {
             .collect::<Vec<_>>()
             .join(" OR ");
         similar = collect(
-            "SELECT argv_json, exit_code, stderr, cwd, created_at FROM command_runs
+            "SELECT argv_json, exit_code, stderr, cwd, created_at, agent FROM command_runs
              WHERE exit_code IS NOT NULL AND exit_code != 0 AND id != ?2
                AND id IN (SELECT rowid FROM command_fts WHERE command_fts MATCH ?1)
              ORDER BY id DESC LIMIT 3",
@@ -3376,7 +3412,7 @@ fn ask_cmd(args: &[String]) -> Result<(), String> {
         if similar.is_empty() {
             if let Some(t) = terms.first() {
                 similar = collect(
-                    "SELECT argv_json, exit_code, stderr, cwd, created_at FROM command_runs
+                    "SELECT argv_json, exit_code, stderr, cwd, created_at, agent FROM command_runs
                      WHERE exit_code IS NOT NULL AND exit_code != 0 AND id != ?2
                        AND (stderr LIKE ?1 OR stdout LIKE ?1)
                      ORDER BY id DESC LIMIT 3",
@@ -3424,7 +3460,8 @@ fn ask_cmd(args: &[String]) -> Result<(), String> {
         "Help me debug a terminal failure. Below is the failing command, its exact\n\
          output, and relevant history from my local memory (past attempts + lessons).\n\n",
     );
-    if let Some((_, argv_json, cwd, exit_code, stderr, stdout, notes, created_at)) = &failure {
+    if let Some((_, argv_json, cwd, exit_code, stderr, stdout, notes, created_at, agent)) = &failure
+    {
         let argv: Vec<String> = serde_json::from_str(argv_json).unwrap_or_default();
         p.push_str("## The failure (just now)\n");
         p.push_str(&format!("Command:   {}\n", argv.join(" ")));
@@ -3438,6 +3475,10 @@ fn ask_cmd(args: &[String]) -> Result<(), String> {
         }
         p.push_str(&format!("Exit code: {}\n", exit_code.unwrap_or(-1)));
         p.push_str(&format!("When:      {created_at}\n\n"));
+        p.push_str(&format!(
+            "Producing agent: {}\n\n",
+            memorywhale_core::provenance::label(agent.as_deref())
+        ));
         let err_blob = if stderr.trim().is_empty() {
             stdout
         } else {
@@ -3447,13 +3488,14 @@ fn ask_cmd(args: &[String]) -> Result<(), String> {
     }
     if !similar.is_empty() {
         p.push_str("## I've hit similar errors before\n");
-        for (argv_json, code, stderr, cwd, at) in &similar {
+        for (argv_json, code, stderr, cwd, at, agent) in &similar {
             let argv: Vec<String> = serde_json::from_str(argv_json).unwrap_or_default();
             p.push_str(&format!(
-                "- `{}` (exit {}, {}, cwd {})\n  err: {}\n",
+                "- `{}` (exit {}, {}, agent: {}, cwd {})\n  err: {}\n",
                 argv.join(" "),
                 code.unwrap_or(-1),
                 at,
+                memorywhale_core::provenance::label(agent.as_deref()),
                 cwd.clone().unwrap_or_default(),
                 tail(stderr, 200)
             ));
@@ -3840,7 +3882,7 @@ fn context_cmd(args: &[String]) -> Result<(), String> {
     // Failed commands are the highest-signal thing for a debugging agent.
     let mut stmt = conn
         .prepare(
-            "SELECT argv_json, cwd, exit_code, stderr, notes, created_at
+            "SELECT argv_json, cwd, exit_code, stderr, notes, created_at, agent
              FROM command_runs
              WHERE (exit_code IS NOT NULL AND exit_code != 0)
                AND (?1 IS NULL OR notes LIKE ?1)
@@ -3858,6 +3900,7 @@ fn context_cmd(args: &[String]) -> Result<(), String> {
                     r.get::<_, String>(3)?,
                     r.get::<_, String>(4)?,
                     r.get::<_, String>(5)?,
+                    r.get::<_, Option<String>>(6)?,
                 ))
             },
         )
@@ -3866,15 +3909,16 @@ fn context_cmd(args: &[String]) -> Result<(), String> {
     let mut any = false;
     println!("## Recent failed commands");
     for row in rows {
-        let (argv_json, cwd, exit_code, stderr, notes, created_at) =
+        let (argv_json, cwd, exit_code, stderr, notes, created_at, agent) =
             row.map_err(|err| format!("row error: {err}"))?;
         let argv: Vec<String> = serde_json::from_str(&argv_json).unwrap_or_default();
         any = true;
         println!(
-            "- `{}` (exit {}, {})\n  cwd: {}\n  err: {}{}",
+            "- `{}` (exit {}, {}, agent: {})\n  cwd: {}\n  err: {}{}",
             argv.join(" "),
             exit_code.unwrap_or(-1),
             created_at,
+            memorywhale_core::provenance::label(agent.as_deref()),
             cwd.unwrap_or_default(),
             tail(&stderr, 200),
             if notes.trim().is_empty() {

--- a/crates/mw-cli/src/lib.rs
+++ b/crates/mw-cli/src/lib.rs
@@ -1289,6 +1289,9 @@ pub struct SearchFilters {
     pub tags: Vec<String>,
     /// Any may match (OR): command|session|note|document|conversation.
     pub sources: Vec<String>,
+    /// Any producing agent may match (OR). `terminal` matches NULL/manual
+    /// records; it is a render/filter label, never a stored value.
+    pub agents: Vec<String>,
     /// created_at on or after this day (start of day, UTC).
     pub after: Option<chrono::DateTime<Utc>>,
     /// created_at on or before this day (end of day, UTC).
@@ -1299,6 +1302,9 @@ pub struct SearchFilters {
 
 /// The source names accepted by `source:` — the same strings `Source::tag()` emits.
 pub const SEARCH_SOURCES: [&str; 5] = ["command", "session", "note", "document", "conversation"];
+/// The agent names accepted by `agent:`. Keep this sourced from core so every
+/// interface uses the same vocabulary.
+pub const SEARCH_AGENTS: [&str; 3] = memorywhale_core::provenance::SUPPORTED_AGENTS;
 
 fn parse_filter_day(kind: &str, val: &str) -> Result<chrono::DateTime<Utc>, String> {
     let d = chrono::NaiveDate::parse_from_str(val, "%Y-%m-%d")
@@ -1333,6 +1339,15 @@ pub fn parse_search_filters(terms: &[&str]) -> Result<(SearchFilters, String), S
                 ));
             }
             f.sources.push(v);
+        } else if let Some(v) = t.strip_prefix("agent:") {
+            let v = v.to_lowercase();
+            if !SEARCH_AGENTS.contains(&v.as_str()) {
+                return Err(format!(
+                    "unknown agent:{v} — use one of {}",
+                    SEARCH_AGENTS.join("|")
+                ));
+            }
+            f.agents.push(v);
         } else if let Some(v) = t.strip_prefix("after:") {
             f.after = Some(parse_filter_day("after", v)?);
         } else if let Some(v) = t.strip_prefix("before:") {
@@ -1370,6 +1385,13 @@ pub fn filter_memories(
     }
     if !f.sources.is_empty() {
         mems.retain(|m| f.sources.iter().any(|s| s == decode_id(m.id).0.tag()));
+    }
+    if !f.agents.is_empty() {
+        mems.retain(|m| {
+            f.agents
+                .iter()
+                .any(|want| memorywhale_core::provenance::label(m.agent.as_deref()) == want)
+        });
     }
     mems
 }
@@ -1738,6 +1760,7 @@ mod tests {
             importance: 0.5,
             tags: tags.iter().map(|s| s.to_string()).collect(),
             embedding: None,
+            agent: None,
         }
     }
 
@@ -1833,12 +1856,18 @@ mod tests {
 
     #[test]
     fn parse_search_filters_splits_filters_from_query() {
-        let (f, q) =
-            parse_search_filters(&["docker", "after:2026-01-01", "tag:Infra", "source:command"])
-                .unwrap();
+        let (f, q) = parse_search_filters(&[
+            "docker",
+            "after:2026-01-01",
+            "tag:Infra",
+            "source:command",
+            "agent:claude",
+        ])
+        .unwrap();
         assert_eq!(q, "docker");
         assert_eq!(f.tags, vec!["infra"]); // lowercased
         assert_eq!(f.sources, vec!["command"]);
+        assert_eq!(f.agents, vec!["claude"]);
         assert!(f.after.is_some());
         // Unknown prefixes stay as query text; a bare word too.
         let (f2, q2) = parse_search_filters(&["ratio:1", "hello"]).unwrap();
@@ -1850,6 +1879,7 @@ mod tests {
     fn parse_search_filters_rejects_bad_values() {
         assert!(parse_search_filters(&["before:nope"]).is_err());
         assert!(parse_search_filters(&["source:banana"]).is_err());
+        assert!(parse_search_filters(&["agent:codex"]).is_err());
         assert!(parse_search_filters(&["limit:x"]).is_err());
     }
 
@@ -1885,6 +1915,41 @@ mod tests {
         let out = filter_memories(mems.clone(), &f);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].id, 3_000_000_001);
+    }
+
+    #[test]
+    fn filter_memories_matches_each_agent_without_changing_source_filters() {
+        let mut claude = mem(1_000_000_001, &["command"], "2026-06-01T00:00:00Z");
+        claude.agent = Some("claude".into());
+        let mut rho = mem(1_000_000_002, &["command"], "2026-06-01T00:00:00Z");
+        rho.agent = Some("rho".into());
+        let manual = mem(1_000_000_003, &["command"], "2026-06-01T00:00:00Z");
+        let note = mem(3_000_000_004, &["note"], "2026-06-01T00:00:00Z");
+        let all = vec![claude, rho, manual, note];
+
+        for (agent, expected) in [
+            ("claude", vec![1_000_000_001]),
+            ("rho", vec![1_000_000_002]),
+            ("terminal", vec![1_000_000_003, 3_000_000_004]),
+        ] {
+            let filters = parse_search_filters(&[&format!("agent:{agent}")])
+                .unwrap()
+                .0;
+            let ids: Vec<_> = filter_memories(all.clone(), &filters)
+                .into_iter()
+                .map(|m| m.id)
+                .collect();
+            assert_eq!(ids, expected, "agent:{agent}");
+        }
+
+        let filters = parse_search_filters(&["source:command", "agent:terminal"])
+            .unwrap()
+            .0;
+        let ids: Vec<_> = filter_memories(all, &filters)
+            .into_iter()
+            .map(|m| m.id)
+            .collect();
+        assert_eq!(ids, vec![1_000_000_003]);
     }
 
     /// End-to-end scoring over the REAL retrieval path (load_memories +

--- a/crates/mw-cli/src/mcp/tools.rs
+++ b/crates/mw-cli/src/mcp/tools.rs
@@ -39,7 +39,8 @@ pub(super) fn tool_defs() -> Value {
             "inputSchema": {"type": "object", "properties": {
                 "query": {"type": "string", "description": "text to search for"},
                 "project": {"type": "string", "description": "optional: only memory recorded for this project, e.g. demo"},
-                "machine": {"type": "string", "description": "optional: only memory recorded on this machine"}
+                "machine": {"type": "string", "description": "optional: only memory recorded on this machine"},
+                "agent": {"type": "string", "enum": ["claude", "rho", "terminal"], "description": "optional producing agent; terminal matches NULL/manual records"}
             }, "required": ["query"]}
         },
         {
@@ -47,7 +48,8 @@ pub(super) fn tool_defs() -> Value {
             "description": "The most relevant remembered memory, engine-ranked, optionally scoped to a project or machine. Each result includes the reasons it was ranked where it did.",
             "inputSchema": {"type": "object", "properties": {
                 "project": {"type": "string", "description": "project tag, e.g. project:demo"},
-                "machine": {"type": "string", "description": "optional: only memory recorded on this machine"}
+                "machine": {"type": "string", "description": "optional: only memory recorded on this machine"},
+                "agent": {"type": "string", "enum": ["claude", "rho", "terminal"], "description": "optional producing agent; terminal matches NULL/manual records"}
             }}
         },
         {
@@ -92,11 +94,16 @@ pub(super) fn call_tool(
                 .get("query")
                 .and_then(Value::as_str)
                 .ok_or_else(|| "search_memory needs a 'query'".to_string())?;
-            search_memory(q, scope_arg(args, "project"), scope_arg(args, "machine"))
+            search_memory(
+                q,
+                scope_arg(args, "project"),
+                scope_arg(args, "machine"),
+                agent_arg(args)?,
+            )
         }
         "get_context" => {
             let project = args.get("project").and_then(Value::as_str);
-            get_context(project, scope_arg(args, "machine"))
+            get_context(project, scope_arg(args, "machine"), agent_arg(args)?)
         }
         "remember" => {
             let text = args
@@ -157,7 +164,7 @@ fn recent_errors(limit: i64) -> Result<String, String> {
     }
     let mut stmt = conn
         .prepare(
-            "SELECT argv_json, cwd, exit_code, stderr, notes, created_at
+            "SELECT argv_json, cwd, exit_code, stderr, notes, created_at, agent
              FROM command_runs
              WHERE exit_code IS NOT NULL AND exit_code != 0
              ORDER BY id DESC LIMIT ?1",
@@ -172,19 +179,21 @@ fn recent_errors(limit: i64) -> Result<String, String> {
                 r.get::<_, String>(3)?,
                 r.get::<_, String>(4)?,
                 r.get::<_, String>(5)?,
+                r.get::<_, Option<String>>(6)?,
             ))
         })
         .map_err(|e| e.to_string())?;
     let mut out = String::new();
     for row in rows {
-        let (argv_json, cwd, exit_code, stderr, notes, created_at) =
+        let (argv_json, cwd, exit_code, stderr, notes, created_at, agent) =
             row.map_err(|e| e.to_string())?;
         let argv: Vec<String> = serde_json::from_str(&argv_json).unwrap_or_default();
         out.push_str(&format!(
-            "- `{}` (exit {}, {})\n  cwd: {}\n  err: {}\n  note: {}\n",
+            "- `{}` (exit {}, {}, agent: {})\n  cwd: {}\n  err: {}\n  note: {}\n",
             argv.join(" "),
             exit_code.unwrap_or(-1),
             created_at,
+            memorywhale_core::provenance::label(agent.as_deref()),
             cwd.unwrap_or_default(),
             last_line(&stderr, 240),
             notes.trim()
@@ -226,11 +235,12 @@ fn render_hit(conn: &Connection, sm: &memorywhale_core::ScoredMemory) -> String 
         reasons.join("; ")
     };
     format!(
-        "- [{} #{}] {}% — {}\n  reasons: {}{}\n",
+        "- [{} #{}] {}% — {}\n  agent: {}\n  reasons: {}{}\n",
         source.tag(),
         real_id,
         sm.percent(),
         snippet,
+        memorywhale_core::provenance::label(sm.memory.agent.as_deref()),
         reasons,
         prov
     )
@@ -262,6 +272,7 @@ fn search_memory(
     query: &str,
     project: Option<&str>,
     machine: Option<&str>,
+    agent: Option<String>,
 ) -> Result<String, String> {
     let conn = open()?;
     let now = Utc::now();
@@ -274,6 +285,11 @@ fn search_memory(
         machine,
         None,
     );
+    let filters = crate::SearchFilters {
+        agents: agent.into_iter().collect(),
+        ..Default::default()
+    };
+    let mems = crate::filter_memories(mems, &filters);
     let engine = memorywhale_core::engine::BuiltinEngine::new(mems);
     let mut q = memorywhale_core::Query::new(query, now);
     let tags = task_tags(&[project, machine]);
@@ -305,7 +321,20 @@ fn scope_arg<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
         .filter(|s| !s.is_empty())
 }
 
-fn get_context(project: Option<&str>, machine: Option<&str>) -> Result<String, String> {
+fn agent_arg(args: &Value) -> Result<Option<String>, String> {
+    let Some(value) = scope_arg(args, "agent") else {
+        return Ok(None);
+    };
+    let term = format!("agent:{value}");
+    let (filters, _) = crate::parse_search_filters(&[term.as_str()])?;
+    Ok(filters.agents.into_iter().next())
+}
+
+fn get_context(
+    project: Option<&str>,
+    machine: Option<&str>,
+    agent: Option<String>,
+) -> Result<String, String> {
     let conn = open()?;
     // Callers have always passed the tag form ("project:demo"); the column
     // holds the bare name, so accept either.
@@ -318,6 +347,11 @@ fn get_context(project: Option<&str>, machine: Option<&str>) -> Result<String, S
         machine,
         None,
     );
+    let filters = crate::SearchFilters {
+        agents: agent.into_iter().collect(),
+        ..Default::default()
+    };
+    let mems = crate::filter_memories(mems, &filters);
     let engine = memorywhale_core::engine::BuiltinEngine::new(mems);
     // Scope by project tag when given: it's both the query text and a task tag
     // so the task-relevance signal can fire when a memory carries the tag.

--- a/crates/mw-cli/src/mcp/tools.rs
+++ b/crates/mw-cli/src/mcp/tools.rs
@@ -187,6 +187,9 @@ fn recent_errors(limit: i64) -> Result<String, String> {
     for row in rows {
         let (argv_json, cwd, exit_code, stderr, notes, created_at, agent) =
             row.map_err(|e| e.to_string())?;
+        if !memorywhale_core::provenance::is_valid(agent.as_deref()) {
+            continue;
+        }
         let argv: Vec<String> = serde_json::from_str(&argv_json).unwrap_or_default();
         out.push_str(&format!(
             "- `{}` (exit {}, {}, agent: {})\n  cwd: {}\n  err: {}\n  note: {}\n",

--- a/crates/mw-cli/src/tui.rs
+++ b/crates/mw-cli/src/tui.rs
@@ -119,10 +119,25 @@ impl App {
     /// the engine returns everything (just reordered), which reads wrong for a
     /// search box.
     fn recompute(&mut self) {
-        let q = Query::new(&self.query, self.now);
+        let terms: Vec<&str> = self.query.split_whitespace().collect();
+        let (filters, search_text) = match crate::parse_search_filters(&terms) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                self.results.clear();
+                self.state.select(None);
+                self.status = format!("  {error}");
+                return;
+            }
+        };
+        let allowed: std::collections::HashSet<i64> =
+            crate::filter_memories(self.engine.memories.clone(), &filters)
+                .into_iter()
+                .map(|memory| memory.id)
+                .collect();
+        let q = Query::new(&search_text, self.now);
         let mut hits = self.engine.retrieve(&q, MAX_RESULTS);
-        let terms: Vec<String> = self
-            .query
+        hits.retain(|sm| allowed.contains(&sm.memory.id));
+        let terms: Vec<String> = search_text
             .to_lowercase()
             .split_whitespace()
             .map(String::from)
@@ -241,7 +256,11 @@ fn render(app: &mut App, f: &mut Frame) {
                     Style::default().fg(Color::Cyan),
                 ),
                 Span::styled(
-                    format!("{:<8} ", source.tag()),
+                    format!(
+                        "{:<8} {:<8} ",
+                        source.tag(),
+                        memorywhale_core::provenance::label(sm.memory.agent.as_deref())
+                    ),
                     Style::default().fg(Color::DarkGray),
                 ),
                 Span::raw(snippet(&sm.memory.text, 48)),
@@ -268,7 +287,11 @@ fn render(app: &mut App, f: &mut Frame) {
             let mut lines = vec![
                 Line::from(vec![
                     Span::styled(
-                        format!("[{}] ", source.tag()),
+                        format!(
+                            "[{} · {}] ",
+                            source.tag(),
+                            memorywhale_core::provenance::label(sm.memory.agent.as_deref())
+                        ),
                         Style::default().fg(Color::Yellow),
                     ),
                     Span::styled(format!("#{id}  "), Style::default().fg(Color::DarkGray)),
@@ -607,6 +630,7 @@ mod tests {
             importance: 0.5,
             tags: vec![],
             embedding: None,
+            agent: None,
         }
     }
 

--- a/crates/mw-cli/src/tui.rs
+++ b/crates/mw-cli/src/tui.rs
@@ -129,14 +129,12 @@ impl App {
                 return;
             }
         };
-        let allowed: std::collections::HashSet<i64> =
-            crate::filter_memories(self.engine.memories.clone(), &filters)
-                .into_iter()
-                .map(|memory| memory.id)
-                .collect();
+        // Apply metadata filters before ranking/truncating so an agent match
+        // cannot be hidden behind MAX_RESULTS higher-ranked other agents.
+        let filtered = crate::filter_memories(self.engine.memories.clone(), &filters);
         let q = Query::new(&search_text, self.now);
-        let mut hits = self.engine.retrieve(&q, MAX_RESULTS);
-        hits.retain(|sm| allowed.contains(&sm.memory.id));
+        let engine = BuiltinEngine::new(filtered);
+        let mut hits = engine.retrieve(&q, MAX_RESULTS);
         let terms: Vec<String> = search_text
             .to_lowercase()
             .split_whitespace()
@@ -687,6 +685,27 @@ mod tests {
         app.recompute();
         assert!(app.results.is_empty());
         assert_eq!(app.state.selected(), None);
+    }
+
+    #[test]
+    fn agent_filter_is_applied_before_result_limit() {
+        let mut memories = (1..=MAX_RESULTS as i64)
+            .map(|id| {
+                let mut memory = mem(id, "same unrelated memory");
+                memory.agent = Some("claude".to_string());
+                memory
+            })
+            .collect::<Vec<_>>();
+        let mut rho_memory = mem(MAX_RESULTS as i64 + 1, "target rho memory");
+        rho_memory.agent = Some("rho".to_string());
+        memories.push(rho_memory);
+
+        let mut app = App::new(BuiltinEngine::new(memories), conn_with_pending(&[]));
+        app.query = "agent:rho".to_string();
+        app.recompute();
+
+        assert_eq!(app.results.len(), 1);
+        assert_eq!(app.results[0].memory.agent.as_deref(), Some("rho"));
     }
 
     #[test]

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -67,8 +67,7 @@ Returns server version, status, and the number of loaded memories:
 
 Searches the same explainable retrieval engine as the CLI. `q` is required;
 `limit` defaults to 20 and accepts 1–50. The optional `agent` filter accepts
-`claude`, `rho`, or `terminal`; `terminal` matches command rows whose nullable
-storage value is `NULL`. The same filter can also be written inline in `q`,
+`claude`, `rho`, or `terminal`; `terminal` matches records whose nullable storage value is `NULL`. The same filter can also be written inline in `q`,
 for example `q=linker+error+agent%3Aclaude`.
 
 Each result includes the namespaced memory ID, score, full stored memory,

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -63,10 +63,13 @@ Returns server version, status, and the number of loaded memories:
 }
 ```
 
-### `GET /api/v1/search?q=<text>&limit=<n>`
+### `GET /api/v1/search?q=<text>&limit=<n>&agent=<agent>`
 
 Searches the same explainable retrieval engine as the CLI. `q` is required;
-`limit` defaults to 20 and accepts 1–50.
+`limit` defaults to 20 and accepts 1–50. The optional `agent` filter accepts
+`claude`, `rho`, or `terminal`; `terminal` matches command rows whose nullable
+storage value is `NULL`. The same filter can also be written inline in `q`,
+for example `q=linker+error+agent%3Aclaude`.
 
 Each result includes the namespaced memory ID, score, full stored memory,
 signals, and human-readable ranking reasons:
@@ -82,6 +85,8 @@ signals, and human-readable ranking reasons:
         "source": "command",
         "source_id": 1,
         "command_id": 1,
+        "agent": "claude",
+        "agent_label": "claude",
         "score": 0.91,
         "memory": {},
         "signals": [],
@@ -99,8 +104,10 @@ Returns one namespaced memory by ID, or `404` if it is not present.
 ### `GET /api/v1/commands/:id`
 
 Returns one captured command run by its raw `command_runs.id`, including command, argv, cwd, exit code,
-stdout, stderr, notes, and timestamp. Malformed historical `argv_json` is
-returned as `null` rather than crashing the API.
+stdout, stderr, notes, timestamp, and nullable `agent` metadata. `agent` is
+`null` for terminal/manual or legacy rows; `agent_label` renders that value as
+the canonical `terminal` label. Malformed historical `argv_json` is returned as
+`null` rather than crashing the API.
 
 Search results include `command_id` when the result comes from a command
 record. Pass that value to this endpoint; do not use the namespaced search

--- a/docs/reference/api.openapi.json
+++ b/docs/reference/api.openapi.json
@@ -292,7 +292,7 @@
         "name": "agent",
         "in": "query",
         "required": false,
-        "description": "Producing agent filter. terminal matches NULL/manual command records.",
+        "description": "Producing agent filter. terminal matches NULL/manual records.",
         "schema": {
           "type": "string",
           "enum": ["claude", "rho", "terminal"]

--- a/docs/reference/api.openapi.json
+++ b/docs/reference/api.openapi.json
@@ -58,6 +58,9 @@
           },
           {
             "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Agent"
           }
         ],
         "responses": {
@@ -283,6 +286,16 @@
           "minimum": 1,
           "maximum": 50,
           "default": 20
+        }
+      },
+      "Agent": {
+        "name": "agent",
+        "in": "query",
+        "required": false,
+        "description": "Producing agent filter. terminal matches NULL/manual command records.",
+        "schema": {
+          "type": "string",
+          "enum": ["claude", "rho", "terminal"]
         }
       },
       "MemoryId": {
@@ -572,6 +585,7 @@
           "importance",
           "tags",
           "embedding"
+          ,"agent"
         ],
         "properties": {
           "id": {
@@ -612,6 +626,14 @@
             "items": {
               "type": "number"
             }
+          },
+          "agent": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": ["claude", "rho", null],
+            "description": "Structured producing agent; null means terminal/manual or legacy capture."
           }
         }
       },
@@ -649,6 +671,8 @@
           "source",
           "source_id",
           "command_id",
+          "agent",
+          "agent_label",
           "score",
           "memory",
           "signals",
@@ -672,6 +696,15 @@
               "null"
             ],
             "format": "int64"
+          },
+          "agent": {
+            "type": ["string", "null"],
+            "enum": ["claude", "rho", null],
+            "description": "Structured producing agent; null means terminal/manual or legacy capture."
+          },
+          "agent_label": {
+            "type": "string",
+            "enum": ["claude", "rho", "terminal"]
           },
           "score": {
             "type": "number"
@@ -705,6 +738,8 @@
           "stderr",
           "notes",
           "created_at"
+          ,"agent",
+          "agent_label"
         ],
         "properties": {
           "id": {
@@ -751,6 +786,15 @@
           "created_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "agent": {
+            "type": ["string", "null"],
+            "enum": ["claude", "rho", null],
+            "description": "Structured producing agent; null means terminal/manual or legacy capture."
+          },
+          "agent_label": {
+            "type": "string",
+            "enum": ["claude", "rho", "terminal"]
           }
         }
       },

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,7 +14,7 @@ mw --version                           # print the installed MemoryWhale version
 mw list                               # list recorded sessions
 mw show 1                             # print the full transcript of a session
 mw search "linker error"              # search commands, output, notes, transcripts
-mw search docker after:2026-01-01 tag:infra   # filter results: tag:X, source:command|session|note|document|conversation, before:/after:YYYY-MM-DD, limit:N
+mw search docker after:2026-01-01 tag:infra   # filter results: tag:X, source:command|session|note|document|conversation, agent:claude|rho|terminal, before:/after:YYYY-MM-DD, limit:N
 mw explain 1000000001                 # why this memory ranks: per-signal breakdown (ids come from `mw search`)
 mw link 1000000001 3000000001 rel:fixed-by   # link two memories (typed edge; ids from `mw search`)
 mw links 1000000001                   # show a memory's linked neighbors (both directions); mw unlink <a> <b> removes

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,6 +84,8 @@ struct CommandRun {
     repository_id: Option<String>,
     repository_name: Option<String>,
     worktree_root: Option<String>,
+    /// Nullable storage provenance; NULL is rendered as terminal/manual.
+    agent: Option<String>,
     exit_code: Option<i64>,
     stdout: String,
     stderr: String,
@@ -473,6 +475,8 @@ struct RecallHit {
     mentions: u32,
     importance: f32,
     tags: Vec<String>,
+    agent: Option<String>,
+    agent_label: String,
 }
 
 fn to_hit(sm: &memorywhale_core::ScoredMemory) -> RecallHit {
@@ -498,6 +502,8 @@ fn to_hit(sm: &memorywhale_core::ScoredMemory) -> RecallHit {
         mentions: sm.memory.mentions,
         importance: sm.memory.importance,
         tags: sm.memory.tags.clone(),
+        agent: sm.memory.agent.clone(),
+        agent_label: memorywhale_core::provenance::label(sm.memory.agent.as_deref()).to_string(),
     }
 }
 
@@ -790,7 +796,7 @@ fn save_command_run(
     conn.query_row(
         "
         SELECT id, command, argv_json, cwd, repository_id, repository_name, worktree_root,
-            exit_code, stdout, stderr, notes, created_at
+            exit_code, stdout, stderr, notes, created_at, agent
         FROM command_runs
         WHERE id = ?1
         ",
@@ -1003,7 +1009,7 @@ fn load_terminal_memory(
         conn.prepare(
             "
             SELECT id, command, argv_json, cwd, repository_id, repository_name, worktree_root,
-                exit_code, stdout, stderr, notes, created_at
+                exit_code, stdout, stderr, notes, created_at, agent
             FROM command_runs
             ORDER BY created_at DESC
             LIMIT 80
@@ -1017,7 +1023,7 @@ fn load_terminal_memory(
             "
             SELECT DISTINCT cr.id, cr.command, cr.argv_json, cr.cwd, cr.repository_id,
                 cr.repository_name, cr.worktree_root, cr.exit_code, cr.stdout, cr.stderr,
-                cr.notes, cr.created_at
+                cr.notes, cr.created_at, cr.agent
             FROM command_runs cr
             LEFT JOIN command_arguments ca ON ca.command_run_id = cr.id
             WHERE cr.command LIKE ?1
@@ -1087,6 +1093,7 @@ fn row_to_command_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<CommandRun> {
         stderr: row.get(9)?,
         notes: row.get(10)?,
         created_at: row.get(11)?,
+        agent: row.get(12)?,
     })
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1080,6 +1080,12 @@ fn row_to_concept(row: &rusqlite::Row<'_>) -> rusqlite::Result<Concept> {
 }
 
 fn row_to_command_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<CommandRun> {
+    let agent: Option<String> = row.get(12)?;
+    if !memorywhale_core::provenance::is_valid(agent.as_deref()) {
+        return Err(rusqlite::Error::InvalidParameterName(
+            "invalid stored agent provenance".to_string(),
+        ));
+    }
     Ok(CommandRun {
         id: row.get(0)?,
         command: row.get(1)?,
@@ -1093,7 +1099,7 @@ fn row_to_command_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<CommandRun> {
         stderr: row.get(9)?,
         notes: row.get(10)?,
         created_at: row.get(11)?,
-        agent: row.get(12)?,
+        agent,
     })
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -406,7 +406,7 @@ function App() {
                 type="button"
               >
                 <span className={`dot ${run.exit_code === 0 ? "command-dot" : "error-dot"}`} />
-                <span>{run.command}</span>
+                <span>{run.command} · {run.agent ?? "terminal"}</span>
               </button>
             ))}
           </div>
@@ -642,6 +642,8 @@ function demoRecallHits(): RecallHit[] {
       mentions: 4,
       importance: 0.65,
       tags: ["command", "error"]
+      ,agent: null,
+      agent_label: "terminal"
     },
     {
       id: 1,
@@ -660,6 +662,8 @@ function demoRecallHits(): RecallHit[] {
       mentions: 1,
       importance: 0.5,
       tags: ["document", "markdown"]
+      ,agent: null,
+      agent_label: "terminal"
     }
   ];
 }

--- a/src/components/DetailsPanel.tsx
+++ b/src/components/DetailsPanel.tsx
@@ -41,6 +41,7 @@ export function DetailsPanel({
           <p className="summary">
             Exit {selected.value.exit_code ?? "unknown"} · {selected.value.cwd || "cwd unknown"}
           </p>
+          <p className="summary">Producing agent: {selected.value.agent ?? "terminal"}</p>
           {selectedArgs.length > 0 && (
             <div className="arg-list">
               {selectedArgs.map((argument) => (

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,8 @@ export type CommandRun = {
   repository_id?: string | null;
   repository_name?: string | null;
   worktree_root?: string | null;
+  /** Nullable storage metadata; null is rendered as the terminal/manual agent. */
+  agent?: "claude" | "rho" | null;
   exit_code?: number | null;
   stdout: string;
   stderr: string;
@@ -104,4 +106,6 @@ export type RecallHit = {
   mentions: number;
   importance: number;
   tags: string[];
+  agent: "claude" | "rho" | null;
+  agent_label: "claude" | "rho" | "terminal" | "unknown";
 };


### PR DESCRIPTION
Implements issue #248 on top of merged #247.

## User-facing behavior

- `mw search ... agent:claude|rho|terminal` filters without changing `source:` semantics.
- CLI, TUI, dashboard, local JSON API, and MCP search/context output structured agent provenance.
- Dashboard/API support agent filters and labels.
- API/OpenAPI contracts document nullable agent metadata and bounded filter values.
- MCP tools accept validated agent filters.
- Mempalace/external results render the canonical agent label without applying local agent filters remotely.

## Storage/retrieval compatibility

- Core `Memory` carries nullable structured agent metadata.
- Legacy command tables without `agent` load as NULL.
- Unsupported stored agent values fail closed rather than being inferred from notes.
- Existing redaction, review, source-kind filtering, repository identity, and terminal behavior remain intact.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace`
- `bash scripts/check-doc-references.sh`
- `npm test`
- live temporary-db smoke test for Claude/terminal capture, search filters, doctor, and API

Depends on #247; follow-up handoff demo is #249.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added producer-agent provenance to command runs, memories, search results, and exported data.
  * Added agent labels and badges across the dashboard, CLI, TUI, viewer, and desktop interface.
  * Added `agent:` filtering for CLI, API, MCP tools, and dashboard searches.
  * Added support for Claude, Rho, and terminal provenance, including legacy records.

* **Bug Fixes**
  * Agent filters now apply before result limits, ensuring matching results are not omitted.
  * Invalid stored provenance values are rejected or safely excluded.

* **Documentation**
  * Updated API, OpenAPI, and CLI references with agent metadata and filtering details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->