### PR TITLE
docs(rho): explain the autonomous memory loop

### DIFF
--- a/docs/guides/agent-memory.md
+++ b/docs/guides/agent-memory.md
@@ -18,3 +18,35 @@ verified client-specific hook and is called out separately in the matrix.
 
 Agent-authored lessons can influence later retrieval. Review provenance and
 confirmation state before treating a conclusion as established evidence.
+
+
+## Next step: an autonomous failure-to-fix loop
+
+The current integration provides MCP tools, a Rho skill, and a limited capture
+hook. The skill can suggest memory use, but the most useful next step for
+MemoryWhale is making that loop reliable and evidence-first:
+
+1. **Retrieve relevant memory when a task starts.** Use the project and the
+   user's request to find a few relevant past fixes and supply them to Rho.
+   Keep a small context budget so memory does not overwhelm the task.
+2. **Look up failures automatically.** When a command fails, search for matching
+   previous failures and show Rho any supported fix. Deduplicate repeated errors
+   so the same failure is not searched on every retry.
+3. **Save lessons after verification.** When a failed command succeeds after a
+   change, propose a memory containing the failure, change, and successful
+   verification. Record observed results automatically, but mark the model's
+   explanation as unverified unless the evidence supports it.
+4. **Preserve useful findings before compaction.** Save unresolved problems,
+   verified fixes, and relevant evidence before Rho summarizes its conversation.
+   Retrieve those memories when needed afterward.
+
+The target flow is:
+
+```text
+failure → retrieve prior evidence → verify a fix → remember the result
+```
+
+Full command and output capture would strengthen this loop. The current Rho
+hook payload is intentionally limited, so MemoryWhale must not imply that every
+agent command was captured. MCP access, command capture, and memory-use guidance
+remain separate capabilities until a future integration closes that boundary.

--- a/docs/guides/agent-memory.md
+++ b/docs/guides/agent-memory.md
@@ -20,25 +20,37 @@ Agent-authored lessons can influence later retrieval. Review provenance and
 confirmation state before treating a conclusion as established evidence.
 
 
-## Next step: an autonomous failure-to-fix loop
+## Roadmap: an autonomous failure-to-fix loop
 
 The current integration provides MCP tools, a Rho skill, and a limited capture
-hook. The skill can suggest memory use, but the most useful next step for
-MemoryWhale is making that loop reliable and evidence-first:
+hook. This section is a shared roadmap, not a claim that those surfaces already
+automate a Rho turn. The skill can suggest memory use, but it cannot currently
+inject memory into a turn, and the observational hook cannot provide a
+pre-compaction callback.
 
-1. **Retrieve relevant memory when a task starts.** Use the project and the
-   user's request to find a few relevant past fixes and supply them to Rho.
-   Keep a small context budget so memory does not overwhelm the task.
-2. **Look up failures automatically.** When a command fails, search for matching
-   previous failures and show Rho any supported fix. Deduplicate repeated errors
-   so the same failure is not searched on every retry.
-3. **Save lessons after verification.** When a failed command succeeds after a
-   change, propose a memory containing the failure, change, and successful
-   verification. Record observed results automatically, but mark the model's
-   explanation as unverified unless the evidence supports it.
-4. **Preserve useful findings before compaction.** Save unresolved problems,
-   verified fixes, and relevant evidence before Rho summarizes its conversation.
-   Retrieve those memories when needed afterward.
+MemoryWhale owns the generic evidence boundary: capture the data a client
+actually provides, retrieve relevant memories, preserve provenance, persist
+observed results, and expose those capabilities through MCP. Rho (or another
+client) must own task lifecycle orchestration, model-context injection, failure
+notifications, and pre-compaction callbacks. Those client-side seams are
+required before the following loop can be automatic:
+
+1. **Retrieve relevant memory when a task starts.** A client-side task-start
+   hook should combine the project and the user's request, ask MemoryWhale for a
+   few relevant past fixes, and supply them to Rho. Keep a small context budget
+   so memory does not overwhelm the task.
+2. **Look up failures automatically.** A client-side failure event should let
+   MemoryWhale search matching previous failures and return any supported fix.
+   Deduplicate repeated errors so the same failure is not searched on every
+   retry.
+3. **Save lessons after verification.** After a failed command succeeds following
+   a change, the client should propose a memory containing the failure, change,
+   and successful verification. MemoryWhale can record observed results, but the
+   model's explanation must remain unverified unless the evidence supports it.
+4. **Preserve useful findings before compaction.** A client-side pre-compaction
+   callback should save unresolved problems, verified fixes, and relevant
+   evidence before Rho summarizes its conversation, then retrieve those memories
+   when needed afterward.
 
 The target flow is:
 
@@ -46,7 +58,18 @@ The target flow is:
 failure → retrieve prior evidence → verify a fix → remember the result
 ```
 
-Full command and output capture would strengthen this loop. The current Rho
-hook payload is intentionally limited, so MemoryWhale must not imply that every
-agent command was captured. MCP access, command capture, and memory-use guidance
-remain separate capabilities until a future integration closes that boundary.
+### Integration boundary and prerequisites
+
+| Responsibility | Owner | Current state |
+| --- | --- | --- |
+| Capture, redaction, provenance, persistence, and retrieval | MemoryWhale | Available through the existing client-specific paths and MCP |
+| Task-start context injection | Rho or another client | Requires a lifecycle hook or explicit client orchestration |
+| Failure-triggered lookup | Rho or another client | Requires a failure event that can invoke MCP without duplicate retries |
+| Verified-fix proposal | Rho/client plus MemoryWhale | Can be built from observed command outcomes and explicit confirmation |
+| Pre-compaction preservation | Rho or another client | Requires a documented pre-compaction callback |
+
+Full command and output capture would strengthen the loop. The current Rho hook
+payload is intentionally limited, so MemoryWhale must not imply that every Rho
+command was captured. MCP access, command capture, and memory-use guidance
+remain separate capabilities until the client-side lifecycle boundaries are
+available.

--- a/integrations/rho/README.md
+++ b/integrations/rho/README.md
@@ -5,6 +5,11 @@ independent ways: `mw-mcp` provides native memory tools, an `after_tool_use`
 hook records bash and powershell calls when the payload includes them, and a
 skill teaches Rho when to search or save debugging memory.
 
+Rho is a separate open-source coding-agent project that MemoryWhale's maintainer
+actively uses and contributes to. That hands-on experience led to
+MemoryWhale's dedicated Rho integration, which supports MCP memory access,
+optional command-capture hooks, and memory-use guidance through a Rho skill.
+
 ## Status
 
 Verified against Rho's [hooks](https://matthewyjiang.github.io/rho/hooks),


### PR DESCRIPTION
Clarifies the relationship between the separate Rho project and MemoryWhale\x27s dedicated integration, then documents the next evidence-first autonomy target for MemoryWhale.

## Added

- Maintainer context for the Rho integration.
- Current boundary: MCP tools, Rho skill, and limited capture hook are separate capabilities.
- Proposed failure → retrieve → verify → remember loop.
- Four priorities: task-start retrieval, automatic failure lookup, verified-fix lesson proposals, and pre-compaction preservation.
- Explicit warning not to imply that every Rho command is captured.

This is documentation-only and does not change capture or retrieval behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for an autonomous failure-to-fix workflow, including retrieving prior evidence, verifying fixes, recording lessons, and preserving findings.
  - Clarified which capabilities are available separately, including MCP memory access, command capture, and memory-use guidance.
  - Expanded the Rho integration overview with context on its practical use and supported memory-related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->