### PR TITLE
docs(i18n): add French README

### DIFF
--- a/.github/workflows/readme-localization.yml
+++ b/.github/workflows/readme-localization.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - README.md
+      - README.fr.md
       - README.zh-CN.md
       - README.zh-TW.md
       - README.ko.md
@@ -15,6 +16,7 @@ on:
   pull_request:
     paths:
       - README.md
+      - README.fr.md
       - README.zh-CN.md
       - README.zh-TW.md
       - README.ko.md
@@ -93,7 +95,7 @@ jobs:
         id: changes
         shell: bash
         run: |
-          if git diff --quiet -- README.zh-CN.md README.zh-TW.md README.ko.md README.ja.md; then
+          if git diff --quiet -- README.fr.md README.zh-CN.md README.zh-TW.md README.ko.md README.ja.md; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -108,12 +110,13 @@ jobs:
           source_sha="$(sha256sum README.md | cut -d' ' -f1)"
           branch="automation/readme-localizations-${source_sha:0:12}"
           title="docs(i18n): synchronize localized READMEs"
+          # shellcheck disable=SC2016 # Markdown backticks are literal, not shell substitutions.
           printf -v body 'Automated translations for README.md source hash `%s`.\n\nGenerated through the configured translation provider and validated for headings, HTML, code, commands, links, and images. Human language review is required before merge.' "$source_sha"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$branch"
-          git add README.zh-CN.md README.zh-TW.md README.ko.md README.ja.md
+          git add README.fr.md README.zh-CN.md README.zh-TW.md README.ko.md README.ja.md
           git commit -m "$title"
 
           if git ls-remote --exit-code --heads origin "$branch" >/dev/null; then

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,219 @@
+<!-- README-SOURCE-SHA256: 0c0dee340943c6650cc58749d96cb86c7728e6fc31cef1f4daba0be190a01965 -->
+
+<p align="center">
+  <img src="assets/memorywhale-logo-sm.png" alt="Logo de MemoryWhale" width="160" />
+</p>
+
+<h1 align="center">MemoryWhale</h1>
+
+<p align="center"><strong>Une mémoire locale et persistante pour le débogage, pensée pour les développeurs et les agents de code.</strong></p>
+
+<p align="center"><a href="README.md">English README</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+
+<p align="center">
+  <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>
+  <a href="https://github.com/wuisabel-gif/MemWhale/releases"><img src="https://img.shields.io/github/v/release/wuisabel-gif/MemWhale?color=2b43dd&label=release" alt="release"/></a>
+  <a href="https://crates.io/crates/memorywhale-cli"><img src="https://img.shields.io/crates/v/memorywhale-cli?color=2b43dd&label=crates.io" alt="crates.io"/></a>
+  <img src="https://img.shields.io/badge/license-MIT-2b43dd" alt="licence MIT"/>
+  <img src="https://img.shields.io/badge/local--first-no%20upload-168a69" alt="local-first, aucun envoi de données"/>
+</p>
+
+MemoryWhale enregistre ce qui s’est réellement passé pendant vos sessions de
+débogage : les commandes, leurs sorties, les erreurs rencontrées et les
+correctifs qui ont fonctionné. Toutes ces informations sont conservées dans une
+base SQLite locale afin que vous et vos agents de code puissiez les retrouver,
+même une fois le terminal, la connexion SSH ou la session de l’agent terminés.
+
+**MemoryWhale 0.10.0 — Agent-Native Memory · 6 septembre 2026.**
+Le CLI, l’interface web et l’application de bureau partagent la version 0.10.0
+du produit ; le cœur Rust réutilisable est en version 0.5.0. Consultez les
+[notes de version](https://github.com/wuisabel-gif/MemWhale/blob/v0.10.0/docs/releases/0.10.0.md)
+pour le guide de mise à niveau et les détails concernant la modification
+incompatible de l’API Rust.
+
+## Pourquoi MemoryWhale ?
+
+- **Gardez une trace de ce qui s’est réellement passé.** Conservez la commande,
+  l’environnement, la sortie, l’erreur et la leçon à en tirer — pas seulement une
+  ligne dans l’historique du shell.
+- **Partagez une même mémoire entre vos agents de code.** Tout client MCP stdio
+  compatible peut lire et écrire dans la même mémoire locale via `mw-mcp`.
+- **Gardez votre historique de développement en local.** MemoryWhale fonctionne
+  sans compte, sans service hébergé et sans facturation de la mémoire au nombre
+  de tokens.
+
+MemoryWhale mémorise votre expérience de développement, pas tout ce que vous
+faites. Il s’agit d’une couche de mémoire dédiée au débogage, et non d’un agent
+de code autonome, d’un système de mémoire personnelle généraliste ou d’un
+substitut à la documentation de vos projets.
+
+## Nouveautés d’Agent-Native Memory
+
+- **Connectez et inspectez vos agents.** Installez l’accès MCP pour Claude Code
+  ou Rho, les hooks de capture et les consignes d’utilisation de la mémoire avec
+  `mw integrate` ; `mw doctor` vérifie séparément MCP, les hooks et les skills.
+- **Gardez une provenance explicite.** Le schéma 10 enregistre l’agent à
+  l’origine d’une commande sous la forme `claude`, `rho` ou `NULL`. Le libellé
+  d’affichage et de filtrage `terminal` désigne une provenance terminal/manuelle
+  ou historique ; il ne prouve pas qu’un humain a exécuté la commande.
+  L’identité de l’agent est distincte du type de source, par exemple `command`,
+  `session` ou `note`.
+- **Partagez un dépôt tout en distinguant les worktrees.** Les identifiants
+  canoniques de dépôt regroupent les worktrees liés tout en conservant la racine
+  propre à chacun et les tags de projet existants. La détection repose sur les
+  métadonnées Git locales, et non sur un service distant.
+- **Utilisez des interfaces locales.** `mw-serve` expose MCP en HTTP via
+  `POST /mcp` ; `mw-serve --api` active explicitement l’API JSON en lecture seule.
+  Les deux utilisent le listener du dashboard ; tout accès hors loopback
+  nécessite un token.
+- **Récupérez explicitement le contexte GitHub.** `mw github context <pr>`
+  récupère les métadonnées d’une PR, ses checks et ses reviews à l’aide de votre
+  session `gh` existante. La commande affiche un contexte limité et expurgé des
+  données sensibles, sans checkout du code ni enregistrement automatique dans
+  la mémoire. Aucune synchronisation GitHub ne s’exécute en arrière-plan.
+
+## Installation
+
+Des binaires précompilés sont disponibles pour Linux x86_64/aarch64 et macOS :
+
+```bash
+(
+  set -eu
+  installer="$(mktemp)"
+  trap 'rm -f "$installer"' EXIT
+  curl -fsSL https://raw.githubusercontent.com/wuisabel-gif/MemWhale/7c3864c743cec9a8fa813dcc0b2459cc2859c849/install.sh -o "$installer"
+  printf '%s  %s\n' '3e0cad72b29c1894d5ff5f7c30b099537f96501801c14b6320c12e169a3ac8d6' "$installer" | shasum -a 256 -c -
+  sh "$installer"
+)
+```
+
+Vous pouvez également l’installer avec Cargo ou Homebrew :
+
+```bash
+cargo install memorywhale-cli
+
+brew tap wuisabel-gif/memorywhale https://github.com/wuisabel-gif/MemWhale
+brew install memorywhale
+```
+
+Après l’installation ou une mise à niveau, vérifiez la version et la
+configuration locale :
+
+```bash
+mw --version
+mw doctor
+```
+
+Sous Windows, MemoryWhale peut être utilisé via
+[WSL](https://learn.microsoft.com/windows/wsl/). Consultez le
+[guide de démarrage](docs/guides/getting-started.md) pour l’installation des
+paquets, la configuration du PATH et les remarques propres à chaque plateforme.
+
+## Exemple en 60 secondes
+
+```bash
+mw global on                         # capture future interactive shell commands
+mw-run -- cargo check                # capture one command and its output
+mw remember "the linker needed libssl-dev"
+mw search "linker error"             # recover the failure and its fix
+mw context --last-error              # compact context for any agent or chat
+mw pet                               # check your memory store's mood
+```
+
+![Démonstration des humeurs de mw pet](assets/pet-demo.gif)
+
+Pour les sessions plus longues, `mw --live` enregistre une session shell de
+façon à résister aux crashs. `mw tui` ouvre un navigateur interactif dans le
+terminal, tandis que `mw-serve` démarre le dashboard web local.
+
+## Fonctionnement
+
+```text
+CAPTURE                 MEMORY                 RETRIEVAL
+shell / mw-run ──────► local SQLite ────────► search / context
+agent hooks ─────────► evidence + lessons ──► similar failures
+                                                   │
+                                              INTERFACES
+                                      CLI / MCP / TUI / Web / Desktop
+```
+
+La capture et la recherche sont indépendantes. MCP permet à un agent d’accéder
+à la mémoire existante ; il n’enregistre pas automatiquement l’activité normale
+du terminal. Consultez la documentation de
+[l’architecture](docs/architecture.md) et le
+[concept de capture](docs/concepts/capture.md) pour une présentation complète
+du modèle.
+
+## Fonctionne avec votre agent de code
+
+`mw-mcp` constitue le point d’intégration commun : il s’agit d’un serveur MCP
+stdio local qui expose six outils de mémoire, également accessibles en HTTP
+via `mw-serve`. Des guides sont disponibles pour Claude Code, Rho, Claude
+Desktop, Cursor, VS Code / GitHub Copilot, Windsurf, Zed, Codex CLI, Cline,
+Continue, Gemini CLI, Goose, OpenClaw, CrowClaw, Hermes Agent ainsi que d’autres
+clients compatibles.
+
+```bash
+mw integrate claude
+mw integrate rho
+mw doctor
+```
+
+Tous les clients n’offrent pas les mêmes fonctionnalités. MCP donne accès à la
+mémoire ; la capture automatique des commandes exécutées nécessite un hook
+spécifique au client. La [matrice d’intégration](integrations/README.md)
+distingue l’accès à la mémoire, la capture et les consignes d’utilisation de la
+mémoire, avec un lien vers chaque guide de configuration vérifié.
+
+Le payload actuel des hooks de Rho ne contient ni le texte de la commande ni
+stdout : les échecs peuvent être enregistrés sous forme de métadonnées avec
+une commande sentinelle ; les appels réussis sans texte de commande sont
+ignorés. La [démo de transfert entre agents](docs/guides/cross-agent-handoff.md)
+utilise des fixtures et un client Rho simulé avec un véritable serveur MCP ;
+elle ne repose ni sur des agents exécutés en conditions réelles ni sur un
+correctif Cargo vérifié.
+
+Le skill fourni indique à l’agent comment utiliser la mémoire ; il n’implémente
+pas automatiquement le rappel au démarrage d’une tâche, la recherche d’erreurs
+ou la sauvegarde avant compaction. Ces décisions de cycle de vie restent à la
+charge du client. Les leçons créées via MCP sont, par défaut, placées en attente
+de validation.
+
+## À qui s’adresse MemoryWhale ?
+
+MemoryWhale s’adresse aux développeurs dont le contexte de débogage se retrouve
+dispersé entre le scrollback du terminal, l’historique du shell, plusieurs
+machines et des sessions temporaires d’agents. Il est particulièrement utile
+si vous :
+
+- déboguez des builds, des dépendances, Git, des environnements ou des déploiements ;
+- utilisez des agents de code sur plusieurs sessions ou passez régulièrement d’un outil à l’autre ;
+- travaillez en SSH ou sur plusieurs machines de développement ;
+- souhaitez pouvoir retrouver facilement les erreurs récurrentes et leurs correctifs ;
+- préférez un stockage local à un service de mémoire hébergé.
+
+Consultez les [cas d’usage](docs/concepts/use-cases.md) pour découvrir chacun de
+ces scénarios de bout en bout, avec de vraies commandes.
+
+## Documentation
+
+- [Sommaire de la documentation](docs/README.md)
+- [Bien démarrer](docs/guides/getting-started.md)
+- [Référence de `mw pet`](docs/reference/pet.md)
+- [Capture du terminal](docs/guides/terminal-capture.md)
+- [Mémoire des agents](docs/guides/agent-memory.md)
+- [Référence du CLI](docs/reference/cli.md)
+- [API JSON locale](docs/reference/api.md)
+- [Référence MCP](docs/reference/mcp.md)
+- [Sécurité et modèle de menace local](docs/SECURITY.md)
+- [Écosystème](ECOSYSTEM.md) — Delphin, ContextGC et MemoryWhale
+- [Guides d’intégration et matrice des fonctionnalités](integrations/README.md)
+
+## Contribuer
+
+MemoryWhale accepte les contributions qui améliorent la capture, la
+conservation, la recherche ou le partage de l’expérience de développement.
+Consultez [CONTRIBUTING.md](CONTRIBUTING.md) pour connaître le périmètre du
+projet, les commandes de développement et la checklist des pull requests.
+
+Distribué sous [licence MIT](LICENSE).

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- README-SOURCE-SHA256: c177f5ebba1899016da1a16ac5f7382f2cb7c39b0d2b0a8cfa73aa0fccf46aec -->
+<!-- README-SOURCE-SHA256: 0c0dee340943c6650cc58749d96cb86c7728e6fc31cef1f4daba0be190a01965 -->
 
 <p align="center">
   <img src="assets/memorywhale-logo-sm.png" alt="MemoryWhale ロゴ" width="160" />
@@ -8,7 +8,7 @@
 
 <p align="center"><strong>開発者とコーディングエージェントのための、永続的なローカルデバッグメモリ。</strong></p>
 
-<p align="center"><a href="README.md">English README</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+<p align="center"><a href="README.md">English README</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
 
 <p align="center">
   <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,4 +1,4 @@
-<!-- README-SOURCE-SHA256: c177f5ebba1899016da1a16ac5f7382f2cb7c39b0d2b0a8cfa73aa0fccf46aec -->
+<!-- README-SOURCE-SHA256: 0c0dee340943c6650cc58749d96cb86c7728e6fc31cef1f4daba0be190a01965 -->
 
 <p align="center">
   <img src="assets/memorywhale-logo-sm.png" alt="MemoryWhale 로고" width="160" />
@@ -8,7 +8,7 @@
 
 <p align="center"><strong>개발자와 코딩 에이전트를 위한 지속적인 로컬 디버깅 메모리.</strong></p>
 
-<p align="center"><a href="README.md">English README</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+<p align="center"><a href="README.md">English README</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
 
 <p align="center">
   <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><strong>Persistent local debugging memory for developers and coding agents.</strong></p>
 
-<p align="center"><a href="README.md">English README</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+<p align="center"><a href="README.md">English README</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
 
 <p align="center">
   <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- README-SOURCE-SHA256: c177f5ebba1899016da1a16ac5f7382f2cb7c39b0d2b0a8cfa73aa0fccf46aec -->
+<!-- README-SOURCE-SHA256: 0c0dee340943c6650cc58749d96cb86c7728e6fc31cef1f4daba0be190a01965 -->
 
 <p align="center">
   <img src="assets/memorywhale-logo-sm.png" alt="MemoryWhale 标志" width="160" />
@@ -8,7 +8,7 @@
 
 <p align="center"><strong>为开发者和编程智能体提供持久化的本地调试记忆。</strong></p>
 
-<p align="center"><a href="README.md">English README</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+<p align="center"><a href="README.md">English README</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
 
 <p align="center">
   <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,4 +1,4 @@
-<!-- README-SOURCE-SHA256: c177f5ebba1899016da1a16ac5f7382f2cb7c39b0d2b0a8cfa73aa0fccf46aec -->
+<!-- README-SOURCE-SHA256: 0c0dee340943c6650cc58749d96cb86c7728e6fc31cef1f4daba0be190a01965 -->
 
 <p align="center">
   <img src="assets/memorywhale-logo-sm.png" alt="MemoryWhale 標誌" width="160" />
@@ -8,7 +8,7 @@
 
 <p align="center"><strong>為開發者與程式設計代理提供持久的本機除錯記憶。</strong></p>
 
-<p align="center"><a href="README.md">English README</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+<p align="center"><a href="README.md">English README</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
 
 <p align="center">
   <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>

--- a/scripts/sync-readme-locales.mjs
+++ b/scripts/sync-readme-locales.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 export const SOURCE_MARKER = "README-SOURCE-SHA256";
 export const LOCALES = [
+  { file: "README.fr.md", language: "French (fr)" },
   { file: "README.zh-CN.md", language: "Simplified Chinese (zh-CN)" },
   { file: "README.zh-TW.md", language: "Traditional Chinese (zh-TW)" },
   { file: "README.ko.md", language: "Korean (ko)" },


### PR DESCRIPTION
## Summary

- Add `README.fr.md` from the French translation supplied by the maintainer, preserving natural developer terms such as CLI, dashboard, hooks, worktrees, payload, stdout, skill, and pull requests.
- Restore Markdown headings, inline code, all documentation links, and the pet demo image lost from the pasted text; remove pasted link-placeholder artifacts.
- Keep fenced examples (including comments and the diagram), commands, URLs, and the installer checksum identical to the canonical English README, as required by the localization contract.
- Add French to the language selector in every README and refresh source hashes after that matching navigation edit.
- Register French in locale validation/translation and workflow path detection/staging. Explain an existing ShellCheck false-positive on literal Markdown backticks.

Related: #222. This adds the supplied translation; it does not claim an independent native-speaker review or close the broader translation-review task.

## Validation

- `npm run test:readme-locales` — all 22 tests pass, including the table-driven translation fixture across all five locales.
- `node scripts/sync-readme-locales.mjs --validate` and `--check` — all five locales pass.
- `bash scripts/check-doc-references.sh` — passes.
- Actionlint — passes for the localization workflow.
- All 27 local French README link/image targets exist; no pasted Unicode link-placeholder artifacts remain.
- `git diff --cached --check` — passes.

No application behavior or release versions changed. Kept separate from the contributor-onboarding initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a complete French translation of the README, including installation, usage, architecture, integrations, and contribution information.
  - Added French to the language navigation across the available README translations.
  - Updated translated README source references to reflect the latest documentation content.

- **Chores**
  - Updated localization synchronization to include the French README automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->