### PR TITLE
chore(homebrew): publish MemoryWhale 0.10.0

### DIFF
--- a/Formula/memorywhale.rb
+++ b/Formula/memorywhale.rb
@@ -9,8 +9,8 @@
 class Memorywhale < Formula
   desc "Local-first terminal memory: record commands, sessions, and output into SQLite"
   homepage "https://github.com/wuisabel-gif/MemWhale"
-  url "https://github.com/wuisabel-gif/MemWhale/archive/refs/tags/v0.9.0.tar.gz"
-  sha256 "bba326bdf026835b2ff691bdd0bc76db2eea69c2b563413e0850d57fd69ded00"
+  url "https://github.com/wuisabel-gif/MemWhale/archive/refs/tags/v0.10.0.tar.gz"
+  sha256 "3300fa7a73c07ae866812e396b6551ae62d48a5508e35f65de83eba9bfca929e"
   license "MIT"
   head "https://github.com/wuisabel-gif/MemWhale.git", branch: "main"
 


### PR DESCRIPTION
Completes the 0.10.0 release (#243, #263).

- Points Homebrew at the verified v0.10.0 source archive.
- SHA-256 independently downloaded and checked: `3300fa7a73c07ae866812e396b6551ae62d48a5508e35f65de83eba9bfca929e`.
- Release workflow and all four platform artifacts passed; core 0.5.0 and CLI 0.10.0 are published on crates.io.
- A local Homebrew build/install/test is being run against this exact formula before merge.

The automation pushed this branch but repository policy does not permit its token to open PRs, so this PR is created with maintainer authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MemoryWhale CLI package to version 0.10.0.
  * Updated the associated release archive reference and verification checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->