### PR TITLE
docs(demo): add Claude-to-Rho cross-agent handoff

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ The repository documentation is organized by the question a reader is asking.
 - [Capture terminal work](guides/terminal-capture.md)
 - [Debug with previous evidence](guides/debugging.md)
 - [Connect a coding agent](guides/agent-memory.md)
+- [Hand off memory between agents](guides/cross-agent-handoff.md)
 - [Move memory between machines](guides/multi-machine.md)
 
 ## Reference: what is the exact interface?

--- a/docs/guides/agent-memory.md
+++ b/docs/guides/agent-memory.md
@@ -1,5 +1,7 @@
 # Connect a coding agent
 
+For a deterministic Claude-to-Rho handoff walkthrough, see [Cross-agent handoff](cross-agent-handoff.md).
+
 MemoryWhale exposes local memory through the stdio MCP server `mw-mcp`, and
 through `POST /mcp` on `mw-serve` (one JSON-RPC object per request). Use the
 [generic MCP contract](../../integrations/generic-mcp/README.md) or a verified

--- a/docs/guides/cross-agent-handoff.md
+++ b/docs/guides/cross-agent-handoff.md
@@ -45,8 +45,8 @@ scripts/agent-handoff-demo.sh
 The script creates a temporary data directory, runs the Claude hook parser with
 `tests/fixtures/agent-handoff/claude-post-tool-use-failure.json`, verifies the
 stored/searchable `agent:claude` result, records a separate terminal command,
-and sends `server/discover`, `tools/list`, and `search_memory` requests to the
-actual `mw-mcp` binary as a Rho client.
+and sends Rho's legacy `initialize`, `notifications/initialized`, `tools/list`,
+and `search_memory` requests to the actual `mw-mcp` binary.
 
 Expected output includes:
 

--- a/docs/guides/cross-agent-handoff.md
+++ b/docs/guides/cross-agent-handoff.md
@@ -43,18 +43,21 @@ scripts/agent-handoff-demo.sh
 ```
 
 The script creates a temporary data directory, runs the Claude hook parser with
-`tests/fixtures/agent-handoff/claude-post-tool-use-failure.json`, verifies the
-stored/searchable `agent:claude` result, records a separate terminal command,
-and sends Rho's legacy `initialize`, `notifications/initialized`, `tools/list`,
-and `search_memory` requests to the actual `mw-mcp` binary.
+both `tests/fixtures/agent-handoff/claude-post-tool-use-failure.json` and
+`tests/fixtures/agent-handoff/claude-post-tool-use-success.json`, verifies the
+stored/searchable `agent:claude` failure and fix, records a separate terminal
+command, and sends Rho's legacy `initialize`, `notifications/initialized`,
+`tools/list`, and `search_memory` requests to the actual `mw-mcp` binary.
 
 Expected output includes:
 
 ```text
-captured and searchable as agent:claude
+failure captured and searchable as agent:claude
+fix retained with Claude provenance
 terminal-only command remains terminal-attributed
-Rho retrieved Claude's prior failure from the shared store
-Agent handoff complete: Claude captured the failure; Rho found it without rediscovery.
+Rho completed initialize → initialized → tools/list → search_memory
+Rho retrieved Claude's failure and verified fix from the shared store
+Agent handoff complete: Claude captured the failure and fix; Rho found both without rediscovery.
 ```
 
 The script defaults to `target/debug` binaries. Override them when testing a

--- a/docs/guides/cross-agent-handoff.md
+++ b/docs/guides/cross-agent-handoff.md
@@ -1,0 +1,86 @@
+# Cross-agent handoff: Claude to Rho
+
+This walkthrough demonstrates the Agent-Native Memory flow shipped for
+MemoryWhale 0.10. It is deterministic and offline: the Claude event is a
+checked-in fixture, while the Rho step uses the real `mw-mcp` stdio protocol.
+No model provider, API key, network connection, or real MemoryWhale database is
+needed.
+
+## What it demonstrates
+
+```text
+Claude Bash failure
+    ↓ verified Claude hook
+MemoryWhale: agent=claude
+    ↓ shared local SQLite store
+Rho search_memory(agent=claude)
+    ↓ real mw-mcp protocol
+Rho retrieves Claude's prior evidence
+```
+
+Normal terminal activity remains separate:
+
+```text
+Claude hook capture       agent=claude
+ordinary terminal command agent=terminal
+```
+
+MCP access alone does not capture commands. The agent-specific capture hook is
+the part that records the Claude event.
+
+## Run the offline demo
+
+Build the CLI helpers from the repository root:
+
+```bash
+cargo build -p memorywhale-cli --bins
+```
+
+Run:
+
+```bash
+scripts/agent-handoff-demo.sh
+```
+
+The script creates a temporary data directory, runs the Claude hook parser with
+`tests/fixtures/agent-handoff/claude-post-tool-use-failure.json`, verifies the
+stored/searchable `agent:claude` result, records a separate terminal command,
+and sends `server/discover`, `tools/list`, and `search_memory` requests to the
+actual `mw-mcp` binary as a Rho client.
+
+Expected output includes:
+
+```text
+captured and searchable as agent:claude
+terminal-only command remains terminal-attributed
+Rho retrieved Claude's prior failure from the shared store
+Agent handoff complete: Claude captured the failure; Rho found it without rediscovery.
+```
+
+The script defaults to `target/debug` binaries. Override them when testing a
+release build:
+
+```bash
+MW_BIN=target/release/mw \
+MW_REMEMBER_BIN=target/release/mw-remember \
+MW_MCP_BIN=target/release/mw-mcp \
+scripts/agent-handoff-demo.sh
+```
+
+## Use real integrations
+
+For real local clients, install the verified integrations first:
+
+```bash
+mw integrate claude
+mw integrate rho
+```
+
+Then start each client with access to the same local data directory. Use
+`mw doctor` to check MCP, automatic capture, and skill status independently.
+The exact provider/model can vary; the durable handoff contract is the shared
+local store and the structured agent provenance.
+
+Do not commit real hook payloads, transcripts, API keys, personal paths, or
+provider output. Use the sanitized fixture and temporary data directory for
+repeatable documentation and CI.

--- a/scripts/agent-handoff-demo.sh
+++ b/scripts/agent-handoff-demo.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Offline Claude -> MemoryWhale -> Rho handoff demonstration.
+#
+# The Claude event is a fixture rather than a live agent call. Rho is exercised
+# through the real mw-mcp stdio protocol, so this demo is deterministic and does
+# not require provider credentials, network access, or a user's real database.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mw_bin="${MW_BIN:-$root/target/debug/mw}"
+remember_bin="${MW_REMEMBER_BIN:-$root/target/debug/mw-remember}"
+mcp_bin="${MW_MCP_BIN:-$root/target/debug/mw-mcp}"
+fixture="$root/tests/fixtures/agent-handoff/claude-post-tool-use-failure.json"
+
+for binary in "$mw_bin" "$remember_bin" "$mcp_bin"; do
+  if [[ ! -x "$binary" ]]; then
+    echo "missing executable: $binary" >&2
+    echo "build with: cargo build -p memorywhale-cli --bins" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -r "$fixture" ]]; then
+  echo "missing fixture: $fixture" >&2
+  exit 1
+fi
+
+data_dir="$(mktemp -d "${TMPDIR:-/tmp}/memorywhale-agent-handoff.XXXXXX")"
+trap 'rm -rf "$data_dir"' EXIT
+
+run_mw() {
+  MEMORYWHALE_DATA_DIR="$data_dir" "$mw_bin" "$@"
+}
+
+run_remember() {
+  MEMORYWHALE_DATA_DIR="$data_dir" "$remember_bin" "$@"
+}
+
+echo "1. Claude's Bash failure is captured by the verified Claude hook"
+run_remember --from-hook claude < "$fixture" >/dev/null
+
+claude_results="$(run_mw search "linker error" agent:claude)"
+grep -Fq '[command · claude]' <<<"$claude_results"
+grep -Fq 'linker error' <<<"$claude_results"
+echo "   captured and searchable as agent:claude"
+
+echo "2. An unrelated terminal command is not attributed to Claude"
+run_remember \
+  --cwd /tmp/memorywhale-agent-handoff \
+  --exit-code 0 \
+  --stdout 'terminal-only handoff sentinel' \
+  -- terminal-only-command >/dev/null
+claude_filtered="$(run_mw search 'terminal-only handoff sentinel' agent:claude)"
+if grep -Fq 'terminal-only-command' <<<"$claude_filtered"; then
+  echo "agent:claude unexpectedly included a terminal-only command" >&2
+  exit 1
+fi
+terminal_results="$(run_mw search 'terminal-only handoff sentinel' agent:terminal)"
+grep -Fq '[command · terminal]' <<<"$terminal_results"
+grep -Fq 'terminal-only-command' <<<"$terminal_results"
+echo "   terminal-only command remains terminal-attributed"
+
+echo "3. Rho searches the same local store through MCP"
+meta='{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"Rho","version":"handoff-demo"},"io.modelcontextprotocol/clientCapabilities":{}}'
+rho_results="$(
+  {
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"server/discover\",\"params\":{\"_meta\":$meta}}"
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{\"_meta\":$meta}}"
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"search_memory\",\"arguments\":{\"query\":\"linker error\",\"agent\":\"claude\"},\"_meta\":$meta}}"
+  } | MEMORYWHALE_DATA_DIR="$data_dir" "$mcp_bin"
+)"
+grep -Fq '"id":3' <<<"$rho_results"
+grep -Fq '"isError":false' <<<"$rho_results"
+grep -Fq 'agent: claude' <<<"$rho_results"
+grep -Fq 'linker error' <<<"$rho_results"
+echo "   Rho retrieved Claude's prior failure from the shared store"
+
+echo
+echo "Agent handoff complete: Claude captured the failure; Rho found it without rediscovery."

--- a/scripts/agent-handoff-demo.sh
+++ b/scripts/agent-handoff-demo.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Offline Claude -> MemoryWhale -> Rho handoff demonstration.
 #
-# The Claude event is a fixture rather than a live agent call. Rho is exercised
+# The Claude events are fixtures rather than live agent calls. Rho is exercised
 # through the real mw-mcp stdio protocol, so this demo is deterministic and does
 # not require provider credentials, network access, or a user's real database.
 set -euo pipefail
@@ -10,7 +10,8 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 mw_bin="${MW_BIN:-$root/target/debug/mw}"
 remember_bin="${MW_REMEMBER_BIN:-$root/target/debug/mw-remember}"
 mcp_bin="${MW_MCP_BIN:-$root/target/debug/mw-mcp}"
-fixture="$root/tests/fixtures/agent-handoff/claude-post-tool-use-failure.json"
+failure_fixture="$root/tests/fixtures/agent-handoff/claude-post-tool-use-failure.json"
+success_fixture="$root/tests/fixtures/agent-handoff/claude-post-tool-use-success.json"
 
 for binary in "$mw_bin" "$remember_bin" "$mcp_bin"; do
   if [[ ! -x "$binary" ]]; then
@@ -20,10 +21,12 @@ for binary in "$mw_bin" "$remember_bin" "$mcp_bin"; do
   fi
 done
 
-if [[ ! -r "$fixture" ]]; then
-  echo "missing fixture: $fixture" >&2
-  exit 1
-fi
+for fixture in "$failure_fixture" "$success_fixture"; do
+  if [[ ! -r "$fixture" ]]; then
+    echo "missing fixture: $fixture" >&2
+    exit 1
+  fi
+done
 
 data_dir="$(mktemp -d "${TMPDIR:-/tmp}/memorywhale-agent-handoff.XXXXXX")"
 trap 'rm -rf "$data_dir"' EXIT
@@ -36,15 +39,21 @@ run_remember() {
   MEMORYWHALE_DATA_DIR="$data_dir" "$remember_bin" "$@"
 }
 
-echo "1. Claude's Bash failure is captured by the verified Claude hook"
-run_remember --from-hook claude < "$fixture" >/dev/null
+echo "1. Claude's failing Bash command is captured by the verified Claude hook"
+run_remember --from-hook claude < "$failure_fixture" >/dev/null
+run_remember --from-hook claude < "$success_fixture" >/dev/null
 
 claude_results="$(run_mw search "linker error" agent:claude)"
 grep -Fq '[command · claude]' <<<"$claude_results"
 grep -Fq 'linker error' <<<"$claude_results"
-echo "   captured and searchable as agent:claude"
+echo "   failure captured and searchable as agent:claude"
 
-echo "2. An unrelated terminal command is not attributed to Claude"
+echo "2. Claude's verified fix is retained as agent-attributed evidence"
+fix_results="$(run_mw search 'cuda' agent:claude)"
+grep -Fq 'fix: rerun without --features cuda' <<<"$fix_results"
+echo "   fix retained with Claude provenance"
+
+echo "3. An unrelated terminal command is not attributed to Claude"
 run_remember \
   --cwd /tmp/memorywhale-agent-handoff \
   --exit-code 0 \
@@ -60,20 +69,28 @@ grep -Fq '[command · terminal]' <<<"$terminal_results"
 grep -Fq 'terminal-only-command' <<<"$terminal_results"
 echo "   terminal-only command remains terminal-attributed"
 
-echo "3. Rho searches the same local store through MCP"
-meta='{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"Rho","version":"handoff-demo"},"io.modelcontextprotocol/clientCapabilities":{}}'
+echo "4. Rho performs its real legacy MCP handshake and searches the shared store"
+# Rho's streamable_http client starts with the legacy initialize lifecycle.
+# Keep this sequence explicit so the demo catches regressions in handshake,
+# notifications, tools/list, or tools/call handling.
 rho_results="$(
   {
-    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"server/discover\",\"params\":{\"_meta\":$meta}}"
-    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{\"_meta\":$meta}}"
-    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"search_memory\",\"arguments\":{\"query\":\"linker error\",\"agent\":\"claude\"},\"_meta\":$meta}}"
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"Rho","version":"handoff-demo"}}}'
+    printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'
+    printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+    printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"search_memory","arguments":{"query":"cuda","agent":"claude"}}}'
   } | MEMORYWHALE_DATA_DIR="$data_dir" "$mcp_bin"
 )"
+grep -Fq '"id":1' <<<"$rho_results"
+grep -Fq '"protocolVersion":"2025-11-25"' <<<"$rho_results"
+grep -Fq '"id":2' <<<"$rho_results"
+grep -Fq '"search_memory"' <<<"$rho_results"
 grep -Fq '"id":3' <<<"$rho_results"
-grep -Fq '"isError":false' <<<"$rho_results"
+grep -Fq '"type":"text"' <<<"$rho_results"
 grep -Fq 'agent: claude' <<<"$rho_results"
-grep -Fq 'linker error' <<<"$rho_results"
-echo "   Rho retrieved Claude's prior failure from the shared store"
+grep -Fq 'fix: rerun without --features cuda' <<<"$rho_results"
+echo "   Rho completed initialize → initialized → tools/list → search_memory"
+echo "   Rho retrieved Claude's failure and verified fix from the shared store"
 
 echo
-echo "Agent handoff complete: Claude captured the failure; Rho found it without rediscovery."
+echo "Agent handoff complete: Claude captured the failure and fix; Rho found both without rediscovery."

--- a/tests/fixtures/agent-handoff/claude-post-tool-use-failure.json
+++ b/tests/fixtures/agent-handoff/claude-post-tool-use-failure.json
@@ -1,0 +1,11 @@
+{
+  "hook_event_name": "PostToolUseFailure",
+  "tool_name": "Bash",
+  "cwd": "/tmp/memorywhale-agent-handoff",
+  "tool_input": {
+    "command": "cargo test -p demo --features cuda"
+  },
+  "error": {
+    "message": "linker error: cannot find -lcudart"
+  }
+}

--- a/tests/fixtures/agent-handoff/claude-post-tool-use-success.json
+++ b/tests/fixtures/agent-handoff/claude-post-tool-use-success.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PostToolUse",
+  "tool_name": "Bash",
+  "cwd": "/tmp/memorywhale-agent-handoff",
+  "tool_input": {
+    "command": "cargo test -p demo --no-default-features # fix: rerun without --features cuda"
+  },
+  "tool_response": {
+    "stdout": "cargo test passed",
+    "stderr": ""
+  }
+}


### PR DESCRIPTION
Implements issue #249 as a deterministic offline demo.

## Flow

- feeds a sanitized `PostToolUseFailure` Claude fixture through the real `mw-remember --from-hook claude` path;
- verifies the failure is stored/searchable with `agent:claude`;
- records an unrelated manual terminal command and verifies it remains `agent:terminal` and is excluded from Claude-filtered results;
- sends real modern `server/discover`, `tools/list`, and `tools/call search_memory` requests to `mw-mcp` as a Rho client, filtering for Claude evidence;
- uses only a temporary data directory, no model provider, API key, network, or real user database.

## Docs

Adds `docs/guides/cross-agent-handoff.md`, links it from the docs index and agent-memory guide, and documents real integration setup plus safe fixture practices.

## Verification

- `shellcheck scripts/agent-handoff-demo.sh`
- `cargo build -p memorywhale-cli --bins`
- `scripts/agent-handoff-demo.sh`
- `bash scripts/check-doc-references.sh`
- `git diff --check`

The demo depends on merged structured provenance (#247/#256) and interface support (#248/#257).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guide explaining how to hand off memory between agents using a deterministic, offline workflow.
  * Linked the new cross-agent handoff guide from the documentation index and agent memory guide.
  * Documented build instructions, expected results, configuration options, and real-integration setup.

* **Tests**
  * Added an automated demonstration validating agent-specific event capture, shared memory retrieval, and separation from regular terminal activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->