### PR TITLE
feat(i18n): add Arabic and German README and website

### DIFF
--- a/.github/workflows/readme-localization.yml
+++ b/.github/workflows/readme-localization.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - README.md
+      - README.ar.md
+      - README.de.md
       - README.fr.md
       - README.zh-CN.md
       - README.zh-TW.md
@@ -16,6 +18,8 @@ on:
   pull_request:
     paths:
       - README.md
+      - README.ar.md
+      - README.de.md
       - README.fr.md
       - README.zh-CN.md
       - README.zh-TW.md
@@ -95,7 +99,7 @@ jobs:
         id: changes
         shell: bash
         run: |
-          if git diff --quiet -- README.fr.md README.zh-CN.md README.zh-TW.md README.ko.md README.ja.md; then
+          if git diff --quiet -- README.ar.md README.de.md README.fr.md README.zh-CN.md README.zh-TW.md README.ko.md README.ja.md; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -116,7 +120,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$branch"
-          git add README.fr.md README.zh-CN.md README.zh-TW.md README.ko.md README.ja.md
+          git add README.ar.md README.de.md README.fr.md README.zh-CN.md README.zh-TW.md README.ko.md README.ja.md
           git commit -m "$title"
 
           if git ls-remote --exit-code --heads origin "$branch" >/dev/null; then

--- a/README.ar.md
+++ b/README.ar.md
@@ -1,0 +1,228 @@
+<!-- README-SOURCE-SHA256: 0a6b911696113a6221346fd4145b26a73f5a62493d8a8d34048d26a832c0c100 -->
+
+<div dir="rtl">
+
+<p align="center">
+  <img src="assets/memorywhale-logo-sm.png" alt="شعار MemoryWhale" width="160" />
+</p>
+
+<h1 align="center">MemoryWhale</h1>
+
+<p align="center"><strong>ذاكرة محلية ودائمة لتصحيح الأخطاء، للمطورين ووكلاء البرمجة.</strong></p>
+
+<p align="center" dir="ltr"><a href="README.md">English README</a> · <a href="README.ar.md" lang="ar">العربية</a> · <a href="README.de.md" lang="de">Deutsch</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+
+<p align="center">
+  <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="التكامل المستمر"/></a>
+  <a href="https://github.com/wuisabel-gif/MemWhale/releases"><img src="https://img.shields.io/github/v/release/wuisabel-gif/MemWhale?color=2b43dd&label=release" alt="الإصدار"/></a>
+  <a href="https://crates.io/crates/memorywhale-cli"><img src="https://img.shields.io/crates/v/memorywhale-cli?color=2b43dd&label=crates.io" alt="crates.io"/></a>
+  <img src="https://img.shields.io/badge/license-MIT-2b43dd" alt="رخصة MIT"/>
+  <img src="https://img.shields.io/badge/local--first-no%20upload-168a69" alt="محلي أولاً، دون رفع تلقائي"/>
+</p>
+
+يسجّل MemoryWhale ما حدث فعلاً أثناء تصحيح الأخطاء: الأوامر، ومخرجاتها،
+والإخفاقات، والإصلاحات التي نجحت. ويحتفظ بهذه الأدلة في قاعدة SQLite محلية
+لتتمكن أنت ووكلاء البرمجة من استرجاعها بعد إغلاق الطرفية أو انقطاع اتصال SSH
+أو انتهاء جلسة الوكيل.
+
+**MemoryWhale 0.10.0 — Agent-Native Memory · 6 سبتمبر 2026.**
+تشترك واجهة سطر الأوامر وواجهة الويب وتطبيق سطح المكتب في إصدار المنتج 0.10.0،
+أما نواة Rust القابلة لإعادة الاستخدام فإصدارها 0.5.0. راجع
+[ملاحظات الإصدار](https://github.com/wuisabel-gif/MemWhale/blob/v0.10.0/docs/releases/0.10.0.md)
+للاطلاع على دليل الترقية والتغيير غير المتوافق في واجهة Rust البرمجية.
+
+## لماذا MemoryWhale؟
+
+- **تذكّر ما حدث فعلاً.** احتفظ بالأمر والبيئة والمخرجات والخطأ والدرس المستفاد،
+  لا بمجرد سطر في سجل أوامر الصدفة.
+- **استخدم ذاكرة مشتركة بين وكلاء البرمجة.** يستطيع أي عميل متوافق مع MCP عبر
+  stdio القراءة من الذاكرة المحلية نفسها والكتابة فيها باستخدام `mw-mcp`.
+- **احتفظ بسجل التطوير محلياً.** يعمل MemoryWhale دون حساب أو خدمة مستضافة
+  أو رسوم على تخزين الذاكرة محسوبة بعدد الرموز.
+
+يسجّل MemoryWhale خبرة التطوير، وليس كل شيء. إنه طبقة ذاكرة لتصحيح الأخطاء،
+وليس وكيل برمجة مستقلاً أو نظاماً عاماً للذاكرة الشخصية أو بديلاً عن توثيق المشروع.
+
+## الجديد في Agent-Native Memory
+
+- **اربط الوكلاء وتحقق من إعدادهم.** ثبّت وصول MCP وخطافات التسجيل وإرشادات
+  استخدام الذاكرة لـ Claude Code أو Rho باستخدام `mw integrate`؛ ويفحص
+  `mw doctor` كلاً من MCP والخطافات والمهارات بصورة مستقلة.
+- **احتفظ بمصدر واضح للأدلة.** يخزّن مخطط قاعدة البيانات 10 هوية وكيل الأمر
+  بالقيم `claude` أو `rho` أو `NULL`. يشير وسم العرض والتصفية `terminal`
+  إلى تسجيل طرفي أو يدوي أو قديم، ولا يثبت أن إنساناً نفّذ الأمر. وهوية الوكيل
+  مستقلة عن نوع المصدر، مثل `command` أو `session` أو `note`.
+- **شارك المستودع مع التمييز بين أشجار العمل.** تجمع معرّفات المستودعات
+  الموحّدة أشجار العمل المرتبطة مع الحفاظ على جذر كل شجرة ووسوم المشروع الحالية.
+  تعتمد عملية الاكتشاف على بيانات Git الوصفية المحلية، لا على خدمة بعيدة.
+- **استخدم واجهات محلية.** يوفّر `mw-serve` واجهة MCP عبر HTTP عند
+  `POST /mcp`؛ ويُفعّل `mw-serve --api` واجهة JSON للقراءة فقط بصورة صريحة.
+  تستخدم الواجهتان مستمع لوحة التحكم نفسه، ويتطلب الوصول من خارج عنوان
+  الحلقة المحلية رمز مصادقة.
+- **استرجع سياق GitHub عند الطلب.** يقرأ `mw github context <pr>` بيانات
+  طلب الدمج وفحوصاته ومراجعاته باستخدام تسجيل الدخول الحالي في `gh`. ويعرض
+  سياقاً محدود الحجم مع تنقيح البيانات الحساسة التي يتعرف عليها، دون استخراج
+  الشيفرة من المستودع أو حفظ السياق تلقائياً في الذاكرة. لا توجد مزامنة GitHub
+  تعمل في الخلفية.
+
+## التثبيت
+
+تتوفر ملفات تنفيذية جاهزة لنظام Linux بمعماريتي x86_64 وaarch64 ولنظام macOS:
+
+<div dir="ltr">
+
+```bash
+(
+  set -eu
+  installer="$(mktemp)"
+  trap 'rm -f "$installer"' EXIT
+  curl -fsSL https://raw.githubusercontent.com/wuisabel-gif/MemWhale/7c3864c743cec9a8fa813dcc0b2459cc2859c849/install.sh -o "$installer"
+  printf '%s  %s\n' '3e0cad72b29c1894d5ff5f7c30b099537f96501801c14b6320c12e169a3ac8d6' "$installer" | shasum -a 256 -c -
+  sh "$installer"
+)
+```
+
+</div>
+
+أو ثبّته باستخدام Cargo أو Homebrew:
+
+<div dir="ltr">
+
+```bash
+cargo install memorywhale-cli
+
+brew tap wuisabel-gif/memorywhale https://github.com/wuisabel-gif/MemWhale
+brew install memorywhale
+```
+
+</div>
+
+بعد التثبيت أو الترقية، تحقّق من الإصدار والإعداد المحلي:
+
+<div dir="ltr">
+
+```bash
+mw --version
+mw doctor
+```
+
+</div>
+
+يمكن لمستخدمي Windows تشغيل MemoryWhale داخل
+[WSL](https://learn.microsoft.com/windows/wsl/). راجع
+[دليل البدء](docs/guides/getting-started.md) لمعرفة كيفية تثبيت الحزم وإعداد
+PATH والملاحظات الخاصة بكل منصة.
+
+## مثال في ستين ثانية
+
+<div dir="ltr">
+
+```bash
+mw global on                         # capture future interactive shell commands
+mw-run -- cargo check                # capture one command and its output
+mw remember "the linker needed libssl-dev"
+mw search "linker error"             # recover the failure and its fix
+mw context --last-error              # compact context for any agent or chat
+mw pet                               # check your memory store's mood
+```
+
+</div>
+
+![عرض توضيحي لحالات mw pet](assets/pet-demo.gif)
+
+للعمل لفترات أطول، يسجّل `mw --live` جلسة الصدفة مع الحفظ المستمر لتقليل
+فقدان البيانات عند التعطّل. ويفتح `mw tui` متصفحاً تفاعلياً داخل الطرفية،
+بينما يشغّل `mw-serve` لوحة التحكم المحلية على الويب.
+
+## كيف يعمل؟
+
+<div dir="ltr">
+
+```text
+CAPTURE                 MEMORY                 RETRIEVAL
+shell / mw-run ──────► local SQLite ────────► search / context
+agent hooks ─────────► evidence + lessons ──► similar failures
+                                                   │
+                                              INTERFACES
+                                      CLI / MCP / TUI / Web / Desktop
+```
+
+</div>
+
+التسجيل والاسترجاع وظيفتان مستقلتان. يمنح MCP الوكيل وصولاً إلى الذاكرة
+الموجودة؛ لكنه لا يسجّل نشاط الطرفية المعتاد تلقائياً. راجع
+[البنية المعمارية](docs/architecture.md) و[مفهوم التسجيل](docs/concepts/capture.md)
+لفهم النموذج كاملاً.
+
+## يعمل مع وكيل البرمجة الذي تستخدمه
+
+يمثّل `mw-mcp` نقطة التكامل المشتركة: خادم MCP محلي عبر stdio يوفّر ست أدوات
+للذاكرة، ويمكن الوصول إليها أيضاً عبر HTTP باستخدام `mw-serve`. تتوفر أدلة
+لـ Claude Code وRho وClaude Desktop وCursor وVS Code / GitHub Copilot وWindsurf
+وZed وCodex CLI وCline وContinue وGemini CLI وGoose وOpenClaw وCrowClaw
+وHermes Agent وغيرها من العملاء المتوافقين.
+
+<div dir="ltr">
+
+```bash
+mw integrate claude
+mw integrate rho
+mw doctor
+```
+
+</div>
+
+لا يوفّر جميع العملاء الإمكانات نفسها. يتيح MCP الوصول إلى الذاكرة، أما
+التسجيل التلقائي للأوامر المنفّذة فيحتاج إلى خطاف خاص بالعميل. تميّز
+[مصفوفة التكامل](integrations/README.md) بين الوصول والتسجيل وإرشادات استخدام
+الذاكرة، وتربط بكل دليل إعداد تم التحقق منه.
+
+لا تتضمن حمولة خطافات Rho الحالية نص الأمر أو stdout: يمكن تسجيل الإخفاقات
+كبيانات وصفية مع أمر بديل يدل على غياب النص، بينما تُتجاوز الاستدعاءات الناجحة
+التي لا تحتوي على نص الأمر. يستخدم
+[عرض تسليم الذاكرة بين الوكلاء](docs/guides/cross-agent-handoff.md)
+بيانات اختبار وعميل Rho محاكياً مع خادم MCP فعلي، لا وكلاء يعملون فعلياً
+ولا إصلاح Cargo تم تنفيذه والتحقق منه.
+
+توجّه المهارة المرفقة استخدام الذاكرة؛ لكنها لا تنفّذ استرجاعاً تلقائياً عند
+بدء المهمة أو بحثاً تلقائياً عن الإخفاقات أو حفظاً قبل ضغط السياق. تبقى قرارات
+دورة الحياة هذه مسؤولية العميل. وتنتظر الدروس التي تُكتب عبر MCP المراجعة
+افتراضياً.
+
+## لمن صُمّم MemoryWhale؟
+
+MemoryWhale مخصص للمطورين الذين يتوزع سياق تصحيح الأخطاء لديهم بين مخرجات
+الطرفية وسجل الصدفة والأجهزة وجلسات الوكلاء المؤقتة. ويكون مفيداً خصوصاً إذا كنت:
+
+- تصلح مشكلات البناء أو الاعتماديات أو Git أو البيئات أو النشر؛
+- تستخدم وكلاء البرمجة عبر جلسات متعددة أو تنتقل بين أدوات مختلفة؛
+- تعمل عبر SSH أو على عدة أجهزة تطوير؛
+- تريد إبقاء الإخفاقات المتكررة وإصلاحاتها قابلة للبحث؛
+- تفضّل التخزين المحلي على خدمة ذاكرة مستضافة.
+
+تعرّف على [حالات الاستخدام](docs/concepts/use-cases.md) لرؤية كل سيناريو
+من البداية إلى النهاية مع أوامر فعلية.
+
+## التوثيق
+
+- [خريطة التوثيق](docs/README.md)
+- [البدء](docs/guides/getting-started.md)
+- [مرجع `mw pet`](docs/reference/pet.md)
+- [تسجيل الطرفية](docs/guides/terminal-capture.md)
+- [ذاكرة الوكلاء](docs/guides/agent-memory.md)
+- [مرجع واجهة سطر الأوامر](docs/reference/cli.md)
+- [واجهة JSON المحلية](docs/reference/api.md)
+- [مرجع MCP](docs/reference/mcp.md)
+- [الأمان ونموذج التهديدات المحلي](docs/SECURITY.md)
+- [منظومة الأدوات](ECOSYSTEM.md) — Delphin وContextGC وMemoryWhale معاً
+- [أدلة التكامل ومصفوفة الإمكانات](integrations/README.md)
+
+## المساهمة
+
+يرحّب MemoryWhale بالتغييرات التي تحسّن تسجيل خبرات التطوير أو حفظها أو
+استرجاعها أو مشاركتها. اقرأ [CONTRIBUTING.md](CONTRIBUTING.md) لمعرفة نطاق
+المشروع وأوامر التطوير وقائمة التحقق الخاصة بطلبات الدمج.
+
+متاح بموجب [رخصة MIT](LICENSE).
+
+</div>

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,213 @@
+<!-- README-SOURCE-SHA256: 0a6b911696113a6221346fd4145b26a73f5a62493d8a8d34048d26a832c0c100 -->
+
+<p align="center">
+  <img src="assets/memorywhale-logo-sm.png" alt="MemoryWhale-Logo" width="160" />
+</p>
+
+<h1 align="center">MemoryWhale</h1>
+
+<p align="center"><strong>Dauerhaftes lokales Debugging-Gedächtnis für Entwickler und Coding-Agenten.</strong></p>
+
+<p align="center" dir="ltr"><a href="README.md">English README</a> · <a href="README.ar.md" lang="ar">العربية</a> · <a href="README.de.md" lang="de">Deutsch</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+
+<p align="center">
+  <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>
+  <a href="https://github.com/wuisabel-gif/MemWhale/releases"><img src="https://img.shields.io/github/v/release/wuisabel-gif/MemWhale?color=2b43dd&label=release" alt="Release"/></a>
+  <a href="https://crates.io/crates/memorywhale-cli"><img src="https://img.shields.io/crates/v/memorywhale-cli?color=2b43dd&label=crates.io" alt="crates.io"/></a>
+  <img src="https://img.shields.io/badge/license-MIT-2b43dd" alt="MIT-Lizenz"/>
+  <img src="https://img.shields.io/badge/local--first-no%20upload-168a69" alt="Local-first, kein Upload"/>
+</p>
+
+MemoryWhale hält fest, was beim Debuggen tatsächlich passiert ist: Befehle,
+Ausgaben, Fehler und die Lösungen, die funktioniert haben. Diese Informationen
+werden lokal in SQLite gespeichert, damit du und deine Coding-Agenten sie auch
+dann wiederfinden, wenn das Terminal, die SSH-Verbindung oder die Agentensitzung
+längst beendet ist.
+
+**MemoryWhale 0.10.0 — Agent-Native Memory · 6. September 2026.**
+CLI, Weboberfläche und Desktop-App haben die gemeinsame Produktversion 0.10.0;
+der wiederverwendbare Rust-Kern hat die Version 0.5.0. Die
+[Release Notes](https://github.com/wuisabel-gif/MemWhale/blob/v0.10.0/docs/releases/0.10.0.md)
+enthalten Hinweise zum Upgrade und zur inkompatiblen Änderung der Rust-API.
+
+## Warum MemoryWhale?
+
+- **Behalte, was wirklich passiert ist.** Bewahre Befehl, Umgebung, Ausgabe,
+  Fehler und Erkenntnis auf – nicht nur eine Zeile in der Shell-History.
+- **Nutze ein gemeinsames Gedächtnis für deine Coding-Agenten.** Jeder kompatible
+  stdio-MCP-Client kann über `mw-mcp` auf denselben lokalen Speicher zugreifen
+  und darin schreiben.
+- **Halte deine Entwicklungshistorie lokal.** MemoryWhale funktioniert ohne
+  Konto, gehosteten Dienst oder tokenbasierte Abrechnung für den Speicher.
+
+MemoryWhale speichert Entwicklungserfahrung, nicht alles. Es ist eine
+Gedächtnisschicht fürs Debugging – kein autonomer Coding-Agent, kein universelles
+persönliches Gedächtnis und kein Ersatz für Projektdokumentation.
+
+## Neu in Agent-Native Memory
+
+- **Agenten verbinden und ihre Einrichtung prüfen.** Mit `mw integrate`
+  installierst du MCP-Zugriff, Capture-Hooks und Hinweise zur Speichernutzung
+  für Claude Code oder Rho. `mw doctor` prüft MCP, Hooks und Skills getrennt.
+- **Die Herkunft nachvollziehbar halten.** Schema 10 speichert den ausführenden
+  Agenten einer Befehlsaufzeichnung als `claude`, `rho` oder `NULL`. Das Anzeige-
+  und Filterlabel `terminal` steht für Terminal-, manuelle oder ältere
+  Aufzeichnungen; es beweist nicht, dass ein Mensch den Befehl ausgeführt hat.
+  Die Agentenidentität ist unabhängig vom Quelltyp, etwa `command`, `session`
+  oder `note`.
+- **Ein Repository teilen, Worktrees unterscheiden.** Kanonische Repository-IDs
+  gruppieren verknüpfte Worktrees, ohne deren jeweilige Wurzelverzeichnisse oder
+  vorhandene Projekt-Tags zu verlieren. Die Erkennung liest lokale Git-Metadaten
+  und kontaktiert keinen entfernten Dienst.
+- **Lokale Schnittstellen nutzen.** `mw-serve` stellt HTTP-MCP unter
+  `POST /mcp` bereit. `mw-serve --api` aktiviert ausdrücklich die schreibgeschützte
+  JSON-API. Beide nutzen den Listener des Dashboards; Zugriffe außerhalb von
+  Loopback erfordern ein Token.
+- **GitHub-Kontext ausdrücklich abrufen.** `mw github context <pr>` liest
+  PR-Metadaten, Checks und Reviews über deine bestehende `gh`-Anmeldung. Der
+  ausgegebene Kontext ist größenbegrenzt und um erkannte sensible Daten bereinigt.
+  Die Funktion checkt keinen Code aus und speichert nichts automatisch als
+  Erinnerung. Es gibt keine GitHub-Synchronisierung im Hintergrund.
+
+## Installation
+
+Vorgefertigte Binärdateien gibt es für Linux x86_64/aarch64 und macOS:
+
+```bash
+(
+  set -eu
+  installer="$(mktemp)"
+  trap 'rm -f "$installer"' EXIT
+  curl -fsSL https://raw.githubusercontent.com/wuisabel-gif/MemWhale/7c3864c743cec9a8fa813dcc0b2459cc2859c849/install.sh -o "$installer"
+  printf '%s  %s\n' '3e0cad72b29c1894d5ff5f7c30b099537f96501801c14b6320c12e169a3ac8d6' "$installer" | shasum -a 256 -c -
+  sh "$installer"
+)
+```
+
+Alternativ kannst du Cargo oder Homebrew verwenden:
+
+```bash
+cargo install memorywhale-cli
+
+brew tap wuisabel-gif/memorywhale https://github.com/wuisabel-gif/MemWhale
+brew install memorywhale
+```
+
+Prüfe nach der Installation oder einem Upgrade die Version und die lokale
+Einrichtung:
+
+```bash
+mw --version
+mw doctor
+```
+
+Unter Windows kannst du MemoryWhale in
+[WSL](https://learn.microsoft.com/windows/wsl/) ausführen. Hinweise zur
+Paketinstallation, zur Einrichtung des PATH und zu den unterstützten Plattformen
+findest du in der [Einstiegsanleitung](docs/guides/getting-started.md).
+
+## Ein Beispiel in 60 Sekunden
+
+```bash
+mw global on                         # capture future interactive shell commands
+mw-run -- cargo check                # capture one command and its output
+mw remember "the linker needed libssl-dev"
+mw search "linker error"             # recover the failure and its fix
+mw context --last-error              # compact context for any agent or chat
+mw pet                               # check your memory store's mood
+```
+
+![Demo der Stimmungen von mw pet](assets/pet-demo.gif)
+
+Für längere Arbeiten zeichnet `mw --live` eine Shell-Sitzung mit regelmäßiger
+Sicherung auf, die auch nach einem Absturz verwertbar bleibt. `mw tui` öffnet
+einen interaktiven Browser im Terminal; `mw-serve` startet das lokale
+Web-Dashboard.
+
+## So funktioniert es
+
+```text
+CAPTURE                 MEMORY                 RETRIEVAL
+shell / mw-run ──────► local SQLite ────────► search / context
+agent hooks ─────────► evidence + lessons ──► similar failures
+                                                   │
+                                              INTERFACES
+                                      CLI / MCP / TUI / Web / Desktop
+```
+
+Aufzeichnung und Abruf sind unabhängig voneinander. MCP gibt einem Agenten
+Zugriff auf vorhandene Erinnerungen, zeichnet aber normale Terminalaktivität
+nicht automatisch auf. Das vollständige Modell beschreiben die
+[Architektur](docs/architecture.md) und das
+[Konzept zur Aufzeichnung](docs/concepts/capture.md).
+
+## Funktioniert mit deinem Coding-Agenten
+
+`mw-mcp` ist der gemeinsame Integrationspunkt: ein lokaler stdio-MCP-Server mit
+sechs Speicherwerkzeugen, die über `mw-serve` auch per HTTP verfügbar sind.
+Es gibt Anleitungen für Claude Code, Rho, Claude Desktop, Cursor, VS Code /
+GitHub Copilot, Windsurf, Zed, Codex CLI, Cline, Continue, Gemini CLI, Goose,
+OpenClaw, CrowClaw, Hermes Agent und weitere kompatible Clients.
+
+```bash
+mw integrate claude
+mw integrate rho
+mw doctor
+```
+
+Nicht alle Clients bieten dieselben Funktionen. MCP ermöglicht den
+Speicherzugriff; die automatische Aufzeichnung ausgeführter Befehle braucht
+einen clientspezifischen Hook. Die [Integrationsmatrix](integrations/README.md)
+unterscheidet Speicherzugriff, Aufzeichnung und Hinweise zur Speichernutzung
+und verlinkt die jeweils geprüften Einrichtungsanleitungen.
+
+Rhos aktuelle Hook-Payload enthält weder Befehlstext noch stdout: Fehler können
+als Metadaten mit einem Platzhalterbefehl gespeichert werden; erfolgreiche
+Aufrufe ohne Befehlstext werden übersprungen. Die
+[Demo zur Übergabe zwischen Agenten](docs/guides/cross-agent-handoff.md)
+verwendet Fixtures und einen simulierten Rho-Client mit echtem MCP – keine live
+ausgeführten Agenten und keinen tatsächlich überprüften Cargo-Fix.
+
+Der mitgelieferte Skill gibt Hinweise zur Speichernutzung. Er implementiert
+keinen automatischen Abruf zum Aufgabenstart, keine automatische Fehlersuche
+und kein Speichern vor einer Kontextkomprimierung. Diese Entscheidungen über
+den Sitzungsablauf bleiben beim Client. Über MCP verfasste Erkenntnisse warten
+standardmäßig auf eine Prüfung.
+
+## Für wen ist MemoryWhale gedacht?
+
+MemoryWhale richtet sich an Entwickler, deren Debugging-Kontext über den
+Terminal-Scrollback, die Shell-History, mehrere Rechner und vorübergehende
+Agentensitzungen verteilt ist. Es ist besonders hilfreich, wenn du:
+
+- Builds, Abhängigkeiten, Git, Entwicklungsumgebungen oder Deployments untersuchst;
+- Coding-Agenten über mehrere Sitzungen nutzt oder zwischen Tools wechselst;
+- über SSH oder auf mehreren Entwicklungsrechnern arbeitest;
+- wiederkehrende Fehler und ihre Lösungen wiederfinden möchtest;
+- lokale Speicherung einem gehosteten Speicherdienst vorziehst.
+
+Die [Anwendungsfälle](docs/concepts/use-cases.md) zeigen diese Szenarien
+Schritt für Schritt mit echten Befehlen.
+
+## Dokumentation
+
+- [Dokumentationsübersicht](docs/README.md)
+- [Erste Schritte](docs/guides/getting-started.md)
+- [`mw pet`-Referenz](docs/reference/pet.md)
+- [Terminalaufzeichnung](docs/guides/terminal-capture.md)
+- [Agentengedächtnis](docs/guides/agent-memory.md)
+- [CLI-Referenz](docs/reference/cli.md)
+- [Lokale JSON-API](docs/reference/api.md)
+- [MCP-Referenz](docs/reference/mcp.md)
+- [Sicherheit und lokales Bedrohungsmodell](docs/SECURITY.md)
+- [Ökosystem](ECOSYSTEM.md) – Delphin, ContextGC und MemoryWhale
+- [Integrationsanleitungen und Funktionsmatrix](integrations/README.md)
+
+## Mitwirken
+
+MemoryWhale begrüßt Änderungen, die das Aufzeichnen, Bewahren, Abrufen oder
+Teilen von Entwicklungserfahrung verbessern. In
+[CONTRIBUTING.md](CONTRIBUTING.md) findest du den Projektumfang,
+Entwicklungsbefehle und die Checkliste für Pull Requests.
+
+Veröffentlicht unter der [MIT-Lizenz](LICENSE).

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,4 +1,4 @@
-<!-- README-SOURCE-SHA256: 0c0dee340943c6650cc58749d96cb86c7728e6fc31cef1f4daba0be190a01965 -->
+<!-- README-SOURCE-SHA256: 0a6b911696113a6221346fd4145b26a73f5a62493d8a8d34048d26a832c0c100 -->
 
 <p align="center">
   <img src="assets/memorywhale-logo-sm.png" alt="Logo de MemoryWhale" width="160" />
@@ -8,7 +8,7 @@
 
 <p align="center"><strong>Une mémoire locale et persistante pour le débogage, pensée pour les développeurs et les agents de code.</strong></p>
 
-<p align="center"><a href="README.md">English README</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+<p align="center" dir="ltr"><a href="README.md">English README</a> · <a href="README.ar.md" lang="ar">العربية</a> · <a href="README.de.md" lang="de">Deutsch</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
 
 <p align="center">
   <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- README-SOURCE-SHA256: 0c0dee340943c6650cc58749d96cb86c7728e6fc31cef1f4daba0be190a01965 -->
+<!-- README-SOURCE-SHA256: 0a6b911696113a6221346fd4145b26a73f5a62493d8a8d34048d26a832c0c100 -->
 
 <p align="center">
   <img src="assets/memorywhale-logo-sm.png" alt="MemoryWhale ロゴ" width="160" />
@@ -8,7 +8,7 @@
 
 <p align="center"><strong>開発者とコーディングエージェントのための、永続的なローカルデバッグメモリ。</strong></p>
 
-<p align="center"><a href="README.md">English README</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+<p align="center" dir="ltr"><a href="README.md">English README</a> · <a href="README.ar.md" lang="ar">العربية</a> · <a href="README.de.md" lang="de">Deutsch</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
 
 <p align="center">
   <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,4 +1,4 @@
-<!-- README-SOURCE-SHA256: 0c0dee340943c6650cc58749d96cb86c7728e6fc31cef1f4daba0be190a01965 -->
+<!-- README-SOURCE-SHA256: 0a6b911696113a6221346fd4145b26a73f5a62493d8a8d34048d26a832c0c100 -->
 
 <p align="center">
   <img src="assets/memorywhale-logo-sm.png" alt="MemoryWhale 로고" width="160" />
@@ -8,7 +8,7 @@
 
 <p align="center"><strong>개발자와 코딩 에이전트를 위한 지속적인 로컬 디버깅 메모리.</strong></p>
 
-<p align="center"><a href="README.md">English README</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+<p align="center" dir="ltr"><a href="README.md">English README</a> · <a href="README.ar.md" lang="ar">العربية</a> · <a href="README.de.md" lang="de">Deutsch</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
 
 <p align="center">
   <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><strong>Persistent local debugging memory for developers and coding agents.</strong></p>
 
-<p align="center"><a href="README.md">English README</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+<p align="center" dir="ltr"><a href="README.md">English README</a> · <a href="README.ar.md" lang="ar">العربية</a> · <a href="README.de.md" lang="de">Deutsch</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
 
 <p align="center">
   <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- README-SOURCE-SHA256: 0c0dee340943c6650cc58749d96cb86c7728e6fc31cef1f4daba0be190a01965 -->
+<!-- README-SOURCE-SHA256: 0a6b911696113a6221346fd4145b26a73f5a62493d8a8d34048d26a832c0c100 -->
 
 <p align="center">
   <img src="assets/memorywhale-logo-sm.png" alt="MemoryWhale 标志" width="160" />
@@ -8,7 +8,7 @@
 
 <p align="center"><strong>为开发者和编程智能体提供持久化的本地调试记忆。</strong></p>
 
-<p align="center"><a href="README.md">English README</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+<p align="center" dir="ltr"><a href="README.md">English README</a> · <a href="README.ar.md" lang="ar">العربية</a> · <a href="README.de.md" lang="de">Deutsch</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
 
 <p align="center">
   <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,4 +1,4 @@
-<!-- README-SOURCE-SHA256: 0c0dee340943c6650cc58749d96cb86c7728e6fc31cef1f4daba0be190a01965 -->
+<!-- README-SOURCE-SHA256: 0a6b911696113a6221346fd4145b26a73f5a62493d8a8d34048d26a832c0c100 -->
 
 <p align="center">
   <img src="assets/memorywhale-logo-sm.png" alt="MemoryWhale 標誌" width="160" />
@@ -8,7 +8,7 @@
 
 <p align="center"><strong>為開發者與程式設計代理提供持久的本機除錯記憶。</strong></p>
 
-<p align="center"><a href="README.md">English README</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
+<p align="center" dir="ltr"><a href="README.md">English README</a> · <a href="README.ar.md" lang="ar">العربية</a> · <a href="README.de.md" lang="de">Deutsch</a> · <a href="README.fr.md">README français</a> · <a href="README.zh-CN.md">简体中文 README</a> · <a href="README.zh-TW.md">繁體中文 README</a> · <a href="README.ko.md">한국어 README</a> · <a href="README.ja.md">日本語 README</a></p>
 
 <p align="center">
   <a href="https://github.com/wuisabel-gif/MemWhale/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/wuisabel-gif/MemWhale/ci.yml?branch=main&label=CI&logo=github" alt="CI"/></a>

--- a/index.html
+++ b/index.html
@@ -147,12 +147,6 @@
         line-height: 1.25;
       }
 
-      html[dir="rtl"] h1 {
-        /* Arabic keeps normal letter spacing, so the Latin brand needs more room. */
-        max-width: 100%;
-        font-size: clamp(2.75rem, 6vw, 5.5rem);
-      }
-
 
       .page {
         position: relative;
@@ -355,11 +349,13 @@
       }
 
       h1 {
-        max-width: 11ch;
-        font-size: clamp(3.45rem, 6.8vw, 6.25rem);
+        /* Fit the content column rather than a font-dependent character count.
+           The wrapping fallback also protects unusually wide system fonts. */
+        max-width: 100%;
+        font-size: clamp(2.75rem, 5.2vw, 4.5rem);
         font-weight: 800;
         line-height: 0.92;
-        overflow-wrap: normal;
+        overflow-wrap: anywhere;
       }
 
       h2 {
@@ -876,10 +872,6 @@
 
         .hero > div:first-child {
           width: auto;
-        }
-
-        h1 {
-          max-width: 12ch;
         }
 
         .hero-visual {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -130,7 +130,27 @@
       }
 
       code {
+        direction: ltr;
+        unicode-bidi: isolate;
         overflow-wrap: anywhere;
+      }
+
+      html[dir="rtl"] {
+        --hero-veil-angle: 270deg;
+      }
+
+      html[dir="rtl"] :is(h1, h2, h3, .eyebrow, .stat span, .language-picker label) {
+        letter-spacing: normal;
+      }
+
+      html[dir="rtl"] :is(h1, h2, h3) {
+        line-height: 1.25;
+      }
+
+      html[dir="rtl"] h1 {
+        /* Arabic keeps normal letter spacing, so the Latin brand needs more room. */
+        max-width: 100%;
+        font-size: clamp(2.75rem, 6vw, 5.5rem);
       }
 
 
@@ -196,6 +216,7 @@
 
       .nav-actions {
         display: flex;
+        flex-wrap: wrap;
         align-items: center;
         justify-content: flex-end;
         gap: 10px;
@@ -204,6 +225,7 @@
 
       .language-picker {
         display: inline-flex;
+        flex-shrink: 0;
         align-items: center;
         gap: 8px;
         min-height: 38px;
@@ -289,12 +311,14 @@
 
       .hero::after {
         position: absolute;
-        inset: 0 auto 0 -30px;
+        inset-block: 0;
+        inset-inline-start: -30px;
+        inset-inline-end: auto;
         z-index: 1;
         width: min(68%, 820px);
         pointer-events: none;
         background: linear-gradient(
-          90deg,
+          var(--hero-veil-angle, 90deg),
           rgba(243, 247, 251, 0.98) 0%,
           rgba(243, 247, 251, 0.9) 62%,
           rgba(243, 247, 251, 0) 100%
@@ -370,7 +394,7 @@
       .hero-visual {
         position: absolute;
         top: 78px;
-        right: 0;
+        inset-inline-end: 0;
         z-index: 0;
         width: min(900px, 58vw);
         min-height: 540px;
@@ -614,6 +638,9 @@
       }
 
       pre {
+        direction: ltr;
+        text-align: left;
+        unicode-bidi: isolate;
         margin: 0;
         padding: 18px;
         overflow: auto;
@@ -679,6 +706,8 @@
       }
 
       .client-chip {
+        direction: ltr;
+        unicode-bidi: isolate;
         border: 1px solid var(--line-2);
         border-radius: 99px;
         padding: 5px 12px;
@@ -755,7 +784,7 @@
       }
 
       .stat span {
-        color: var(--faint);
+        color: var(--muted);
         font-size: 0.76rem;
         letter-spacing: 0.1em;
         text-transform: uppercase;
@@ -856,7 +885,7 @@
         .hero-visual {
           position: relative;
           top: auto;
-          right: auto;
+          inset-inline-end: auto;
           width: 100%;
           min-height: 520px;
         }
@@ -979,6 +1008,8 @@
             <label for="language-select" data-i18n="language.label">Language</label>
             <select id="language-select" name="language" aria-label="Language" data-i18n-aria-label="language.label">
               <option value="en" data-i18n="language.en">English</option>
+              <option value="ar" lang="ar" dir="rtl" data-i18n="language.ar">العربية</option>
+              <option value="de" lang="de" data-i18n="language.de">Deutsch</option>
               <option value="fr" data-i18n="language.fr">Français</option>
               <option value="zh-CN" data-i18n="language.zh-CN">简体中文</option>
               <option value="zh-TW" data-i18n="language.zh-TW">繁體中文</option>
@@ -1239,7 +1270,7 @@
               client with the evidence it retrieves, including any model
               provider to which that client sends context.
             </p>
-            <div class="client-strip" aria-label="Clients with integration guides" data-i18n-aria-label="agents.clientsLabel">
+            <div class="client-strip" role="group" aria-label="Clients with integration guides" data-i18n-aria-label="agents.clientsLabel">
               <span class="client-chip">Claude Code</span>
               <span class="client-chip">Rho</span>
               <span class="client-chip">Claude Desktop</span>

--- a/scripts/check-site.mjs
+++ b/scripts/check-site.mjs
@@ -1,6 +1,7 @@
 import { readFile, access } from "node:fs/promises";
 import { resolve } from "node:path";
 import vm from "node:vm";
+import { LOCALES } from "./sync-readme-locales.mjs";
 
 const root = resolve(new URL("..", import.meta.url).pathname);
 const html = await readFile(resolve(root, "index.html"), "utf8");
@@ -33,7 +34,7 @@ expect(html.includes('<script defer src="site-i18n.js"></script>'), "local defer
 expect(!/<script\b[^>]*\bsrc=["'](?:https?:)?\/\//i.test(html), "landing page loads a remote script");
 expect(!/(?:fonts\.(?:googleapis|gstatic)\.com|unpkg\.com|jsdelivr\.net)/i.test(`${html}\n${i18nSource}`), "landing page loads a third-party resource");
 
-const supportedLanguages = ["en", "fr", "zh-CN", "zh-TW", "ko", "ja"];
+const supportedLanguages = ["en", ...LOCALES.map(({ file }) => file.slice("README.".length, -".md".length))];
 const selector = html.match(/<select\b[^>]*id="language-select"[\s\S]*?<\/select>/i)?.[0] ?? "";
 expect(selector.includes('name="language"'), "language selector is missing a name");
 expect(selector.includes('aria-label="Language"'), "language selector is missing an accessible label");
@@ -66,11 +67,26 @@ if (dictionaryApi) {
   for (const language of supportedLanguages) {
     expect(dictionaryApi.translations[language], `site dictionary is missing language: ${language}`);
     if (!dictionaryApi.translations[language]) continue;
+    const dictionary = dictionaryApi.translations[language];
+    for (const key of ["title", "description", "jsonLdDescription"]) {
+      expect(typeof dictionary.meta?.[key] === "string" && dictionary.meta[key].trim().length > 0,
+        `${language} dictionary is missing metadata: ${key}`);
+    }
     for (const key of translationKeys) {
       expect(
-        typeof dictionaryApi.translations[language][key] === "string",
+        typeof dictionary[key] === "string" && dictionary[key].trim().length > 0,
         `${language} dictionary is missing key: ${key}`
       );
+      const english = dictionaryApi.translations.en[key];
+      if (typeof english !== "string" || typeof dictionary[key] !== "string") continue;
+      for (const [name, pattern] of [
+        ["code", /<code\b[^>]*>([\s\S]*?)<\/code>/g],
+        ["links", /\bhref="([^"]+)"/g],
+      ]) {
+        const values = (text) => [...text.matchAll(pattern)].map((match) => match[1]).sort();
+        expect(JSON.stringify(values(english)) === JSON.stringify(values(dictionary[key])),
+          `${language} changed protected ${name} in ${key}`);
+      }
     }
   }
 }

--- a/scripts/site-smoke.mjs
+++ b/scripts/site-smoke.mjs
@@ -102,6 +102,16 @@ try {
         await page.screenshot({ path: `${artifactDir}/${language}-${size}.png`, fullPage: true });
         if (language === "ar" || language === "de") {
           await page.locator(".hero").screenshot({ path: `${artifactDir}/${language}-${size}-hero.png` });
+          if (size === "desktop") {
+            // Exercise the containment fallback independently of the host's
+            // installed fonts (CI's Linux fonts differ from macOS).
+            const fontOverride = await page.addStyleTag({ content: "h1 { font-family: monospace !important; font-size: 120px !important; }" });
+            try {
+              await checkLanguage(page, language, `${label}/wide-font`);
+            } finally {
+              await fontOverride.evaluate(element => element.remove());
+            }
+          }
         }
         // Exercise RTL -> LTR -> original selection on mobile as well as desktop.
         if (language === "ar") {

--- a/scripts/site-smoke.mjs
+++ b/scripts/site-smoke.mjs
@@ -1,212 +1,179 @@
 import { chromium } from "playwright";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
+import vm from "node:vm";
 
 const baseUrl = process.env.SITE_URL ?? "http://127.0.0.1:4173/index.html";
-const artifactDir = "artifacts/site-smoke";
-const languages = ["en", "fr", "zh-CN", "zh-TW", "ko", "ja"];
-const expected = {
-  en: {
-    title: "MemoryWhale — terminal memory for you and your AI agent",
-    heading: "MemoryWhale remembers what your terminal forgets.",
-    nav: "Terminal Memory"
-  },
-  fr: {
-    title: "MemoryWhale — une mémoire de terminal pour vous et votre agent IA",
-    heading: "MemoryWhale se souvient de ce que votre terminal oublie.",
-    nav: "Mémoire du terminal"
-  },
-  "zh-CN": {
-    title: "MemoryWhale — 为你和 AI 智能体提供的终端记忆",
-    heading: "MemoryWhale 记住终端忘记的事。",
-    nav: "终端记忆"
-  },
-  "zh-TW": {
-    title: "MemoryWhale — 為你與 AI 代理提供的終端機記憶",
-    heading: "MemoryWhale 記住終端機忘記的事。",
-    nav: "終端機記憶"
-  },
-  ko: {
-    title: "MemoryWhale — 나와 AI 에이전트를 위한 터미널 메모리",
-    heading: "MemoryWhale은 터미널이 잊는 것을 기억합니다.",
-    nav: "터미널 메모리"
-  },
-  ja: {
-    title: "MemoryWhale — あなたと AI エージェントのためのターミナルメモリ",
-    heading: "MemoryWhale はターミナルが忘れることを覚えています。",
-    nav: "ターミナルメモリ"
-  }
-};
-const viewports = [
-  ["mobile", 390, 844],
-  ["desktop", 1440, 900]
+const artifactDir = process.env.SITE_ARTIFACT_DIR ?? "artifacts/site-smoke";
+const sandbox = {};
+vm.runInNewContext(await readFile(new URL("../site-i18n.js", import.meta.url), "utf8"), sandbox);
+const { supportedLanguages: languages, translations } = sandbox.MEMORYWHALE_I18N;
+const viewports = [["mobile", 390, 844], ["desktop", 1440, 900]];
+const sampledKeys = [
+  "hero.title", "nav.terminal", "release.title", "who.title", "terminal.title",
+  "how.title", "agents.title", "demo.title", "data.title", "security.copy", "run.title",
 ];
 await mkdir(artifactDir, { recursive: true });
-
+const failures = [];
+const expect = (condition, message) => { if (!condition) failures.push(message); };
 const languageUrl = (language) => {
   const url = new URL(baseUrl);
-  url.searchParams.set("lang", language);
+  if (language) url.searchParams.set("lang", language);
+  else url.searchParams.delete("lang");
+  url.searchParams.set("smoke", "preserve-me");
   url.hash = "demo";
   return url.toString();
 };
-const browserLanguageUrl = () => {
-  const url = new URL(baseUrl);
-  url.searchParams.delete("lang");
-  url.hash = "demo";
-  return url.toString();
-};
+
+function trackErrors(page, label) {
+  page.on("console", (message) => {
+    if (message.type() === "error") failures.push(`${label}: console: ${message.text()}`);
+  });
+  page.on("pageerror", (error) => failures.push(`${label}: page: ${error.message}`));
+}
+
+async function checkLanguage(page, language, label) {
+  const dictionary = translations[language];
+  expect(await page.locator("html").getAttribute("lang") === language, `${label}: wrong html lang`);
+  expect(await page.locator("html").getAttribute("dir") === (language === "ar" ? "rtl" : "ltr"), `${label}: wrong reading direction`);
+  expect(await page.locator("#language-select").inputValue() === language, `${label}: wrong selector value`);
+  expect(await page.title() === dictionary.meta.title, `${label}: wrong document title`);
+  expect(await page.locator("h1").evaluate((element) => {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const box = element.getBoundingClientRect();
+    return [...range.getClientRects()].every(rect => rect.left >= box.left - 1 && rect.right <= box.right + 1);
+  }), `${label}: heading text overflows its box`);
+  expect(await page.locator('meta[name="description"]').getAttribute("content") === dictionary.meta.description, `${label}: wrong description`);
+  const jsonLd = JSON.parse(await page.locator('script[type="application/ld+json"]').textContent());
+  expect(jsonLd.inLanguage === language && jsonLd.description === dictionary.meta.jsonLdDescription, `${label}: wrong JSON-LD`);
+  // Social preview metadata is deliberately static English, not localized SEO.
+  expect(await page.locator('meta[property="og:title"]').getAttribute("content") === translations.en.meta.title, `${label}: static social metadata changed`);
+
+  for (const key of sampledKeys) {
+    const actual = await page.locator(`[data-i18n="${key}"]`).innerText();
+    const wanted = await page.evaluate((html) => {
+      const fragment = document.createElement("template");
+      fragment.innerHTML = html;
+      return fragment.content.textContent;
+    }, dictionary[key]);
+    expect(actual.replace(/\s+/g, " ").trim() === wanted.replace(/\s+/g, " ").trim(), `${label}: untranslated content in ${key}`);
+  }
+  expect(await page.locator(".client-strip").getAttribute("aria-label") === dictionary["agents.clientsLabel"], `${label}: wrong client-group label`);
+  expect(await page.locator("#demo img").getAttribute("alt") === dictionary["demo.imageAlt"], `${label}: wrong image alternative`);
+
+  const picker = page.getByRole("combobox", { name: dictionary["language.label"], exact: true });
+  await picker.scrollIntoViewIfNeeded();
+  const box = await picker.boundingBox();
+  expect(await picker.isVisible() && box && box.width >= 80 && box.height >= 24, `${label}: language selector is not usable`);
+  expect(await picker.evaluate((element) => {
+    const box = element.getBoundingClientRect();
+    const top = document.elementFromPoint(box.x + box.width / 2, box.y + box.height / 2);
+    return top === element || element.contains(top);
+  }), `${label}: selector is covered`);
+  expect(await page.locator("#language-select option").count() === languages.length, `${label}: missing language options`);
+
+  const direction = await page.locator("pre").first().evaluate((element) => {
+    const style = getComputedStyle(element);
+    return { direction: style.direction, align: style.textAlign };
+  });
+  expect(direction.direction === "ltr" && direction.align === "left", `${label}: command blocks are not LTR`);
+  expect(await page.locator("code").evaluateAll((elements) => elements.every((element) => getComputedStyle(element).direction === "ltr")), `${label}: inline code is not LTR`);
+  for (const selector of ["#demo", "#data", "#security", "#run"]) {
+    expect(await page.locator(selector).count() === 1, `${label}: missing section ${selector}`);
+  }
+  expect(await page.locator("a[href^='http']").count() >= 3, `${label}: external links missing`);
+  const url = new URL(page.url());
+  expect(url.hash === "#demo" && url.searchParams.get("smoke") === "preserve-me", `${label}: URL anchor or unrelated query lost`);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1), `${label}: horizontal overflow`);
+}
 
 const browser = await chromium.launch({ headless: true });
-const failures = [];
 try {
   for (const language of languages) {
-    for (const [name, width, height] of viewports) {
+    for (const [size, width, height] of viewports) {
+      const label = `${language}/${size}`;
       const page = await browser.newPage({ viewport: { width, height } });
-      const consoleErrors = [];
-      const pageErrors = [];
-      page.on("console", (message) => {
-        if (message.type() === "error") consoleErrors.push(message.text());
-      });
-      page.on("pageerror", (error) => pageErrors.push(error.message));
-
-      const url = languageUrl(language);
-      const response = await page.goto(url, { waitUntil: "networkidle" });
-      if (!response || !response.ok()) {
-        failures.push(`${language}/${name}: page did not load successfully (${response?.status() ?? "no response"})`);
-      }
-      await page.screenshot({ path: `${artifactDir}/${language}-${name}.png`, fullPage: true });
-
-      const heading = await page.locator("h1").innerText();
-      const navText = await page.locator(".nav-links a[href='#terminal-memory']").innerText();
-      const pageTitle = await page.title();
-      const requiredSections = ["#demo", "#data", "#security", "#run"];
-      for (const selector of requiredSections) {
-        if ((await page.locator(selector).count()) !== 1) {
-          failures.push(`${language}/${name}: missing required section ${selector}`);
-        }
-      }
-      if ((await page.locator("a[href^='http']").count()) < 3) {
-        failures.push(`${language}/${name}: expected external release/security links`);
-      }
-      if ((await page.locator("#language-select option").count()) !== languages.length) {
-        failures.push(`${language}/${name}: language selector does not expose all six options`);
-      }
-      const selectedLanguage = await page.locator("#language-select").inputValue();
-      if (selectedLanguage !== language) {
-        failures.push(`${language}/${name}: selector selected ${selectedLanguage}, expected ${language}`);
-      }
-      const documentLanguage = await page.locator("html").getAttribute("lang");
-      if (documentLanguage !== language) {
-        failures.push(`${language}/${name}: html lang is ${documentLanguage}, expected ${language}`);
-      }
-      if (pageTitle !== expected[language].title) {
-        failures.push(`${language}/${name}: unexpected document title: ${pageTitle}`);
-      }
-      const jsonLd = await page.locator('script[type="application/ld+json"]').textContent();
+      trackErrors(page, label);
       try {
-        if (JSON.parse(jsonLd ?? "{}").inLanguage !== language) {
-          failures.push(`${language}/${name}: JSON-LD language metadata was not updated`);
+        const response = await page.goto(languageUrl(language), { waitUntil: "networkidle" });
+        expect(response?.ok(), `${label}: page load failed`);
+        await checkLanguage(page, language, label);
+        expect(new URL(page.url()).searchParams.get("lang") === language, `${label}: query language changed`);
+        await page.screenshot({ path: `${artifactDir}/${language}-${size}.png`, fullPage: true });
+        if (language === "ar" || language === "de") {
+          await page.locator(".hero").screenshot({ path: `${artifactDir}/${language}-${size}-hero.png` });
         }
-      } catch {
-        failures.push(`${language}/${name}: JSON-LD metadata is not valid JSON`);
-      }
-      const currentUrl = new URL(page.url());
-      if (currentUrl.searchParams.get("lang") !== language || currentUrl.hash !== "#demo") {
-        failures.push(`${language}/${name}: language query or anchor was not preserved (${page.url()})`);
-      }
-      const horizontalOverflow = await page.evaluate(
-        () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1
-      );
-      if (horizontalOverflow) failures.push(`${language}/${name}: horizontal overflow detected`);
-      if (heading !== expected[language].heading) {
-        failures.push(`${language}/${name}: unexpected hero heading: ${heading}`);
-      }
-      if (navText !== expected[language].nav) {
-        failures.push(`${language}/${name}: unexpected visible nav label: ${navText}`);
-      }
-      if (consoleErrors.length) failures.push(`${language}/${name}: console errors: ${consoleErrors.join(" | ")}`);
-      if (pageErrors.length) failures.push(`${language}/${name}: page errors: ${pageErrors.join(" | ")}`);
-
-      if (language === "en" && name === "desktop") {
-        const beforePath = new URL(page.url()).pathname;
-        await page.locator("#language-select").selectOption("fr");
-        const afterUrl = new URL(page.url());
-        if (afterUrl.pathname !== beforePath || afterUrl.hash !== "#demo" || afterUrl.searchParams.get("lang") !== "fr") {
-          failures.push(`selector change navigated away or lost the anchor (${page.url()})`);
+        // Exercise RTL -> LTR -> original selection on mobile as well as desktop.
+        if (language === "ar") {
+          const examples = await page.locator("pre").allTextContents();
+          for (const next of ["de", "en", "ar"]) {
+            await page.locator("#language-select").selectOption(next);
+            await checkLanguage(page, next, `${label}/switch-${next}`);
+            expect(new URL(page.url()).searchParams.get("lang") === next, `${label}: selected locale missing from URL`);
+            expect(JSON.stringify(await page.locator("pre").allTextContents()) === JSON.stringify(examples), `${label}: translated executable examples`);
+          }
+          expect(await page.evaluate(() => localStorage.getItem("memorywhale.language")) === "ar", `${label}: selection not saved`);
+          await page.goto(languageUrl(null), { waitUntil: "networkidle" });
+          await checkLanguage(page, "ar", `${label}/stored-reload`);
+          expect(!new URL(page.url()).searchParams.has("lang"), `${label}: stored preference rewrote URL`);
         }
-        if ((await page.locator("h1").innerText()) !== expected.fr.heading) {
-          failures.push("selector change did not render the French hero heading");
-        }
+      } finally {
+        await page.close();
       }
-      await page.close();
     }
   }
 
-  for (const [locale, language] of [["zh-Hans", "zh-CN"], ["zh-Hant", "zh-TW"]]) {
-    const context = await browser.newContext({
-      locale,
-      viewport: { width: 1440, height: 900 }
-    });
+  const preferenceCases = [
+    { locale: "ar-EG", expected: "ar" },
+    { locale: "de-AT", expected: "de" },
+    { locale: "zh-Hans", expected: "zh-CN" },
+    { locale: "zh-Hant-TW", expected: "zh-TW" },
+    { locale: "en-US", stored: "ar", expected: "ar" },
+    { locale: "ar-SA", stored: "de", query: "unsupported", expected: "de" },
+    { locale: "ar-SA", stored: "ar", query: "de-DE", expected: "de" },
+    { locale: "de-DE", blockedStorage: true, expected: "de" },
+    { locale: "de-DE", languages: ["unsupported"], expected: "de" },
+    { locale: "es-ES", expected: "en" },
+  ];
+  for (const [index, settings] of preferenceCases.entries()) {
+    const label = `preference-${index}/${settings.locale}`;
+    const context = await browser.newContext({ locale: settings.locale, viewport: { width: 390, height: 844 } });
+    await context.addInitScript(({ stored, blockedStorage, languages }) => {
+      if (stored) localStorage.setItem("memorywhale.language", stored);
+      if (blockedStorage) {
+        Storage.prototype.getItem = () => { throw new DOMException("Blocked", "SecurityError"); };
+        Storage.prototype.setItem = () => { throw new DOMException("Blocked", "SecurityError"); };
+      }
+      if (languages) Object.defineProperty(navigator, "languages", { get: () => languages });
+    }, settings);
     try {
       const page = await context.newPage();
-      const consoleErrors = [];
-      const pageErrors = [];
-      page.on("console", (message) => {
-        if (message.type() === "error") consoleErrors.push(message.text());
-      });
-      page.on("pageerror", (error) => pageErrors.push(error.message));
-
-      const response = await page.goto(browserLanguageUrl(), { waitUntil: "networkidle" });
-      if (!response || !response.ok()) {
-        failures.push(`${locale}: page did not load successfully (${response?.status() ?? "no response"})`);
+      trackErrors(page, label);
+      const response = await page.goto(languageUrl(settings.query), { waitUntil: "networkidle" });
+      expect(response?.ok(), `${label}: page load failed`);
+      await checkLanguage(page, settings.expected, label);
+      expect(new URL(page.url()).searchParams.get("lang") === (settings.query ?? null), `${label}: initial URL was rewritten`);
+      if (settings.blockedStorage) {
+        await page.locator("#language-select").selectOption("ar");
+        await checkLanguage(page, "ar", `${label}/blocked-storage-switch`);
+      } else if (!settings.stored) {
+        expect(await page.evaluate(() => localStorage.getItem("memorywhale.language")) === null, `${label}: initial detection unexpectedly persisted`);
       }
-      const heading = await page.locator("h1").innerText();
-      const pageTitle = await page.title();
-      const documentLanguage = await page.locator("html").getAttribute("lang");
-      const currentUrl = new URL(page.url());
-      const storedLanguage = await page.evaluate(() => window.localStorage.getItem("memorywhale.language"));
-      if (currentUrl.searchParams.has("lang")) {
-        failures.push(`${locale}: browser-language detection unexpectedly added a lang query (${page.url()})`);
-      }
-      if (storedLanguage !== null) {
-        failures.push(`${locale}: browser-language detection unexpectedly used localStorage (${storedLanguage})`);
-      }
-      if (pageTitle !== expected[language].title) {
-        failures.push(`${locale}: unexpected browser-detected document title: ${pageTitle}`);
-      }
-      if (heading !== expected[language].heading) {
-        failures.push(`${locale}: unexpected browser-detected hero heading: ${heading}`);
-      }
-      if (documentLanguage !== language) {
-        failures.push(`${locale}: browser-detected html lang is ${documentLanguage}, expected ${language}`);
-      }
-      if (consoleErrors.length) failures.push(`${locale}: console errors: ${consoleErrors.join(" | ")}`);
-      if (pageErrors.length) failures.push(`${locale}: page errors: ${pageErrors.join(" | ")}`);
-      await page.close();
     } finally {
       await context.close();
     }
   }
 
-  const noScriptContext = await browser.newContext({
-    viewport: { width: 1440, height: 900 },
-    javaScriptEnabled: false
-  });
+  const noScriptContext = await browser.newContext({ javaScriptEnabled: false });
   try {
     const page = await noScriptContext.newPage();
-    const response = await page.goto(languageUrl("en"), { waitUntil: "networkidle" });
-    if (!response || !response.ok()) {
-      failures.push(`no-js/en: page did not load successfully (${response?.status() ?? "no response"})`);
-    }
-    if ((await page.locator("h1").innerText()) !== expected.en.heading) {
-      failures.push("no-js/en: English hero heading is not present without JavaScript");
-    }
-    if ((await page.locator(".nav-links a[href='#terminal-memory']").innerText()) !== expected.en.nav) {
-      failures.push("no-js/en: English navigation is not present without JavaScript");
-    }
-    if (!(await page.locator("pre").first().innerText()).includes("https://raw.githubusercontent.com/wuisabel-gif/MemWhale/main/install.sh")) {
-      failures.push("no-js/en: install command example is not present without JavaScript");
-    }
-    await page.close();
+    const response = await page.goto(languageUrl("ar"), { waitUntil: "networkidle" });
+    expect(response?.ok(), "no-js: page load failed");
+    expect(await page.locator("html").getAttribute("lang") === "en", "no-js: fallback is not English");
+    expect(await page.locator("html").getAttribute("dir") === "ltr", "no-js: fallback direction is not LTR");
+    expect(await page.locator("h1").innerText() === translations.en["hero.title"], "no-js: English heading missing");
+    expect(await page.locator(".nav-links a[href='#terminal-memory']").innerText() === translations.en["nav.terminal"], "no-js: English navigation missing");
+    expect((await page.locator("pre").first().innerText()).includes("install.sh"), "no-js: command example missing");
   } finally {
     await noScriptContext.close();
   }
@@ -218,4 +185,4 @@ if (failures.length) {
   console.error(failures.map((failure) => `- ${failure}`).join("\n"));
   process.exit(1);
 }
-console.log("landing-page browser smoke passed for all six languages at mobile and desktop widths");
+console.log(`landing-page smoke passed: ${languages.length} languages, mobile/desktop, RTL, preferences, and no-JS fallback`);

--- a/scripts/sync-readme-locales.mjs
+++ b/scripts/sync-readme-locales.mjs
@@ -5,6 +5,8 @@ import { fileURLToPath } from "node:url";
 
 export const SOURCE_MARKER = "README-SOURCE-SHA256";
 export const LOCALES = [
+  { file: "README.ar.md", language: "Arabic (ar)", direction: "rtl" },
+  { file: "README.de.md", language: "German (de)" },
   { file: "README.fr.md", language: "French (fr)" },
   { file: "README.zh-CN.md", language: "Simplified Chinese (zh-CN)" },
   { file: "README.zh-TW.md", language: "Traditional Chinese (zh-TW)" },
@@ -195,11 +197,60 @@ function validateReadmeShape(markdown, file) {
   }
 }
 
-export function validateTranslation(source, translated) {
+// Direction wrappers are generated here, not supplied by the translation
+// provider. Keep Arabic prose RTL and the unchanged fenced examples LTR.
+export function formatLocalizedBody(markdown, { direction = "ltr" } = {}) {
+  if (direction !== "rtl") return markdown;
+  const body = markdown.trim();
+  const parts = [];
+  let cursor = 0;
+  for (const block of parseFencedCode(body).blocks) {
+    const start = body.indexOf(block, cursor);
+    parts.push(body.slice(cursor, start), `<div dir="ltr">\n\n${block}\n\n</div>`);
+    cursor = start + block.length;
+  }
+  parts.push(body.slice(cursor));
+  return `<div dir="rtl">\n\n${parts.join("")}\n\n</div>`;
+}
+
+function unwrapDirectionalBody(translated, options) {
+  if (options.direction !== "rtl") return translated;
+  const wrapped = translated.trim();
+  const prefix = '<div dir="rtl">\n\n';
+  const suffix = '\n\n</div>';
+  if (!wrapped.startsWith(prefix) || !wrapped.endsWith(suffix)) {
+    throw new Error("RTL translation must have its generated direction wrapper");
+  }
+  const inner = wrapped.slice(prefix.length, -suffix.length);
+  const codePrefix = '<div dir="ltr">\n\n';
+  const parts = [];
+  let cursor = 0;
+  for (const block of parseFencedCode(inner).blocks) {
+    const start = inner.indexOf(block, cursor);
+    const end = start + block.length;
+    if (inner.slice(start - codePrefix.length, start) !== codePrefix
+      || inner.slice(end, end + suffix.length) !== suffix) {
+      throw new Error("RTL translation changed generated direction wrappers");
+    }
+    parts.push(inner.slice(cursor, start - codePrefix.length), block);
+    cursor = end + suffix.length;
+  }
+  parts.push(inner.slice(cursor));
+  const body = parts.join("");
+  // Only the exact generated layout is exempt from the HTML structure check.
+  // Extra attributes, missing LTR code wrappers, and arbitrary wrappers fail.
+  if (formatLocalizedBody(body, options) !== wrapped) {
+    throw new Error("RTL translation changed generated direction wrappers");
+  }
+  return body;
+}
+
+export function validateTranslation(source, translated, options = {}) {
   if (!translated.trim()) throw new Error("translation is empty");
   if (translated.includes(`<!-- ${SOURCE_MARKER}:`)) {
     throw new Error("translation must not include the source hash marker");
   }
+  translated = unwrapDirectionalBody(translated, options);
   validateReadmeShape(source, "README.md");
   validateReadmeShape(translated, "translated README");
 
@@ -299,7 +350,7 @@ export async function inspectLocales(directory = root, { requireCurrent = false 
     const parsed = parseLocalizedReadme(content, locale.file);
     validateReadmeShape(parsed.body, locale.file);
     const current = parsed.sourceHash === currentHash;
-    if (current) validateTranslation(source, parsed.body);
+    if (current) validateTranslation(source, parsed.body, locale);
     results.push({ ...locale, current, sourceHash: parsed.sourceHash });
   }
 
@@ -331,7 +382,7 @@ export async function translateStaleLocales(directory = root, options = {}) {
       fetchImpl: options.fetchImpl,
     });
     validateTranslation(source, translated);
-    const content = `<!-- ${SOURCE_MARKER}: ${currentHash} -->\n\n${translated}\n`;
+    const content = `<!-- ${SOURCE_MARKER}: ${currentHash} -->\n\n${formatLocalizedBody(translated, locale)}\n`;
     await writeFile(resolve(directory, locale.file), content);
   }
 

--- a/scripts/sync-readme-locales.tests.mjs
+++ b/scripts/sync-readme-locales.tests.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
   LOCALES,
+  formatLocalizedBody,
   hashContent,
   parseLocalizedReadme,
   translateMarkdown,
@@ -62,6 +63,43 @@ test("translated image alt text is allowed", () => {
 test("the English README passes the complete protection contract", async () => {
   const readme = await readFile(new URL("../README.md", import.meta.url), "utf8");
   assert.doesNotThrow(() => validateTranslation(readme, readme));
+});
+
+test("RTL layout preserves Markdown and wraps fenced examples in LTR", () => {
+  const rtl = { direction: "rtl" };
+  const body = formatLocalizedBody(source, rtl);
+  assert.match(body, /^<div dir="rtl">\n\n/);
+  assert.equal((body.match(/<div dir="ltr">/g) ?? []).length, 2);
+  assert.match(body, /<div dir="ltr">\n\n```bash\nmw search "linker error"\n```\n\n<\/div>/);
+  assert.doesNotThrow(() => validateTranslation(source, body, rtl));
+  assert.equal(formatLocalizedBody(source), source);
+  assert.throws(() => validateTranslation(source, body), /protected HTML/);
+});
+
+test("RTL layout cannot bypass command, link, or HTML protections", () => {
+  const rtl = { direction: "rtl" };
+  const body = formatLocalizedBody(source, rtl);
+  for (const tampered of [
+    body.replace("mw search", "mw delete"),
+    body.replace("docs/guide.md", "https://untrusted.example/"),
+    body.replace('<img src=', '<img onclick="alert(1)" src='),
+  ]) {
+    assert.throws(() => validateTranslation(source, tampered, rtl), /protected/);
+  }
+  for (const tampered of [
+    source,
+    body.replace('dir="rtl"', 'dir="rtl" onclick="alert(1)"'),
+    body.replace('<div dir="ltr">', '<div dir="rtl">'),
+    body.replace('<div dir="ltr">\n\n', '').replace('```\n\n</div>', '```'),
+  ]) {
+    assert.throws(() => validateTranslation(source, tampered, rtl), /RTL translation/);
+  }
+});
+
+test("RTL wrappers do not consume literal direction markup inside code", () => {
+  const htmlExample = source + '\n```html\n<div dir="ltr">\n\nexample\n\n</div>\n```\n';
+  const rtl = { direction: "rtl" };
+  assert.doesNotThrow(() => validateTranslation(htmlExample, formatLocalizedBody(htmlExample, rtl), rtl));
 });
 
 test("validation rejects changes to protected README content", async (t) => {
@@ -229,5 +267,10 @@ test("stale locale files are translated and stamped with the current hash", asyn
   for (const locale of LOCALES) {
     const localized = parseLocalizedReadme(await readFile(join(directory, locale.file), "utf8"));
     assert.equal(localized.sourceHash, hashContent(source));
+    assert.doesNotThrow(() => validateTranslation(source, localized.body, locale));
+    if (locale.direction === "rtl") {
+      assert.ok(localized.body.startsWith('<div dir="rtl">'));
+      assert.ok(localized.body.includes('<div dir="ltr">'));
+    }
   }
 });

--- a/site-i18n.js
+++ b/site-i18n.js
@@ -20,6 +20,8 @@ const EN = {
   "nav.contextgc": "ContextGC ↗",
   "language.label": "Language",
   "language.en": "English",
+  "language.ar": "العربية",
+  "language.de": "Deutsch",
   "language.fr": "Français",
   "language.zh-CN": "简体中文",
   "language.zh-TW": "繁體中文",
@@ -153,6 +155,320 @@ const EN = {
   "footer.integrations": "Integrations"
 };
 
+const AR = {
+  meta: {
+    title: "MemoryWhale — ذاكرة الطرفية لك ولوكيل الذكاء الاصطناعي الخاص بك",
+    description:
+      "يلتقط MemoryWhale شواهد العمل التطويري في قاعدة SQLite محلية، لتمكين الأشخاص والأدوات الموثوقة من استرجاع الإخفاقات السابقة والدروس المستفادة. يعطي الأولوية للتخزين المحلي، مع تصدير ونقل بطلب صريح.",
+    jsonLdDescription:
+      "ذاكرة محلية دائمة لتصحيح الأخطاء، للمطورين ووكلاء البرمجة. تلتقط شواهد الطرفية في قاعدة SQLite محلية وتتيحها عبر MCP."
+  },
+  "nav.label": "التنقل في الصفحة",
+  "brand.home": "الصفحة الرئيسية لـ MemoryWhale",
+  "nav.terminal": "ذاكرة الطرفية",
+  "nav.how": "كيف يعمل",
+  "nav.agents": "وكلاء الذكاء الاصطناعي",
+  "nav.who": "لمن صُمّم",
+  "nav.install": "التثبيت",
+  "nav.docs": "التوثيق",
+  "nav.releases": "الإصدارات",
+  "nav.github": "GitHub ↗",
+  "nav.delphin": "Delphin ↗",
+  "nav.contextgc": "ContextGC ↗",
+  "language.label": "اللغة",
+  "language.en": "الإنجليزية",
+  "language.ar": "العربية",
+  "language.de": "Deutsch",
+  "language.fr": "الفرنسية",
+  "language.zh-CN": "الصينية المبسطة",
+  "language.zh-TW": "الصينية التقليدية",
+  "language.ko": "الكورية",
+  "language.ja": "اليابانية",
+  "release.banner": "🐋 v0.10.0 — ذاكرة مصممة للوكلاء · 6 سبتمبر 2026 · ملاحظات الإصدار ودليل الترقية →",
+  "hero.eyebrow": "ذاكرة طرفية بأولوية للتخزين المحلي",
+  "hero.title": "يتذكّر MemoryWhale ما تنساه طرفيتك.",
+  "hero.lead":
+    "التقط شواهد الطرفية، واحفظها في قاعدة SQLite محلية، واسترجع الإخفاقات والدروس المهمة. يعطي MemoryWhale الأولوية للتخزين المحلي: فلا يرفع بياناتك أو يزامنها بصمت.",
+  "hero.demoCta": "شاهد العرض التجريبي في 60 ثانية",
+  "hero.installCta": "ثبّت MemoryWhale",
+  "hero.securityCta": "اقرأ نموذج الأمان",
+  "hero.memoryChip": "ذاكرة الطرفية نشطة",
+  "hero.whaleAlt": "حوت مضيء يسبح بين عُقد رسم بياني معرفي",
+  "release.eyebrow": "الجديد في 0.10.0",
+  "release.title": "ذاكرة مشتركة. مصادر واضحة.",
+  "release.copy":
+    "يشمل إصدار المنتج 0.10.0 واجهة سطر الأوامر (CLI)، وواجهة الويب، وتطبيق سطح المكتب. أما النواة القابلة لإعادة الاستخدام بلغة Rust فإصدارها 0.5.0: تتطلب القيم الحرفية لـ <code>Memory</code> في Rust الآن <code>agent: Option&lt;String&gt;</code>؛ وتظل بيانات JSON القديمة قابلة للقراءة بفضل القيمة الافتراضية في serde.",
+  "release.connectTitle": "اربط Claude Code وRho",
+  "release.connectBody":
+    "يثبّت كلٌّ من <code>mw integrate claude</code> و<code>mw integrate rho</code> إمكانية الوصول عبر MCP، وخطافات الالتقاط، ومهارة. يفحص <code>mw doctor</code> هذه المكوّنات كلًّا على حدة.",
+  "release.provenanceTitle": "اعرف مصدر الشواهد",
+  "release.provenanceBody":
+    "يخزّن المخطط 10 هوية الوكيل لكل أمر بالقيم <code>claude</code> أو <code>rho</code> أو <code>NULL</code>؛ وتُعرض القيمة الأخيرة باسم <code>terminal</code>. هوية الوكيل مستقلة عن نوع المصدر. وتجمع معرّفات المستودعات الموحّدة أشجار العمل المرتبطة (worktrees) دون فقدان مسار أيٍّ منها.",
+  "release.interfaceTitle": "اختر واجهتك المحلية",
+  "release.interfaceBody":
+    "يضيف <code>mw-serve</code> دعم HTTP MCP على <code>POST /mcp</code>. يفعّل <code>--api</code> واجهة JSON API للقراءة فقط باختيار صريح. يقرأ <code>mw github context &lt;pr&gt;</code> صراحةً البيانات الوصفية لطلبات السحب (PR)، والفحوص، وحالات الإيداعات، والمراجعات باستخدام تسجيل دخولك إلى <code>gh</code>: دون إجراء checkout أو حفظ تلقائي أو مزامنة في الخلفية.",
+  "who.eyebrow": "لمن صُمّم",
+  "who.title": "مصمّم لثلاث طرق للعمل.",
+  "who.copy":
+    "يخدم MemoryWhale المطورين الذين يتوزّع سياق تصحيح الأخطاء لديهم بين سجل مخرجات الطرفية، وسجل الصدفة، والأجهزة، وجلسات الوكلاء المؤقتة. اطّلع على <a href=\"https://github.com/wuisabel-gif/MemWhale/blob/main/docs/concepts/use-cases.md\" style=\"color:var(--azure);text-decoration:underline;\">الشروحات التفصيلية لحالات الاستخدام</a> مع سجلات أوامر حقيقية.",
+  "who.shellTitle": "🔍 من يصحّح الأخطاء عبر سطر الأوامر",
+  "who.shellBody":
+    "واجهت خطأ البناء أو الربط أو الاعتماديات نفسه مرتين. يحتفظ سجل الصدفة بالأمر — لا بالمخرجات، أو نهاية رسالة الخطأ، أو الحل. يعيد <code>mw search</code> التنفيذ السابق الذي أخفق <em>والدرس</em> المرتبط به.",
+  "who.multiTitle": "🛰️ من يعمل على أجهزة متعددة",
+  "who.multiBody":
+    "Jetson، وخادم المختبر، والحاسوب المحمول — تنقطع الجلسات ويحتفظ كل جهاز بسجل خاص وغير مكتمل. يحفظ <code>mw --live</code> تلقائيًا رغم انقطاع الاتصال؛ وينقل <code>mw push</code> / <code>mw pull</code> الذاكرة بين الأجهزة بطلب صريح.",
+  "who.agentTitle": "🤖 مستخدم وكلاء البرمجة",
+  "who.agentBody":
+    "<bdi dir=\"ltr\">Claude Code, Codex, Cursor</bdi> — تبدأ كل جلسة بشرح بيئتك من جديد. مع <code>mw-mcp</code>، يستطيع الوكيل الاستعلام عن الشواهد السابقة وحفظ درس صراحةً باستخدام <code>remember</code>. لا يزال عليك التحقق من نجاح أي إصلاح.",
+  "terminal.eyebrow": "ذاكرة الطرفية",
+  "terminal.title": "قصرٌ للذاكرة في سطر الأوامر.",
+  "terminal.copy":
+    "يخزّن MemoryWhale جلسات الطرفية في ذاكرة محلية منظّمة. وبدلًا من الاحتفاظ بكتلة نصية ضخمة واحدة، يحفظ الأمر، وكل وسيطة، ودليل العمل، ورمز الخروج، والمخرجات القياسية stdout، ومخرجات الأخطاء stderr، وملاحظاتك الخاصة.",
+  "terminal.argsTitle": "وسيطات قابلة للبحث",
+  "terminal.argsBody":
+    "تُفصل الخيارات مثل <code>--manifest-path</code> والمسارات والأوامر الفرعية وأسماء الحزم وخيارات النماذج في صفوف مستقلة.",
+  "terminal.errorsTitle": "سجلات الأخطاء تبقى مرتبطة بأوامرها",
+  "terminal.errorsBody":
+    "يُحفظ stderr إلى جانب الأمر الذي أنتجه، ليبقى السبب والسياق معًا.",
+  "terminal.liveTitle": "حفظ تلقائي مستمر للجلسات",
+  "terminal.liveBody":
+    "يسجّل <code>mw --live</code> نص جلسة الصدفة النشطة في SQLite كل بضع ثوانٍ، بحيث يمكن أن يبقى سجل ذاكرة صالح للاستخدام حتى عند انقطاع الاتصال.",
+  "terminal.graphTitle": "عُقد بيانية للإخفاقات",
+  "terminal.graphBody":
+    "تظهر الأوامر المخفقة في مجرّة المعرفة وترتبط بمفاهيم مستخرجة مثل <bdi dir=\"ltr\">cargo, Tauri, SQLite</bdi> والمنافذ وعمليات البناء.",
+  "how.eyebrow": "كيف يعمل",
+  "how.title": "التقط، خزّن، استخرج، استكشف.",
+  "how.captureTitle": "التقاط",
+  "how.captureBody": "ألصق سجل تنفيذ من الطرفية، أو استدعِ أداة Rust المساعدة، أو ابدأ جلسة صدفة تُحفظ تلقائيًا باستمرار.",
+  "how.storeTitle": "تخزين",
+  "how.storeBody": "يحفظ SQLite عمليات تنفيذ الأوامر ووسيطاتها محليًا على جهازك.",
+  "how.extractTitle": "استخراج",
+  "how.extractBody": "يستخرج Rust الكلمات المفتاحية من الأوامر والملاحظات ونصوص الأخطاء.",
+  "how.exploreTitle": "استكشاف",
+  "how.exploreBody": "ابحث أو انقر عُقد الأوامر في واجهة الرسم البياني المضيئة.",
+  "agents.eyebrow": "وكلاء الذكاء الاصطناعي",
+  "agents.title": "امنح وكيلك ذاكرة لما أخفق من قبل.",
+  "agents.copy":
+    "قد تفقد جلسات وكلاء البرمجة السياق وتكرّر تصحيح أخطاء سبق أن عالجتها. <code>mw-mcp</code> خادم Model Context Protocol يتيح الوصول إلى ذاكرتك المحلية — سجّله مرة واحدة ليتمكن <bdi dir=\"ltr\">Claude Code, Rho, Codex, Cursor</bdi> من الاستعلام مباشرةً عن الإخفاقات السابقة. يجب أن تثق بالعميل الذي يطّلع على الشواهد المسترجعة، وكذلك بأي مزوّد نموذج يرسل إليه ذلك العميل السياق.",
+  "agents.clientsLabel": "عملاء تتوفر لهم أدلة تكامل",
+  "agents.matrix": "المزيد في جدول الإمكانات",
+  "agents.guides":
+    "<a href=\"https://github.com/wuisabel-gif/MemWhale/blob/main/integrations/README.md\" style=\"color:var(--azure);text-decoration:underline;\">أدلة إعداد العملاء والأدوات</a> — يوضّح جدول الإمكانات دعم MCP والالتقاط التلقائي وحالة التحقق لكل عميل، بما في ذلك بوابات النماذج مثل OpenRouter وCLIProxyAPI.",
+  "agents.setupLabel": "الإعداد",
+  "agents.setupValue": "أمر واحد",
+  "agents.toolsLabel": "الأدوات",
+  "agents.toolsValue": "6 أدوات MCP محلية: <bdi dir=\"ltr\">recent_errors · search_memory · get_context · remember · similar_failures · stats</bdi>",
+  "agents.noAgentLabel": "لا تستخدم وكيلًا؟",
+  "agents.noAgentValue": "يطبع <bdi dir=\"ltr\">mw context</bdi> ملخصًا جاهزًا للصق",
+  "demo.eyebrow": "التقاط ← ذاكرة ← استرجاع",
+  "demo.title": "شاهد دورة العمل الأساسية ببيانات اصطناعية.",
+  "demo.copy":
+    "التقط أمرًا واحدًا، واحفظ الشرح الذي أدى إلى إصلاحه، ثم ابحث في المخزن المحلي عندما يتكرر الإخفاق نفسه. يوفّر MCP الاسترجاع والكتابة الصريحة؛ ولا يلتقط نشاط الطرفية العادي تلقائيًا.",
+  "demo.handoff":
+    "يستورد <a href=\"https://github.com/wuisabel-gif/MemWhale/blob/main/docs/guides/cross-agent-handoff.md\" style=\"color:var(--azure);text-decoration:underline;\">العرض التجريبي دون اتصال لتسليم السياق من Claude إلى Rho</a> بيانات اختبار جاهزة ويحاكي عميل Rho باستخدام MCP حقيقي. لا يشغّل وكلاء فعليين، ولا ينفّذ إصلاح Cargo الوارد في بيانات الاختبار أو يتحقق منه. تحتفظ خطافات Rho حاليًا بالبيانات الوصفية للإخفاق عند غياب نص الأمر؛ وتتجاوز الاستدعاءات الناجحة التي لا تحتوي على نص الأمر. ولا يزال الاسترجاع التلقائي عند بدء المهمة، والبحث عن الإخفاقات، والحفظ قبل ضغط السياق مهامًا على مستوى تنسيق العميل، وليست أتمتة متاحة ضمن المنتج.",
+  "demo.imageAlt": "عرض تجريبي لطرفية MemoryWhale ولوحة التحكم ببيانات اصطناعية",
+  "data.eyebrow": "بياناتك",
+  "data.title": "الأولوية للتخزين المحلي تعني خيارات واضحة.",
+  "data.copy":
+    "توجد قاعدة البيانات على جهازك: عادةً في <code>~/.local/share/MemoryWhale/</code> على Linux أو <code>~/Library/Application Support/MemoryWhale/</code> على macOS. اضبط <code>MEMORYWHALE_DATA_DIR</code> لاختيار موقع آخر.",
+  "data.captureLabel": "ضوابط الالتقاط",
+  "data.captureValue": "<code>.mwignore</code>، سياسة المسارات، التقاط الأوامر فقط",
+  "data.redactionLabel": "حجب البيانات الحساسة",
+  "data.redactionValue": "يساعد على حجب الأسرار الشائعة؛ لكنه ليس حدًا أمنيًا",
+  "data.sizeLabel": "حد الحجم",
+  "data.sizeValue": "الحد الافتراضي للحقول النصية الملتقطة هو 1 MiB، مع اقتطاع ما يتجاوزه",
+  "data.inspectLabel": "فحص / حذف",
+  "data.inspectValue": "<code>mw audit</code> · <code>mw rm</code> · <code>mw prune</code>",
+  "data.transferLabel": "النقل",
+  "data.transferValue": "<code>mw export</code> / <code>mw import</code> أو نقل صريح عبر SSH",
+  "data.stewardshipLabel": "إدارة الذاكرة",
+  "data.stewardshipValue": "<code>mw memory compact</code> — معاينة دون تنفيذ أولًا، مع الحفاظ على الصفوف",
+  "security.eyebrow": "نموذج الأمان",
+  "security.title": "محلي افتراضيًا، وبقرار صريح عند المشاركة.",
+  "security.copy":
+    "تستخدم واجهة سطر الأوامر (CLI)، والواجهة النصية (TUI)، وخادم MCP، ولوحة الويب، وواجهة سطح المكتب المخزن المحلي. يعمل <code>mw-mcp</code> كعملية محلية موثوقة عبر stdio؛ وترتبط لوحة الويب افتراضيًا بعنوان loopback. تتطلب إتاحة اللوحة على عنوان غير loopback رمز وصول، وينبغي قصر إتاحتها على شبكة موثوقة. يتطلب HTTP MCP المحمي مصادقة Bearer؛ وتشترك واجهة JSON API، التي تُفعّل باختيار صريح، في ضوابط الوصول الخاصة بلوحة الويب. لا يشفّر HTTP الاتصال. ولا تحوّل أيٌّ من الواجهتين وصول العميل إلى التقاط تلقائي. راجع <a href=\"https://github.com/wuisabel-gif/MemWhale/blob/main/docs/SECURITY.md\" style=\"color:var(--azure);text-decoration:underline;\">نموذج تهديدات البيانات المحلية</a>.",
+  "run.eyebrow": "التثبيت",
+  "run.title": "سطر واحد. لا حاجة إلى Rust.",
+  "run.copy":
+    "تتوفر ملفات تنفيذية جاهزة لأنظمة Linux x86_64/aarch64 وmacOS. يتحقق برنامج التثبيت من ملفات SHA256 المنشورة عندما يوفّرها الإصدار؛ وقد لا تتوفر قيمة تحقق للإصدارات الأقدم. ابدأ بالتقاط واحد بطلب صريح، وافحصه، ثم فكّر في <code>mw global on</code>. لا يُعد Windows هدفًا مدعومًا بصورة أصلية؛ ويمكن لـ WSL استخدام نسخة Linux.",
+  "run.tryLabel": "جرّب أولًا",
+  "run.tryValue": "<code>mw demo</code> — يكتب بيانات نموذجية في المخزن المحدد",
+  "run.prebuiltLabel": "تثبيت ملفات تنفيذية جاهزة",
+  "run.prebuiltValue":
+    "<a href=\"https://github.com/wuisabel-gif/MemWhale/blob/v0.10.0/docs/releases/0.10.0.md#install-or-upgrade\">تعليمات تثبيت لإصدار محدد مع التحقق من المجموع الاختباري</a>",
+  "run.cargoLabel": "Cargo",
+  "run.cargoValue": "<code>cargo install memorywhale-cli --version 0.10.0 --locked</code>",
+  "run.debianLabel": "Debian / Jetson",
+  "run.debianValue": ".deb على صفحة الإصدارات",
+  "run.securityLabel": "الأمان",
+  "run.securityValue": "<a href=\"#security\">اقرأ النموذج</a>",
+  "run.verifyLabel": "التحقق",
+  "run.verifyValue": "<code>mw --version</code> · <code>mw doctor</code>",
+  "footer.copyright": "حقوق النشر (c) 2026 wuisabel-gif. MemoryWhale - ذاكرة طرفية ورسم بياني معرفي باستخدام Rust/Tauri.",
+  "footer.docs": "التوثيق",
+  "footer.useCases": "حالات الاستخدام",
+  "footer.cli": "مرجع CLI",
+  "footer.security": "سياسة الأمان",
+  "footer.integrations": "التكاملات"
+};
+
+const DE = {
+  meta: {
+    title: "MemoryWhale — Terminal-Gedächtnis für dich und deinen KI-Agenten",
+    description:
+      "MemoryWhale erfasst Belege aus der Entwicklungsarbeit in einer lokalen SQLite-Datenbank, damit Menschen und vertrauenswürdige Werkzeuge frühere Fehler und Erkenntnisse abrufen können. Lokale Speicherung hat Vorrang; Export und Übertragung erfolgen auf ausdrücklichen Wunsch.",
+    jsonLdDescription:
+      "Dauerhaftes lokales Debugging-Gedächtnis für Entwickler und Programmieragenten. Erfasst Belege aus dem Terminal in einer lokalen SQLite-Datenbank und stellt sie über MCP bereit."
+  },
+  "nav.label": "Seitennavigation",
+  "brand.home": "MemoryWhale-Startseite",
+  "nav.terminal": "Terminal-Gedächtnis",
+  "nav.how": "Funktionsweise",
+  "nav.agents": "KI-Agenten",
+  "nav.who": "Für wen?",
+  "nav.install": "Installieren",
+  "nav.docs": "Dokumentation",
+  "nav.releases": "Versionen",
+  "nav.github": "GitHub ↗",
+  "nav.delphin": "Delphin ↗",
+  "nav.contextgc": "ContextGC ↗",
+  "language.label": "Sprache",
+  "language.en": "Englisch",
+  "language.ar": "العربية",
+  "language.de": "Deutsch",
+  "language.fr": "Französisch",
+  "language.zh-CN": "Chinesisch (vereinfacht)",
+  "language.zh-TW": "Chinesisch (traditionell)",
+  "language.ko": "Koreanisch",
+  "language.ja": "Japanisch",
+  "release.banner": "🐋 v0.10.0 — Gedächtnis für KI-Agenten · 6. September 2026 · Versionshinweise und Upgrade-Anleitung →",
+  "hero.eyebrow": "Terminal-Gedächtnis mit lokalem Schwerpunkt",
+  "hero.title": "MemoryWhale merkt sich, was dein Terminal vergisst.",
+  "hero.lead":
+    "Erfasse Belege aus dem Terminal, bewahre sie in einer lokalen SQLite-Datenbank auf und rufe wichtige Fehler und Erkenntnisse wieder ab. MemoryWhale setzt auf lokale Speicherung: Deine Daten werden nicht unbemerkt hochgeladen oder synchronisiert.",
+  "hero.demoCta": "Die 60-Sekunden-Demo ansehen",
+  "hero.installCta": "MemoryWhale installieren",
+  "hero.securityCta": "Sicherheitsmodell lesen",
+  "hero.memoryChip": "Terminal-Gedächtnis aktiv",
+  "hero.whaleAlt": "Leuchtender Wal, der durch die Knoten eines Wissensgraphen schwimmt",
+  "release.eyebrow": "Neu in 0.10.0",
+  "release.title": "Geteiltes Gedächtnis. Klare Herkunft.",
+  "release.copy":
+    "Der Produktstand 0.10.0 umfasst CLI, Weboberfläche und Desktop-App. Der wiederverwendbare Rust-Kern hat die Version 0.5.0: Rust-<code>Memory</code>-Literale erfordern jetzt <code>agent: Option&lt;String&gt;</code>; älteres JSON bleibt dank des serde-Standardwerts lesbar.",
+  "release.connectTitle": "Claude Code und Rho anbinden",
+  "release.connectBody":
+    "<code>mw integrate claude</code> und <code>mw integrate rho</code> installieren MCP-Zugriff, Erfassungs-Hooks und einen Skill. <code>mw doctor</code> prüft diese Komponenten unabhängig voneinander.",
+  "release.provenanceTitle": "Wissen, woher die Belege stammen",
+  "release.provenanceBody":
+    "Schema 10 speichert die Agenten von Befehlen als <code>claude</code>, <code>rho</code> oder <code>NULL</code>; Letzteres wird als <code>terminal</code> angezeigt. Der Agent ist vom Quelltyp getrennt. Kanonische Repository-IDs fassen verknüpfte Worktrees zusammen, ohne den Pfad des einzelnen Worktrees zu verlieren.",
+  "release.interfaceTitle": "Wähle deine lokale Oberfläche",
+  "release.interfaceBody":
+    "<code>mw-serve</code> ergänzt HTTP MCP unter <code>POST /mcp</code>. <code>--api</code> aktiviert ausdrücklich eine schreibgeschützte JSON-API. <code>mw github context &lt;pr&gt;</code> liest über deine <code>gh</code>-Anmeldung gezielt PR-Metadaten, Prüfungen, Commit-Status und Reviews: kein Checkout, kein automatisches Speichern und keine Hintergrundsynchronisierung.",
+  "who.eyebrow": "Für wen?",
+  "who.title": "Für drei Arbeitsweisen entwickelt.",
+  "who.copy":
+    "MemoryWhale ist für Entwickler gedacht, deren Debugging-Kontext über den Terminal-Rücklauf, den Shell-Verlauf, verschiedene Rechner und kurzlebige Agentensitzungen verstreut ist. Die ausführlichen <a href=\"https://github.com/wuisabel-gif/MemWhale/blob/main/docs/concepts/use-cases.md\" style=\"color:var(--azure);text-decoration:underline;\">Anwendungsbeispiele</a> zeigen echte Befehlsprotokolle.",
+  "who.shellTitle": "🔍 Fehlersuche vor allem in der Shell",
+  "who.shellBody":
+    "Derselbe Build-, Linker- oder Abhängigkeitsfehler tritt zum zweiten Mal auf. Der Shell-Verlauf merkt sich den Befehl — nicht seine Ausgabe, das Ende der Fehlermeldung oder die Lösung. <code>mw search</code> liefert den früheren fehlgeschlagenen Lauf <em>und</em> die zugehörige Erkenntnis.",
+  "who.multiTitle": "🛰️ Arbeit auf mehreren Rechnern",
+  "who.multiBody":
+    "Jetson, Laborserver, Laptop — Sitzungen brechen ab, und jeder Rechner behält seinen eigenen, unvollständigen Verlauf. <code>mw --live</code> speichert auch bei Verbindungsabbrüchen automatisch; <code>mw push</code> / <code>mw pull</code> übertragen das Gedächtnis gezielt zwischen Rechnern.",
+  "who.agentTitle": "🤖 Entwicklung mit Programmieragenten",
+  "who.agentBody":
+    "Claude Code, Codex, Cursor — jede Sitzung beginnt damit, deine Umgebung erneut zu erklären. Mit <code>mw-mcp</code> kann der Agent frühere Belege abfragen und mit <code>remember</code> ausdrücklich eine Erkenntnis speichern. Ob eine Fehlerbehebung funktioniert, musst du weiterhin selbst überprüfen.",
+  "terminal.eyebrow": "Terminal-Gedächtnis",
+  "terminal.title": "Ein Gedächtnispalast für die Arbeit auf der Kommandozeile.",
+  "terminal.copy":
+    "MemoryWhale speichert Terminalsitzungen als strukturiertes lokales Gedächtnis. Statt eines riesigen Textblocks hält es den Befehl, jedes Argument, das Arbeitsverzeichnis, den Exit-Code, stdout, stderr und deine eigenen Notizen fest.",
+  "terminal.argsTitle": "Argumente werden durchsuchbar",
+  "terminal.argsBody":
+    "Optionen wie <code>--manifest-path</code>, Pfade, Unterbefehle, Paketnamen und Modelloptionen werden in eigenen Zeilen gespeichert.",
+  "terminal.errorsTitle": "Fehlerprotokolle bleiben zugeordnet",
+  "terminal.errorsBody":
+    "stderr bleibt beim auslösenden Befehl gespeichert, damit Ursache und Kontext zusammenbleiben.",
+  "terminal.liveTitle": "Automatisches Speichern laufender Sitzungen",
+  "terminal.liveBody":
+    "<code>mw --live</code> schreibt das Protokoll der aktiven Shell alle paar Sekunden in SQLite. So kann auch nach einem Verbindungsabbruch eine nutzbare Aufzeichnung erhalten bleiben.",
+  "terminal.graphTitle": "Fehler als Graphknoten",
+  "terminal.graphBody":
+    "Fehlgeschlagene Befehle erscheinen in der Wissensgalaxie und werden mit extrahierten Begriffen wie cargo, Tauri, SQLite, Ports und Builds verknüpft.",
+  "how.eyebrow": "Funktionsweise",
+  "how.title": "Erfassen, speichern, extrahieren, erkunden.",
+  "how.captureTitle": "Erfassen",
+  "how.captureBody": "Füge ein Terminalprotokoll ein, rufe das Rust-Hilfsprogramm auf oder starte eine Shell mit laufender automatischer Speicherung.",
+  "how.storeTitle": "Speichern",
+  "how.storeBody": "SQLite speichert Befehlsausführungen und Argumente lokal auf deinem Rechner.",
+  "how.extractTitle": "Extrahieren",
+  "how.extractBody": "Rust extrahiert Schlüsselwörter aus Befehlen, Notizen und Fehlertexten.",
+  "how.exploreTitle": "Erkunden",
+  "how.exploreBody": "Suche oder klicke auf Befehlsknoten in der leuchtenden Graphoberfläche.",
+  "agents.eyebrow": "KI-Agenten",
+  "agents.title": "Gib deinem Agenten ein Gedächtnis für frühere Fehler.",
+  "agents.copy":
+    "Sitzungen mit Programmieragenten können Kontext verlieren und bereits erledigte Fehlersuche wiederholen. <code>mw-mcp</code> ist ein Model Context Protocol-Server für dein lokales Gedächtnis — registriere ihn einmal, damit Claude Code, Rho, Codex oder Cursor frühere Fehler direkt abfragen können. Du musst dem Client die abgerufenen Belege anvertrauen können — ebenso jedem Modellanbieter, an den er Kontext sendet.",
+  "agents.clientsLabel": "Clients mit Integrationsanleitungen",
+  "agents.matrix": "Mehr in der Übersicht",
+  "agents.guides":
+    "<a href=\"https://github.com/wuisabel-gif/MemWhale/blob/main/integrations/README.md\" style=\"color:var(--azure);text-decoration:underline;\">Einrichtungsanleitungen für Clients und Werkzeuge</a> — die Funktionsmatrix dokumentiert MCP-Unterstützung, automatische Erfassung und Prüfstatus pro Client, einschließlich Modell-Gateways wie OpenRouter und CLIProxyAPI.",
+  "agents.setupLabel": "Einrichtung",
+  "agents.setupValue": "Ein Befehl",
+  "agents.toolsLabel": "Werkzeuge",
+  "agents.toolsValue": "6 lokale MCP-Werkzeuge: recent_errors · search_memory · get_context · remember · similar_failures · stats",
+  "agents.noAgentLabel": "Kein Agent?",
+  "agents.noAgentValue": "mw context gibt eine Übersicht zum direkten Einfügen aus",
+  "demo.eyebrow": "Erfassung → Gedächtnis → Abruf",
+  "demo.title": "Der Kernablauf mit synthetischen Daten.",
+  "demo.copy":
+    "Erfasse einen Befehl, speichere die Erklärung zur funktionierenden Lösung und durchsuche den lokalen Speicher, wenn derselbe Fehler wieder auftritt. MCP ermöglicht das Abrufen und ausdrücklich angestoßene Schreiben von Daten; normale Terminalaktivität erfasst es nicht automatisch.",
+  "demo.handoff":
+    "Die <a href=\"https://github.com/wuisabel-gif/MemWhale/blob/main/docs/guides/cross-agent-handoff.md\" style=\"color:var(--azure);text-decoration:underline;\">Offline-Demo zur Übergabe von Claude an Rho</a> importiert Testdaten und simuliert einen Rho-Client mit echtem MCP. Sie startet keine echten Agenten und führt die in den Testdaten enthaltene Cargo-Fehlerbehebung weder aus noch überprüft sie diese. Rho-Hooks bewahren derzeit Fehlermetadaten auf, wenn der Befehlstext fehlt; erfolgreiche Aufrufe ohne Befehlstext werden übersprungen. Automatisches Abrufen zu Aufgabenbeginn, Nachschlagen von Fehlern und Speichern vor der Kontextverdichtung bleiben Aufgaben der Client-Orchestrierung und sind keine mitgelieferte Automatisierung.",
+  "demo.imageAlt": "MemoryWhale-Demo von Terminal und Dashboard mit synthetischen Daten",
+  "data.eyebrow": "Deine Daten",
+  "data.title": "Lokale Speicherung hat Vorrang — mit transparenten Optionen.",
+  "data.copy":
+    "Die Datenbank liegt auf deinem Rechner: unter Linux meist in <code>~/.local/share/MemoryWhale/</code>, unter macOS in <code>~/Library/Application Support/MemoryWhale/</code>. Mit <code>MEMORYWHALE_DATA_DIR</code> wählst du einen anderen Speicherort.",
+  "data.captureLabel": "Erfassung steuern",
+  "data.captureValue": "<code>.mwignore</code>, Pfadrichtlinie, nur Befehle",
+  "data.redactionLabel": "Schwärzung",
+  "data.redactionValue": "Hilft beim Schwärzen üblicher Geheimnisse; ist keine Sicherheitsgrenze",
+  "data.sizeLabel": "Größenlimit",
+  "data.sizeValue": "Erfasste Textfelder sind standardmäßig auf 1 MiB begrenzt; Überlängen werden abgeschnitten",
+  "data.inspectLabel": "Prüfen / löschen",
+  "data.inspectValue": "<code>mw audit</code> · <code>mw rm</code> · <code>mw prune</code>",
+  "data.transferLabel": "Übertragung",
+  "data.transferValue": "<code>mw export</code> / <code>mw import</code> oder gezielte SSH-Übertragung",
+  "data.stewardshipLabel": "Gedächtnispflege",
+  "data.stewardshipValue": "<code>mw memory compact</code> — zuerst ein Probelauf, Zeilen bleiben erhalten",
+  "security.eyebrow": "Sicherheitsmodell",
+  "security.title": "Standardmäßig lokal, bewusst geteilt.",
+  "security.copy":
+    "CLI, TUI, MCP-Server, Web-Dashboard und Desktop-Hülle nutzen den lokalen Speicher. <code>mw-mcp</code> ist ein vertrauenswürdiger lokaler stdio-Prozess; das Dashboard bindet sich standardmäßig an Loopback. Ein Dashboard außerhalb von Loopback benötigt ein Token und sollte nur in einem vertrauenswürdigen Netzwerk erreichbar sein. Geschütztes HTTP MCP erfordert Bearer-Authentifizierung; die ausdrücklich aktivierte JSON-API nutzt dieselben Zugriffskontrollen wie das Dashboard. HTTP verschlüsselt die Verbindung nicht. Keine der beiden Schnittstellen macht den Clientzugriff zu einer automatischen Erfassung. Siehe das <a href=\"https://github.com/wuisabel-gif/MemWhale/blob/main/docs/SECURITY.md\" style=\"color:var(--azure);text-decoration:underline;\">Bedrohungsmodell für lokale Daten</a>.",
+  "run.eyebrow": "Installieren",
+  "run.title": "Eine Zeile. Kein Rust nötig.",
+  "run.copy":
+    "Vorkompilierte Programme sind für Linux x86_64/aarch64 und macOS verfügbar. Das Installationsprogramm prüft die veröffentlichten SHA256-Dateien, sofern die jeweilige Version sie bereitstellt; bei älteren Versionen kann eine Prüfsumme fehlen. Beginne mit einer gezielten Erfassung, prüfe sie und ziehe erst danach <code>mw global on</code> in Betracht. Windows wird nicht nativ unterstützt; WSL kann den Linux-Build verwenden.",
+  "run.tryLabel": "Zuerst ausprobieren",
+  "run.tryValue": "<code>mw demo</code> — schreibt Beispieldaten in den ausgewählten Speicher",
+  "run.prebuiltLabel": "Vorkompiliert installieren",
+  "run.prebuiltValue":
+    "<a href=\"https://github.com/wuisabel-gif/MemWhale/blob/v0.10.0/docs/releases/0.10.0.md#install-or-upgrade\">Anleitung zum versionsgebundenen Installer mit Prüfsummenprüfung</a>",
+  "run.cargoLabel": "Cargo",
+  "run.cargoValue": "<code>cargo install memorywhale-cli --version 0.10.0 --locked</code>",
+  "run.debianLabel": "Debian / Jetson",
+  "run.debianValue": ".deb auf der Versionsseite",
+  "run.securityLabel": "Sicherheit",
+  "run.securityValue": "<a href=\"#security\">Modell lesen</a>",
+  "run.verifyLabel": "Überprüfen",
+  "run.verifyValue": "<code>mw --version</code> · <code>mw doctor</code>",
+  "footer.copyright": "Urheberrecht (c) 2026 wuisabel-gif. MemoryWhale - Terminal-Gedächtnis und Wissensgraph mit Rust/Tauri.",
+  "footer.docs": "Dokumentation",
+  "footer.useCases": "Anwendungsfälle",
+  "footer.cli": "CLI-Referenz",
+  "footer.security": "Sicherheitsrichtlinie",
+  "footer.integrations": "Integrationen"
+};
+
 const FR = {
   meta: {
     title: "MemoryWhale — une mémoire de terminal pour vous et votre agent IA",
@@ -175,6 +491,8 @@ const FR = {
   "nav.contextgc": "ContextGC ↗",
   "language.label": "Langue",
   "language.en": "Anglais",
+  "language.ar": "العربية",
+  "language.de": "Deutsch",
   "language.fr": "Français",
   "language.zh-CN": "Chinois simplifié",
   "language.zh-TW": "Chinois traditionnel",
@@ -330,6 +648,8 @@ const ZH_CN = {
   "nav.contextgc": "ContextGC ↗",
   "language.label": "语言",
   "language.en": "英语",
+  "language.ar": "العربية",
+  "language.de": "Deutsch",
   "language.fr": "法语",
   "language.zh-CN": "简体中文",
   "language.zh-TW": "繁体中文",
@@ -484,6 +804,8 @@ const ZH_TW = {
   "nav.contextgc": "ContextGC ↗",
   "language.label": "語言",
   "language.en": "英文",
+  "language.ar": "العربية",
+  "language.de": "Deutsch",
   "language.fr": "法文",
   "language.zh-CN": "簡體中文",
   "language.zh-TW": "繁體中文",
@@ -638,6 +960,8 @@ const KO = {
   "nav.contextgc": "ContextGC ↗",
   "language.label": "언어",
   "language.en": "영어",
+  "language.ar": "العربية",
+  "language.de": "Deutsch",
   "language.fr": "프랑스어",
   "language.zh-CN": "중국어 간체",
   "language.zh-TW": "중국어 번체",
@@ -792,6 +1116,8 @@ const JA = {
   "nav.contextgc": "ContextGC ↗",
   "language.label": "言語",
   "language.en": "英語",
+  "language.ar": "العربية",
+  "language.de": "Deutsch",
   "language.fr": "フランス語",
   "language.zh-CN": "簡体字中国語",
   "language.zh-TW": "繁体字中国語",
@@ -926,13 +1252,15 @@ const JA = {
 
 const translations = {
   en: EN,
+  ar: AR,
+  de: DE,
   fr: FR,
   "zh-CN": ZH_CN,
   "zh-TW": ZH_TW,
   ko: KO,
   ja: JA
 };
-const supportedLanguages = Object.freeze(["en", "fr", "zh-CN", "zh-TW", "ko", "ja"]);
+const supportedLanguages = Object.freeze(["en", "ar", "de", "fr", "zh-CN", "zh-TW", "ko", "ja"]);
 
 globalThis.MEMORYWHALE_I18N = Object.freeze({ supportedLanguages, translations });
 
@@ -951,7 +1279,7 @@ globalThis.MEMORYWHALE_I18N = Object.freeze({ supportedLanguages, translations }
     if (normalized === "zh-tw" || normalized === "zh-hk" || normalized === "zh-mo") return "zh-TW";
     if (normalized === "zh-cn" || normalized === "zh-sg" || normalized === "zh") return "zh-CN";
     const primary = normalized.split("-")[0];
-    return ["en", "fr", "ko", "ja"].includes(primary) ? primary : null;
+    return ["en", "ar", "de", "fr", "ko", "ja"].includes(primary) ? primary : null;
   };
 
   const readStoredLanguage = () => {
@@ -963,9 +1291,10 @@ globalThis.MEMORYWHALE_I18N = Object.freeze({ supportedLanguages, translations }
   };
 
   const browserLanguage = () => {
-    const candidates = Array.isArray(navigator.languages) && navigator.languages.length
-      ? navigator.languages
-      : [navigator.language];
+    const candidates = [
+      ...(Array.isArray(navigator.languages) ? navigator.languages : []),
+      navigator.language
+    ];
     for (const candidate of candidates) {
       const language = normalizeLanguage(candidate);
       if (language && languageSet.has(language)) return language;
@@ -1009,6 +1338,7 @@ globalThis.MEMORYWHALE_I18N = Object.freeze({ supportedLanguages, translations }
     const selectedLanguage = languageSet.has(language) ? language : "en";
     const dictionary = translations[selectedLanguage] || translations.en;
     document.documentElement.lang = selectedLanguage;
+    document.documentElement.dir = selectedLanguage === "ar" ? "rtl" : "ltr";
     document.title = dictionary.meta.title;
     const description = document.querySelector('meta[name="description"]');
     if (description) description.setAttribute("content", dictionary.meta.description);


### PR DESCRIPTION
## Summary

- Add complete Arabic and German READMEs and website dictionaries, alongside English, French, Simplified Chinese, Traditional Chinese, Korean, and Japanese.
- Update all README language selectors and source hashes, and register both locales in the synchronization workflow.
- Render Arabic prose right-to-left while keeping fenced README examples and website code left-to-right. Direction returns to LTR on every other language selection.
- Mirror the website hero layout with logical CSS positioning and adjust Arabic heading sizing/spacing. Improve label contrast and expose the client strip as a named group.
- Preserve commands, links, versions, security caveats, capture limitations, and the existing English static social-preview boundary.

## Safeguards

RTL README wrappers are generated by the synchronization helper, not invented by a translation provider. Validation removes only the exact generated layout and then applies all existing protected-command/link/HTML checks. Tests cover malformed wrappers, changed commands/links/attributes, and literal direction markup inside code.

Website selection supports regional Arabic/German tags, query > stored > browser precedence, a final navigator.language fallback, and hash/query preservation. No new service, dependency, model credential, or network-based translation is added.

## Verification

- 25 localization tests pass; all seven translated READMEs have current source hashes and pass the content contract.
- Static website checks cover all eight languages, required metadata, and unchanged code/link values.
- Playwright smoke passes for all eight languages at mobile/desktop widths, RTL-to-LTR switching, persistence/reload, regional browser detection, unsupported query fallback, blocked storage, no-JavaScript English fallback, accessible picker interaction, metadata/alt labels, and text-overflow bounds.
- GitHub-rendered Arabic Markdown verified: RTL headings and all six fenced examples LTR.
- npm test, npm run build, documentation-reference check, actionlint, and diff checks pass.
- Read-only review found no actionable issues; independent native-language review is still welcome.

No Rust behavior or release versions changed. The existing untracked PowerPoint files were left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Arabic and German translations for the website and README documentation.
  * Added Arabic right-to-left layout support, including correctly aligned headings, navigation, and localized content.
  * Expanded the language selector to include Arabic and German, with improved language preference handling.
  * Preserved left-to-right formatting for commands, code samples, and technical content.
* **Documentation**
  * Updated language navigation across existing README translations to link to Arabic and German versions.
  * Added localized installation, usage, architecture, integration, and contribution guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->