### PR TITLE
ci: fix invalid runner context in memory-audit workflow

### DIFF
--- a/.github/workflows/memory-audit.yml
+++ b/.github/workflows/memory-audit.yml
@@ -10,8 +10,6 @@ jobs:
   memory-audit:
     name: Audit and search memory
     runs-on: ubuntu-latest
-    env:
-      MEMORYWHALE_DATA_DIR: ${{ runner.temp }}/memorywhale
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -23,12 +21,16 @@ jobs:
         run: cargo build --locked --release -p memorywhale-cli --bins
 
       - name: Run privacy audit
+        env:
+          MEMORYWHALE_DATA_DIR: ${{ runner.temp }}/memorywhale
         run: |
           mkdir -p "$MEMORYWHALE_DATA_DIR"
           target/release/mw audit
 
       - name: Verify memory capture and retrieval
         shell: bash
+        env:
+          MEMORYWHALE_DATA_DIR: ${{ runner.temp }}/memorywhale
         run: |
           set -euo pipefail
           mkdir -p "$MEMORYWHALE_DATA_DIR"


### PR DESCRIPTION
## Problem

The `Memory audit` workflow has failed instantly on every event since it was added in #136 — 0-second runs, no jobs, no logs — and GitHub lists it by file path (`.github/workflows/memory-audit.yml`) instead of its display name.

GitHub's parse error on the failed runs:

```
Invalid workflow file: .github/workflows/memory-audit.yml#L1
(Line: 14, Col: 29): Unrecognized named-value: 'runner'.
Located at position 1 within expression: runner.temp
```

The `runner` context is not available in job-level `env:`, so the workflow file is invalid. GitHub creates a phantom failed run on **every push to any branch** while the file stays invalid, which is why red X marks keep appearing across the repo.

## Fix

Move `MEMORYWHALE_DATA_DIR` from job-level `env:` into the two steps that consume it. Step-level `env:` supports the `runner` context, and both steps already reference `$MEMORYWHALE_DATA_DIR` in their `run` blocks, so no other changes are needed.

## Verification

- YAML parses and the job no longer declares job-level `env`
- Both `Run privacy audit` and `Verify memory capture and retrieval` steps now carry the variable
- Once merged, the workflow should register under its real name and the phantom push failures stop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated privacy audit workflow configuration to apply the memory data directory setting directly to the relevant verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->